### PR TITLE
Fix event dates

### DIFF
--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -15,7 +15,9 @@ export default function Tasks() {
       }
       ;(p.activity || []).forEach(a => {
         const m = a.match(/(\d{4}-\d{2}-\d{2})/)
-        all.push({ date: m ? m[1] : '', label: `${p.name}: ${a}`, type: 'past' })
+        if (m) {
+          all.push({ date: m[1], label: `${p.name}: ${a}`, type: 'past' })
+        }
       })
     })
     return all.sort((a, b) => new Date(a.date) - new Date(b.date))

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -1,0 +1,33 @@
+import { render, screen } from '@testing-library/react'
+import Tasks from '../Tasks.jsx'
+
+const samplePlants = [
+  {
+    id: 1,
+    name: 'Plant A',
+    nextWater: '2025-07-17',
+    activity: ['Repotted'],
+  },
+  {
+    id: 2,
+    name: 'Plant B',
+    nextWater: '2025-07-15',
+    activity: ['Watered on 2025-07-10'],
+  },
+]
+
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: () => ({ plants: samplePlants }),
+}))
+
+test('ignores activities without valid dates when generating events', () => {
+  render(<Tasks />)
+
+  expect(screen.queryByText(/Repotted/)).toBeNull()
+
+  const items = screen.getAllByRole('listitem')
+  expect(items).toHaveLength(3)
+  expect(items[0]).toHaveTextContent('Plant B: Watered on 2025-07-10')
+  expect(items[1]).toHaveTextContent('Water Plant B')
+  expect(items[2]).toHaveTextContent('Water Plant A')
+})


### PR DESCRIPTION
## Summary
- skip history entries without a date
- test for ignoring activity items that lack dates

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687301e9ff6083248c72ff6fbfa655a2