### PR TITLE
Add lazy loading for plant images

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -10,7 +10,7 @@ export default function PlantCard({ plant }) {
     <div className="p-4 border rounded-xl shadow-sm bg-white">
       <Link to={`/plant/${plant.id}`}
         className="block mb-2">
-        <img src={plant.image} alt={plant.name} className="w-full h-48 object-cover rounded-md" />
+        <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-48 object-cover rounded-md" />
         <h2 className="font-semibold text-lg mt-2">{plant.name}</h2>
       </Link>
       <p className="text-sm text-gray-600">Last watered: {plant.lastWatered}</p>

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -43,7 +43,7 @@ export default function MyPlants() {
       <div className="grid grid-cols-2 gap-4">
         {filtered.map(plant => (
           <Link key={plant.id} to={`/plant/${plant.id}`} className="block">
-            <img src={plant.image} alt={plant.name} className="w-full h-40 object-cover rounded-lg" />
+            <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-40 object-cover rounded-lg" />
             <p className="mt-1 text-center text-sm">{plant.name}</p>
           </Link>
         ))}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -15,7 +15,7 @@ export default function PlantDetail() {
   return (
     <div className="space-y-2">
       <div className="space-y-4">
-        <img src={plant.image} alt={plant.name} className="w-full h-64 object-cover rounded-xl" />
+        <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-64 object-cover rounded-xl" />
         <div>
           <h1 className="text-2xl font-bold">{plant.name}</h1>
           {plant.nickname && <p className="text-gray-500">{plant.nickname}</p>}


### PR DESCRIPTION
## Summary
- lazily load images in PlantCard, MyPlants, and PlantDetail
- run tests

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_6872dab86c888324b6eb4f3520ad0d4d