### PR TITLE
Fix duplicate plant detail content

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -14,11 +14,6 @@ export default function PlantDetail() {
 
   return (
     <div className="space-y-2">
-      <img src={plant.image} alt={plant.name} className="w-full h-48 object-cover rounded" />
-      <h1 className="text-2xl font-bold">{plant.name}</h1>
-      <p>Last watered: {plant.lastWatered}</p>
-      <p>Next water: {plant.nextWater}</p>
-
       <div className="space-y-4">
         <img src={plant.image} alt={plant.name} className="w-full h-64 object-cover rounded-xl" />
         <div>
@@ -27,8 +22,11 @@ export default function PlantDetail() {
         </div>
 
         <div className="grid gap-1 text-sm">
+          <p><strong>Last watered:</strong> {plant.lastWatered}</p>
           <p><strong>Next watering:</strong> {plant.nextWater}</p>
-          {plant.lastFertilized && <p><strong>Last fertilized:</strong> {plant.lastFertilized}</p>}
+          {plant.lastFertilized && (
+            <p><strong>Last fertilized:</strong> {plant.lastFertilized}</p>
+          )}
         </div>
 
         <div className="grid gap-1 text-sm">

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -3,7 +3,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import PlantDetail from '../PlantDetail.jsx'
 import plants from '../../plants.json'
 
-test('renders plant details', () => {
+test('renders plant details without duplicates', () => {
   const plant = plants[0]
   render(
     <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
@@ -13,8 +13,9 @@ test('renders plant details', () => {
     </MemoryRouter>
   )
 
-  expect(screen.getAllByText(plant.name)[0]).toBeInTheDocument()
+  const headings = screen.getAllByRole('heading', { name: plant.name })
+  expect(headings).toHaveLength(1)
 
-  expect(screen.getAllByText(plant.name).length).toBeGreaterThan(0)
-
+  const images = screen.getAllByAltText(plant.name)
+  expect(images).toHaveLength(1)
 })


### PR DESCRIPTION
## Summary
- remove repeated image and header in PlantDetail
- show last watering and next watering info once
- update tests to assert no duplicates

## Testing
- `npm test --silent --maxWorkers=2`

------
https://chatgpt.com/codex/tasks/task_e_687272e771b88324ab1eff20549b573d