### PR TITLE
Add animated timeline tasks view

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -5,3 +5,18 @@
 body {
   @apply bg-gray-50 text-gray-900;
 }
+
+@keyframes fade-in-up {
+  from {
+    opacity: 0;
+    transform: translateY(8px);
+  }
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+.animate-fade-in-up {
+  animation: fade-in-up 0.3s ease both;
+}

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -1,3 +1,44 @@
+import { useMemo } from 'react'
+import plants from '../plants.json'
+
 export default function Tasks() {
-  return <div className="text-gray-700">Tasks view coming soon</div>
+  const events = useMemo(() => {
+    const all = []
+    plants.forEach(p => {
+      if (p.nextWater) {
+        all.push({ date: p.nextWater, label: `Water ${p.name}`, type: 'task' })
+      }
+      if (p.nextFertilize) {
+        all.push({ date: p.nextFertilize, label: `Fertilize ${p.name}`, type: 'task' })
+      }
+      ;(p.activity || []).forEach(a => {
+        const m = a.match(/(\d{4}-\d{2}-\d{2})/)
+        all.push({ date: m ? m[1] : '', label: `${p.name}: ${a}`, type: 'past' })
+      })
+    })
+    return all.sort((a, b) => new Date(a.date) - new Date(b.date))
+  }, [])
+
+  const today = new Date().toISOString().slice(0, 10)
+
+  return (
+    <div className="overflow-y-auto max-h-full p-4">
+      <ul className="relative border-l border-gray-300 pl-4 space-y-6">
+        {events.map((e, i) => {
+          const overdue = e.type === 'task' && e.date < today
+          return (
+            <li key={i} className="relative animate-fade-in-up">
+              <span
+                className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${
+                  overdue ? 'bg-red-500 animate-pulse' : 'bg-green-500'
+                }`}
+              ></span>
+              <p className="text-xs text-gray-500">{e.date}</p>
+              <p className={overdue ? 'text-red-600 font-medium' : ''}>{e.label}</p>
+            </li>
+          )
+        })}
+      </ul>
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- add fade-in-up animation class
- create animated timeline in `Tasks` page

## Testing
- `npm install --legacy-peer-deps`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6871f46ac5d48324aae589d8e384a31e