### PR TITLE
Add OpenWeather integration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+# Rename this file to .env and add your OpenWeather API key
+VITE_OPENWEATHER_KEY=

--- a/README.md
+++ b/README.md
@@ -42,3 +42,13 @@ npm run preview
 ```
 This starts a local server and outputs a URL to open the optimized app in your browser.
 
+## Weather API
+
+The Home page displays local weather using the OpenWeather API. Create a `.env` file with your API key:
+
+```bash
+VITE_OPENWEATHER_KEY=your_api_key_here
+```
+
+Restart the dev server after adding the file so Vite can load the environment variable.
+

--- a/src/components/WeatherWidget.jsx
+++ b/src/components/WeatherWidget.jsx
@@ -1,0 +1,29 @@
+import { useState, useEffect } from 'react';
+import { fetchWeather } from '../services/weather';
+
+export default function WeatherWidget({ city = 'London' }) {
+  const [weather, setWeather] = useState(null);
+  const [error, setError] = useState(null);
+
+  useEffect(() => {
+    fetchWeather(city)
+      .then(setWeather)
+      .catch(err => setError(err.message));
+  }, [city]);
+
+  if (error) {
+    return <div className="text-red-500">Error: {error}</div>;
+  }
+
+  if (!weather) {
+    return <div>Loading weather...</div>;
+  }
+
+  return (
+    <div className="flex items-center space-x-2 mb-4">
+      <span className="text-lg font-medium">{weather.name}</span>
+      <span>{Math.round(weather.main.temp)}°C</span>
+      <span>{weather.weather[0].main}</span>
+    </div>
+  );
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,9 +1,11 @@
 import PlantCard from '../components/PlantCard'
+import WeatherWidget from '../components/WeatherWidget'
 import plants from '../plants.json'
 
 export default function Home() {
   return (
     <div>
+      <WeatherWidget city="London" />
       <h1 className="text-xl font-bold mb-4">Today’s Plant Care</h1>
       <div className="grid gap-4">
         {plants.map(plant => (

--- a/src/services/weather.js
+++ b/src/services/weather.js
@@ -1,0 +1,12 @@
+export async function fetchWeather(city) {
+  const apiKey = import.meta.env.VITE_OPENWEATHER_KEY;
+  if (!apiKey) {
+    throw new Error('Missing OpenWeather API key');
+  }
+  const url = `https://api.openweathermap.org/data/2.5/weather?q=${encodeURIComponent(city)}&units=metric&appid=${apiKey}`;
+  const res = await fetch(url);
+  if (!res.ok) {
+    throw new Error('Failed to fetch weather');
+  }
+  return res.json();
+}


### PR DESCRIPTION
## Summary
- show current weather on the Home page
- fetch weather data from OpenWeather API
- document how to add the API key

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6871f488bd008324ac5d8e871930e546