### PR TITLE
Add integration test for Add page

### DIFF
--- a/src/pages/__tests__/Add.test.jsx
+++ b/src/pages/__tests__/Add.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import Add from '../Add.jsx'
+import MyPlants from '../MyPlants.jsx'
+import { PlantProvider } from '../../PlantContext.jsx'
+
+// test adding a plant
+
+test('addPlant updates context and redirects to MyPlants', () => {
+  const { container } = render(
+    <PlantProvider>
+      <MemoryRouter initialEntries={['/add']}>
+        <Routes>
+          <Route path="/add" element={<Add />} />
+          <Route path="/myplants" element={<MyPlants />} />
+        </Routes>
+      </MemoryRouter>
+    </PlantProvider>
+  )
+
+  const nameInput = container.querySelector('input[required]')
+  fireEvent.change(nameInput, { target: { value: 'Test Plant' } })
+
+  fireEvent.click(screen.getByRole('button', { name: /add plant/i }))
+
+  expect(screen.getByRole('heading', { name: /my plants/i })).toBeInTheDocument()
+  expect(screen.getByText('Test Plant')).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- create test for Add page form submission and redirection

## Testing
- `npm test`
- `npx jest src/pages/__tests__/Add.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_687301ec0dfc83248e0ab68f2ae25afb