### PR TITLE
Fix TaskItem test file

### DIFF
--- a/src/components/__tests__/TaskItem.test.jsx
+++ b/src/components/__tests__/TaskItem.test.jsx
@@ -21,12 +21,13 @@ test('renders task text', () => {
 
 test('icon svg is aria-hidden', () => {
   const { container } = render(
-    <BrowserRouter>
+    <MemoryRouter>
       <TaskItem task={task} />
-    </BrowserRouter>
+    </MemoryRouter>
   )
   const svg = container.querySelector('svg')
   expect(svg).toHaveAttribute('aria-hidden', 'true')
+});
 
 test('mark as done does not navigate', () => {
   render(
@@ -40,4 +41,4 @@ test('mark as done does not navigate', () => {
   fireEvent.click(screen.getByText('Mark as Done'))
   expect(screen.queryByText('Plant Page')).not.toBeInTheDocument()
 
-})
+});


### PR DESCRIPTION
## Summary
- update tests to use MemoryRouter
- close open test blocks correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68726f7276b48324ab4b08b33632a64a