### PR TITLE
Implement plant timeline view

### DIFF
--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -1,3 +1,59 @@
+import { usePlants } from '../PlantContext.jsx'
+import { useMemo } from 'react'
+
 export default function Timeline() {
-  return <div className="text-gray-700">Timeline view coming soon</div>
+  const { plants } = usePlants()
+
+  const events = useMemo(() => {
+    const all = []
+    plants.forEach(p => {
+      if (p.lastWatered) {
+        all.push({
+          date: p.lastWatered,
+          label: `Watered ${p.name}`,
+          type: 'water',
+        })
+      }
+      if (p.lastFertilized) {
+        all.push({
+          date: p.lastFertilized,
+          label: `Fertilized ${p.name}`,
+          type: 'fertilize',
+        })
+      }
+      ;(p.activity || []).forEach(a => {
+        const m = a.match(/(\d{4}-\d{2}-\d{2})/)
+        if (m) {
+          all.push({
+            date: m[1],
+            label: `${p.name}: ${a}`,
+            type: 'note',
+          })
+        }
+      })
+    })
+    return all.sort((a, b) => new Date(a.date) - new Date(b.date))
+  }, [plants])
+
+  const colors = {
+    water: 'bg-blue-500',
+    fertilize: 'bg-yellow-500',
+    note: 'bg-gray-400',
+  }
+
+  return (
+    <div className="overflow-y-auto max-h-full p-4 text-gray-700 dark:text-gray-200">
+      <ul className="relative border-l border-gray-300 pl-4 space-y-6">
+        {events.map((e, i) => (
+          <li key={i} className="relative">
+            <span
+              className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
+            ></span>
+            <p className="text-xs text-gray-500">{e.date}</p>
+            <p>{e.label}</p>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
 }

--- a/src/pages/__tests__/Timeline.test.jsx
+++ b/src/pages/__tests__/Timeline.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen } from '@testing-library/react'
+import Timeline from '../Timeline.jsx'
+
+const samplePlants = [
+  {
+    id: 1,
+    name: 'Plant A',
+    lastWatered: '2025-07-11',
+    lastFertilized: '2025-07-01',
+    activity: ['Repotted'],
+  },
+  {
+    id: 2,
+    name: 'Plant B',
+    lastWatered: '2025-07-10',
+    activity: ['Watered on 2025-07-09'],
+  },
+]
+
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: () => ({ plants: samplePlants }),
+}))
+
+test('ignores activities without valid dates when generating events', () => {
+  render(<Timeline />)
+
+  expect(screen.queryByText(/Repotted/)).toBeNull()
+
+  const items = screen.getAllByRole('listitem')
+  expect(items).toHaveLength(4)
+  expect(items[0]).toHaveTextContent('Fertilized Plant A')
+  expect(items[1]).toHaveTextContent('Plant B: Watered on 2025-07-09')
+  expect(items[2]).toHaveTextContent('Watered Plant B')
+  expect(items[3]).toHaveTextContent('Watered Plant A')
+})


### PR DESCRIPTION
## Summary
- implement a `Timeline` page that compiles plant events
- color-code water/fertilize/note events
- add tests for Timeline page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873085e649c8324a6d85498b17de38c