### PR TITLE
Add detailed plant page

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -4,18 +4,20 @@ import MyPlants from './pages/MyPlants'
 import Tasks from './pages/Tasks'
 import Add from './pages/Add'
 import Settings from './pages/Settings'
+import PlantDetail from './pages/PlantDetail'
 import BottomNav from './components/BottomNav'
 
 export default function App() {
   return (
     <div className="pb-16 p-4 font-sans">{/* bottom padding for nav */}
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/myplants" element={<MyPlants />} />
-        <Route path="/tasks" element={<Tasks />} />
-        <Route path="/add" element={<Add />} />
-        <Route path="/settings" element={<Settings />} />
-      </Routes>
+        <Routes>
+          <Route path="/" element={<Home />} />
+          <Route path="/myplants" element={<MyPlants />} />
+          <Route path="/tasks" element={<Tasks />} />
+          <Route path="/add" element={<Add />} />
+          <Route path="/plant/:id" element={<PlantDetail />} />
+          <Route path="/settings" element={<Settings />} />
+        </Routes>
       <BottomNav />
     </div>
   )

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -1,8 +1,13 @@
+import { Link } from 'react-router-dom'
+
 export default function PlantCard({ plant }) {
   return (
     <div className="p-4 border rounded-xl shadow-sm bg-white">
-      <img src={plant.image} alt={plant.name} className="w-full h-48 object-cover rounded-md mb-2" />
-      <h2 className="font-semibold text-lg">{plant.name}</h2>
+      <Link to={`/plant/${plant.id}`}
+        className="block mb-2">
+        <img src={plant.image} alt={plant.name} className="w-full h-48 object-cover rounded-md" />
+        <h2 className="font-semibold text-lg mt-2">{plant.name}</h2>
+      </Link>
       <p className="text-sm text-gray-600">Last watered: {plant.lastWatered}</p>
       <p className="text-sm text-green-700 font-medium">Next: {plant.nextWater}</p>
       <button className="mt-2 px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 transition">

--- a/src/components/__tests__/PlantCard.test.jsx
+++ b/src/components/__tests__/PlantCard.test.jsx
@@ -1,5 +1,6 @@
-import { render, screen } from '@testing-library/react';
-import PlantCard from '../PlantCard.jsx';
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import PlantCard from '../PlantCard.jsx'
 
 const plant = {
   image: 'test.jpg',
@@ -9,6 +10,10 @@ const plant = {
 };
 
 test('renders plant name', () => {
-  render(<PlantCard plant={plant} />);
-  expect(screen.getByText('Aloe Vera')).toBeInTheDocument();
-});
+  render(
+    <MemoryRouter>
+      <PlantCard plant={plant} />
+    </MemoryRouter>
+  )
+  expect(screen.getByText('Aloe Vera')).toBeInTheDocument()
+})

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -1,0 +1,72 @@
+import { useParams } from 'react-router-dom'
+import { useState } from 'react'
+import plants from '../plants.json'
+
+export default function PlantDetail() {
+  const { id } = useParams()
+  const plant = plants.find(p => p.id === Number(id))
+  const [tab, setTab] = useState('activity')
+
+  if (!plant) {
+    return <div className="text-gray-700">Plant not found</div>
+  }
+
+  return (
+    <div className="space-y-4">
+      <img src={plant.image} alt={plant.name} className="w-full h-64 object-cover rounded-xl" />
+      <div>
+        <h1 className="text-2xl font-bold">{plant.name}</h1>
+        {plant.nickname && <p className="text-gray-500">{plant.nickname}</p>}
+      </div>
+
+      <div className="grid gap-1 text-sm">
+        <p><strong>Next watering:</strong> {plant.nextWater}</p>
+        {plant.lastFertilized && <p><strong>Last fertilized:</strong> {plant.lastFertilized}</p>}
+      </div>
+
+      <div className="grid gap-1 text-sm">
+        {plant.light && <p><strong>Light:</strong> {plant.light}</p>}
+        {plant.humidity && <p><strong>Humidity:</strong> {plant.humidity}</p>}
+        {plant.difficulty && <p><strong>Difficulty:</strong> {plant.difficulty}</p>}
+      </div>
+
+      <div>
+        <div className="flex space-x-4 border-b">
+          <button
+            className={`py-2 ${tab === 'activity' ? 'border-b-2 border-green-500 font-medium' : ''}`}
+            onClick={() => setTab('activity')}
+          >
+            Activity
+          </button>
+          <button
+            className={`py-2 ${tab === 'notes' ? 'border-b-2 border-green-500 font-medium' : ''}`}
+            onClick={() => setTab('notes')}
+          >
+            Notes
+          </button>
+          <button
+            className={`py-2 ${tab === 'care' ? 'border-b-2 border-green-500 font-medium' : ''}`}
+            onClick={() => setTab('care')}
+          >
+            Advanced
+          </button>
+        </div>
+        <div className="p-4">
+          {tab === 'activity' && (
+            <ul className="list-disc pl-4 space-y-1">
+              {(plant.activity || []).map((a, i) => (
+                <li key={i}>{a}</li>
+              ))}
+            </ul>
+          )}
+          {tab === 'notes' && (
+            <div>{plant.notes || 'No notes yet.'}</div>
+          )}
+          {tab === 'care' && (
+            <div>{plant.advancedCare || 'No advanced care info.'}</div>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -1,0 +1,16 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import PlantDetail from '../PlantDetail.jsx'
+import plants from '../../plants.json'
+
+test('renders plant details', () => {
+  const plant = plants[0]
+  render(
+    <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+      <Routes>
+        <Route path="/plant/:id" element={<PlantDetail />} />
+      </Routes>
+    </MemoryRouter>
+  )
+  expect(screen.getByText(plant.name)).toBeInTheDocument()
+})

--- a/src/plants.json
+++ b/src/plants.json
@@ -2,15 +2,38 @@
   {
     "id": 1,
     "name": "Monstera",
+    "nickname": "Swiss Cheese",
     "image": "/images/monstera.jpg",
     "lastWatered": "2025-07-07",
-    "nextWater": "2025-07-14"
+    "nextWater": "2025-07-14",
+    "lastFertilized": "2025-07-01",
+    "nextFertilize": "2025-08-01",
+    "light": "Bright indirect",
+    "humidity": "High",
+    "difficulty": "Easy",
+    "activity": [
+      "Watered on 2025-07-07",
+      "Rotated on 2025-07-05"
+    ],
+    "notes": "Doing well",
+    "advancedCare": "Propagate in water"
   },
   {
     "id": 2,
     "name": "Snake Plant",
+    "nickname": "Mother-in-Law's Tongue",
     "image": "/images/snakeplant.jpg",
     "lastWatered": "2025-07-10",
-    "nextWater": "2025-07-17"
+    "nextWater": "2025-07-17",
+    "lastFertilized": "2025-06-15",
+    "nextFertilize": "2025-07-15",
+    "light": "Low to bright indirect",
+    "humidity": "Average",
+    "difficulty": "Easy",
+    "activity": [
+      "Watered on 2025-07-10"
+    ],
+    "notes": "Prefers dry soil",
+    "advancedCare": "Allow soil to dry between waterings"
   }
 ]


### PR DESCRIPTION
## Summary
- create PlantDetail page with tabs for activity, notes, and advanced care
- add route for plant details
- link PlantCard to PlantDetail
- extend sample plant data with extra fields
- update tests for routing and add new test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871f15469d08324a0c9b2997a5fb032