### PR TITLE
Add bottom navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,21 +1,22 @@
-import { Routes, Route, Link } from 'react-router-dom'
+import { Routes, Route } from 'react-router-dom'
 import Home from './pages/Home'
-import Timeline from './pages/Timeline'
-import Gallery from './pages/Gallery'
+import MyPlants from './pages/MyPlants'
+import Tasks from './pages/Tasks'
+import Add from './pages/Add'
+import Settings from './pages/Settings'
+import BottomNav from './components/BottomNav'
 
 export default function App() {
   return (
-    <div className="p-4 font-sans">
-      <nav className="flex justify-around border-b pb-2 mb-4 text-sm text-green-700 font-medium">
-        <Link to="/">Home</Link>
-        <Link to="/timeline">Timeline</Link>
-        <Link to="/gallery">Gallery</Link>
-      </nav>
+    <div className="pb-16 p-4 font-sans">{/* bottom padding for nav */}
       <Routes>
         <Route path="/" element={<Home />} />
-        <Route path="/timeline" element={<Timeline />} />
-        <Route path="/gallery" element={<Gallery />} />
+        <Route path="/myplants" element={<MyPlants />} />
+        <Route path="/tasks" element={<Tasks />} />
+        <Route path="/add" element={<Add />} />
+        <Route path="/settings" element={<Settings />} />
       </Routes>
+      <BottomNav />
     </div>
   )
 }

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -1,0 +1,93 @@
+import { NavLink } from 'react-router-dom'
+
+function IconWrapper({ children, className }) {
+  return (
+    <svg
+      className={`w-6 h-6 ${className}`}
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+    >
+      {children}
+    </svg>
+  )
+}
+
+const HomeIcon = () => (
+  <IconWrapper>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
+    />
+  </IconWrapper>
+)
+
+const ListIcon = () => (
+  <IconWrapper>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
+    />
+  </IconWrapper>
+)
+
+const CheckCircleIcon = () => (
+  <IconWrapper>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+    />
+  </IconWrapper>
+)
+
+const PlusCircleIcon = () => (
+  <IconWrapper>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
+    />
+  </IconWrapper>
+)
+
+const UserIcon = () => (
+  <IconWrapper>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
+    />
+  </IconWrapper>
+)
+
+export default function BottomNav() {
+  const items = [
+    { to: '/', label: 'Home', icon: HomeIcon },
+    { to: '/myplants', label: 'My Plants', icon: ListIcon },
+    { to: '/tasks', label: 'Tasks', icon: CheckCircleIcon },
+    { to: '/add', label: 'Add', icon: PlusCircleIcon },
+    { to: '/settings', label: 'Profile', icon: UserIcon },
+  ]
+
+  return (
+    <nav className="fixed bottom-0 left-0 right-0 border-t bg-white flex justify-around py-2">
+      {items.map(({ to, label, icon: Icon }) => (
+        <NavLink
+          key={to}
+          to={to}
+          className={({ isActive }) =>
+            `flex flex-col items-center text-xs ${isActive ? 'text-green-700' : 'text-gray-500'}`
+          }
+        >
+          <Icon className="mb-1" />
+          {label}
+        </NavLink>
+      ))}
+    </nav>
+  )
+}

--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -1,0 +1,3 @@
+export default function Add() {
+  return <div className="text-gray-700">Add view coming soon</div>
+}

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -1,0 +1,3 @@
+export default function MyPlants() {
+  return <div className="text-gray-700">My Plants view coming soon</div>
+}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,0 +1,3 @@
+export default function Settings() {
+  return <div className="text-gray-700">Profile settings coming soon</div>
+}

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -1,0 +1,3 @@
+export default function Tasks() {
+  return <div className="text-gray-700">Tasks view coming soon</div>
+}


### PR DESCRIPTION
## Summary
- implement a new `BottomNav` component with minimalist icons
- add placeholder pages for My Plants, Tasks, Add, and Settings
- update `App.jsx` to use bottom navigation and new routes

## Testing
- `npm run build` *(fails: Cannot find module @rollup/rollup-linux-x64-gnu)*

------
https://chatgpt.com/codex/tasks/task_e_6871ef0271708324bf6863f71cb250d9