### PR TITLE
Improve PlantDetail tabs accessibility

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -1,12 +1,24 @@
 import { useParams } from 'react-router-dom'
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import plants from '../plants.json'
 
 export default function PlantDetail() {
   const { id } = useParams()
   const plant = plants.find(p => p.id === Number(id))
 
+  const tabNames = ['activity', 'notes', 'care']
+  const tabRefs = useRef([])
   const [tab, setTab] = useState('activity')
+
+  const handleKeyDown = (e, index) => {
+    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
+      e.preventDefault()
+      const dir = e.key === 'ArrowRight' ? 1 : -1
+      const nextIndex = (index + dir + tabNames.length) % tabNames.length
+      setTab(tabNames[nextIndex])
+      tabRefs.current[nextIndex]?.focus()
+    }
+  }
 
   if (!plant) {
     return <div className="text-gray-700">Plant not found</div>
@@ -36,22 +48,37 @@ export default function PlantDetail() {
         </div>
 
         <div>
-          <div className="flex space-x-4 border-b">
+          <div className="flex space-x-4 border-b" role="tablist">
             <button
+              role="tab"
+              ref={el => (tabRefs.current[0] = el)}
+              aria-selected={tab === 'activity'}
+              tabIndex={tab === 'activity' ? 0 : -1}
               className={`py-2 ${tab === 'activity' ? 'border-b-2 border-green-500 font-medium' : ''}`}
               onClick={() => setTab('activity')}
+              onKeyDown={e => handleKeyDown(e, 0)}
             >
               Activity
             </button>
             <button
+              role="tab"
+              ref={el => (tabRefs.current[1] = el)}
+              aria-selected={tab === 'notes'}
+              tabIndex={tab === 'notes' ? 0 : -1}
               className={`py-2 ${tab === 'notes' ? 'border-b-2 border-green-500 font-medium' : ''}`}
               onClick={() => setTab('notes')}
+              onKeyDown={e => handleKeyDown(e, 1)}
             >
               Notes
             </button>
             <button
+              role="tab"
+              ref={el => (tabRefs.current[2] = el)}
+              aria-selected={tab === 'care'}
+              tabIndex={tab === 'care' ? 0 : -1}
               className={`py-2 ${tab === 'care' ? 'border-b-2 border-green-500 font-medium' : ''}`}
               onClick={() => setTab('care')}
+              onKeyDown={e => handleKeyDown(e, 2)}
             >
               Advanced
             </button>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import PlantDetail from '../PlantDetail.jsx'
 import plants from '../../plants.json'
@@ -18,4 +18,26 @@ test('renders plant details without duplicates', () => {
 
   const images = screen.getAllByAltText(plant.name)
   expect(images).toHaveLength(1)
+})
+
+test('tab keyboard navigation works', () => {
+  const plant = plants[0]
+  render(
+    <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+      <Routes>
+        <Route path="/plant/:id" element={<PlantDetail />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+  const tabs = screen.getAllByRole('tab')
+  expect(tabs).toHaveLength(3)
+  expect(tabs[0]).toHaveAttribute('aria-selected', 'true')
+
+  tabs[0].focus()
+  fireEvent.keyDown(tabs[0], { key: 'ArrowRight' })
+
+  const updatedTabs = screen.getAllByRole('tab')
+  expect(updatedTabs[1]).toHaveAttribute('aria-selected', 'true')
+  expect(document.activeElement).toBe(updatedTabs[1])
 })


### PR DESCRIPTION
## Summary
- add keyboard navigation and ARIA semantics to PlantDetail tabs
- test tablist behavior with arrow keys

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6872dbbcf4f88324935d729f3ad7cd7a