### PR TITLE
Implement plant watering context

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -1,0 +1,32 @@
+import { createContext, useContext, useState } from 'react'
+import initialPlants from './plants.json'
+
+const PlantContext = createContext()
+
+export function PlantProvider({ children }) {
+  const [plants, setPlants] = useState(initialPlants)
+
+  const markWatered = id => {
+    setPlants(prev =>
+      prev.map(p => {
+        if (p.id === id) {
+          const today = new Date()
+          const todayStr = today.toISOString().slice(0, 10)
+          const next = new Date(today)
+          next.setDate(today.getDate() + 7)
+          const nextStr = next.toISOString().slice(0, 10)
+          return { ...p, lastWatered: todayStr, nextWater: nextStr }
+        }
+        return p
+      })
+    )
+  }
+
+  return (
+    <PlantContext.Provider value={{ plants, markWatered }}>
+      {children}
+    </PlantContext.Provider>
+  )
+}
+
+export const usePlants = () => useContext(PlantContext)

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -1,6 +1,11 @@
 import { Link } from 'react-router-dom'
+import { usePlants } from '../PlantContext.jsx'
 
 export default function PlantCard({ plant }) {
+  const { markWatered } = usePlants()
+
+  const handleWatered = () => markWatered(plant.id)
+
   return (
     <div className="p-4 border rounded-xl shadow-sm bg-white">
       <Link to={`/plant/${plant.id}`}
@@ -10,7 +15,10 @@ export default function PlantCard({ plant }) {
       </Link>
       <p className="text-sm text-gray-600">Last watered: {plant.lastWatered}</p>
       <p className="text-sm text-green-700 font-medium">Next: {plant.nextWater}</p>
-      <button className="mt-2 px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 transition">
+      <button
+        onClick={handleWatered}
+        className="mt-2 px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 transition"
+      >
         Mark as Watered
       </button>
     </div>

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -1,4 +1,5 @@
 import { Link } from 'react-router-dom'
+import { usePlants } from '../PlantContext.jsx'
 
 function IconWrapper({ children }) {
   return (
@@ -53,12 +54,17 @@ const icons = {
 }
 
 export default function TaskItem({ task, onComplete }) {
+  const { markWatered } = usePlants()
   const Icon = icons[task.type]
 
   const handleComplete = e => {
     e.preventDefault()
     e.stopPropagation()
-    if (onComplete) onComplete(task)
+    if (onComplete) {
+      onComplete(task)
+    } else if (task.type === 'Water') {
+      markWatered(task.plantId)
+    }
   }
 
   return (

--- a/src/components/__tests__/PlantCard.test.jsx
+++ b/src/components/__tests__/PlantCard.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import PlantCard from '../PlantCard.jsx'
+import { PlantProvider } from '../../PlantContext.jsx'
 
 const plant = {
   image: 'test.jpg',
@@ -11,9 +12,11 @@ const plant = {
 
 test('renders plant name', () => {
   render(
-    <MemoryRouter>
-      <PlantCard plant={plant} />
-    </MemoryRouter>
+    <PlantProvider>
+      <MemoryRouter>
+        <PlantCard plant={plant} />
+      </MemoryRouter>
+    </PlantProvider>
   )
   expect(screen.getByText('Aloe Vera')).toBeInTheDocument()
 })

--- a/src/components/__tests__/TaskItem.test.jsx
+++ b/src/components/__tests__/TaskItem.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import TaskItem from '../TaskItem.jsx'
+import { PlantProvider } from '../../PlantContext.jsx'
 
 const task = {
   id: 1,
@@ -12,18 +13,22 @@ const task = {
 
 test('renders task text', () => {
   render(
-    <MemoryRouter>
-      <TaskItem task={task} />
-    </MemoryRouter>
+    <PlantProvider>
+      <MemoryRouter>
+        <TaskItem task={task} />
+      </MemoryRouter>
+    </PlantProvider>
   )
   expect(screen.getByText('Water Monstera')).toBeInTheDocument()
 })
 
 test('icon svg is aria-hidden', () => {
   const { container } = render(
-    <MemoryRouter>
-      <TaskItem task={task} />
-    </MemoryRouter>
+    <PlantProvider>
+      <MemoryRouter>
+        <TaskItem task={task} />
+      </MemoryRouter>
+    </PlantProvider>
   )
   const svg = container.querySelector('svg')
   expect(svg).toHaveAttribute('aria-hidden', 'true')
@@ -31,12 +36,14 @@ test('icon svg is aria-hidden', () => {
 
 test('mark as done does not navigate', () => {
   render(
-    <MemoryRouter initialEntries={['/']}>
-      <Routes>
-        <Route path="/" element={<TaskItem task={task} />} />
-        <Route path="/plant/:id" element={<div>Plant Page</div>} />
-      </Routes>
-    </MemoryRouter>
+    <PlantProvider>
+      <MemoryRouter initialEntries={['/']}>
+        <Routes>
+          <Route path="/" element={<TaskItem task={task} />} />
+          <Route path="/plant/:id" element={<div>Plant Page</div>} />
+        </Routes>
+      </MemoryRouter>
+    </PlantProvider>
   )
   fireEvent.click(screen.getByText('Mark as Done'))
   expect(screen.queryByText('Plant Page')).not.toBeInTheDocument()

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -2,12 +2,15 @@ import React from 'react'
 import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
+import { PlantProvider } from './PlantContext.jsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <BrowserRouter basename="/lisa">
-      <App />
-    </BrowserRouter>
+    <PlantProvider>
+      <BrowserRouter basename="/lisa">
+        <App />
+      </BrowserRouter>
+    </PlantProvider>
   </React.StrictMode>
 )

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,7 +1,9 @@
 import TaskItem from '../components/TaskItem'
-import tasks from '../tasks.json'
+import { usePlants } from '../PlantContext.jsx'
 
 export default function Home() {
+  const { plants } = usePlants()
+
   const today = new Date().toLocaleDateString(undefined, {
     weekday: 'long',
     month: 'long',
@@ -24,8 +26,17 @@ export default function Home() {
       <section>
         <h2 className="font-semibold mb-2">Today’s Tasks</h2>
         <div className="space-y-2">
-          {tasks.map(task => (
-            <TaskItem key={task.id} task={task} />
+          {plants.map(p => (
+            <TaskItem
+              key={p.id}
+              task={{
+                id: p.id,
+                plantId: p.id,
+                plantName: p.name,
+                image: p.image,
+                type: 'Water',
+              }}
+            />
           ))}
         </div>
       </section>

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -1,7 +1,9 @@
 import { useMemo } from 'react'
-import plants from '../plants.json'
+import { usePlants } from '../PlantContext.jsx'
 
 export default function Tasks() {
+  const { plants } = usePlants()
+
   const events = useMemo(() => {
     const all = []
     plants.forEach(p => {
@@ -17,7 +19,7 @@ export default function Tasks() {
       })
     })
     return all.sort((a, b) => new Date(a.date) - new Date(b.date))
-  }, [])
+  }, [plants])
 
   const today = new Date().toISOString().slice(0, 10)
 


### PR DESCRIPTION
## Summary
- add `PlantContext` for storing watering dates
- update `PlantCard` and `TaskItem` to update global state
- generate tasks from context in `Home` page
- compute events from context in `Tasks` page
- wrap tests with provider

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6872d93f3c508324bffbe68c07ce1069