### PR TITLE
Configure subdirectory deployment

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,10 @@ Open that URL in your browser to view the app.
 npm run build
 ```
 
+When deploying to a subdirectory (for example `/lisa/`), set `base` in
+`vite.config.js` and pass the same value as the router `basename` so asset paths
+resolve correctly.
+
 After building you can preview the production build with:
 ```bash
 npm run preview

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -6,7 +6,7 @@ import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter>
+    <BrowserRouter basename="/lisa">
       <App />
     </BrowserRouter>
   </React.StrictMode>

--- a/vite.config.js
+++ b/vite.config.js
@@ -2,5 +2,6 @@ import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
 export default defineConfig({
+  base: '/lisa/',
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- set `base` in `vite.config.js`
- give `BrowserRouter` a basename
- document subdirectory deploys in README

## Testing
- `npm test`
- `npm run build`
- `npm run preview` (manual exit)

------
https://chatgpt.com/codex/tasks/task_e_68727abf133c832481dd05ac40e41c57