### PR TITLE
Add dark mode toggle

### DIFF
--- a/src/ThemeContext.jsx
+++ b/src/ThemeContext.jsx
@@ -1,0 +1,38 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const ThemeContext = createContext()
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('theme')
+      if (stored) return stored
+    }
+    if (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
+      return 'dark'
+    }
+    return 'light'
+  })
+
+  useEffect(() => {
+    const root = document.documentElement
+    if (theme === 'dark') {
+      root.classList.add('dark')
+    } else {
+      root.classList.remove('dark')
+    }
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('theme', theme)
+    }
+  }, [theme])
+
+  const toggleTheme = () => setTheme(prev => (prev === 'dark' ? 'light' : 'dark'))
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  )
+}
+
+export const useTheme = () => useContext(ThemeContext)

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -76,7 +76,7 @@ export default function BottomNav() {
   ]
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 border-t bg-white flex justify-around py-2">
+    <nav className="fixed bottom-0 left-0 right-0 border-t bg-white dark:bg-gray-800 flex justify-around py-2">
       {items.map(({ to, label, icon: Icon }) => (
         <NavLink
           key={to}

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -7,13 +7,13 @@ export default function PlantCard({ plant }) {
   const handleWatered = () => markWatered(plant.id)
 
   return (
-    <div className="p-4 border rounded-xl shadow-sm bg-white">
+    <div className="p-4 border rounded-xl shadow-sm bg-white dark:bg-gray-800">
       <Link to={`/plant/${plant.id}`}
         className="block mb-2">
         <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-48 object-cover rounded-md" />
         <h2 className="font-semibold text-lg mt-2">{plant.name}</h2>
       </Link>
-      <p className="text-sm text-gray-600">Last watered: {plant.lastWatered}</p>
+      <p className="text-sm text-gray-600 dark:text-gray-400">Last watered: {plant.lastWatered}</p>
       <p className="text-sm text-green-700 font-medium">Next: {plant.nextWater}</p>
       <button
         onClick={handleWatered}

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -4,7 +4,7 @@ import { usePlants } from '../PlantContext.jsx'
 function IconWrapper({ children }) {
   return (
     <svg
-      className="w-6 h-6 text-gray-500"
+      className="w-6 h-6 text-gray-500 dark:text-gray-400"
       xmlns="http://www.w3.org/2000/svg"
       fill="none"
       viewBox="0 0 24 24"
@@ -68,7 +68,7 @@ export default function TaskItem({ task, onComplete }) {
   }
 
   return (
-    <div className="flex items-center gap-2 p-2 border rounded-lg bg-white hover:bg-gray-50">
+    <div className="flex items-center gap-2 p-2 border rounded-lg bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700">
       <Link to={`/plant/${task.plantId}`} className="flex items-center flex-1 gap-2">
         <img
           src={task.image}

--- a/src/index.css
+++ b/src/index.css
@@ -6,6 +6,10 @@ body {
   @apply bg-gray-50 text-gray-900;
 }
 
+.dark body {
+  @apply bg-gray-900 text-gray-100;
+}
+
 @keyframes fade-in-up {
   from {
     opacity: 0;

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -3,14 +3,17 @@ import ReactDOM from 'react-dom/client'
 import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import { PlantProvider } from './PlantContext.jsx'
+import { ThemeProvider } from './ThemeContext.jsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <PlantProvider>
-      <BrowserRouter basename="/lisa">
-        <App />
-      </BrowserRouter>
-    </PlantProvider>
+    <ThemeProvider>
+      <PlantProvider>
+        <BrowserRouter basename="/lisa">
+          <App />
+        </BrowserRouter>
+      </PlantProvider>
+    </ThemeProvider>
   </React.StrictMode>
 )

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,3 +1,17 @@
+import { useTheme } from '../ThemeContext.jsx'
+
 export default function Settings() {
-  return <div className="text-gray-700">Profile settings coming soon</div>
+  const { theme, toggleTheme } = useTheme()
+
+  return (
+    <div className="space-y-4 text-gray-700 dark:text-gray-200">
+      <h1 className="text-xl font-bold">Settings</h1>
+      <button
+        onClick={toggleTheme}
+        className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700"
+      >
+        Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
+      </button>
+    </div>
+  )
 }

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 export default {
+  darkMode: 'class',
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
     extend: {},


### PR DESCRIPTION
## Summary
- enable class-based dark mode in Tailwind config
- implement a ThemeProvider context with toggle logic
- wrap the app with ThemeProvider
- support dark styling for layout components
- add dark mode toggle in Settings page

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687304189ae48324bdb65684ee4ba118