### PR TITLE
Add plant photo gallery

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import Tasks from './pages/Tasks'
 import Add from './pages/Add'
 import Settings from './pages/Settings'
 import PlantDetail from './pages/PlantDetail'
+import Gallery from './pages/Gallery'
 import BottomNav from './components/BottomNav'
 
 export default function App() {
@@ -18,6 +19,7 @@ export default function App() {
         <Route path="/add" element={<Add />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/plant/:id" element={<PlantDetail />} />
+        <Route path="/plant/:id/gallery" element={<Gallery />} />
       </Routes>
 
 

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,3 +1,53 @@
+import { useParams } from 'react-router-dom'
+import { usePlants } from '../PlantContext.jsx'
+
 export default function Gallery() {
-  return <div className="text-gray-700">Gallery view coming soon</div>
+  const { id } = useParams()
+  const { plants } = usePlants()
+  const plant = plants.find(p => p.id === Number(id))
+
+  if (!plant) {
+    return <div className="text-gray-700">Plant not found</div>
+  }
+
+  const photos = plant.photos || []
+
+  return (
+    <div className="space-y-4">
+      <h1 className="text-xl font-bold">{plant.name} Gallery</h1>
+
+      {/* desktop grid */}
+      <div className="hidden md:grid grid-cols-3 gap-4">
+        {photos.map((src, i) => (
+          <div
+            key={i}
+            className="aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900"
+          >
+            <img
+              src={src}
+              alt={plant.name}
+              loading="lazy"
+              className="w-full h-full object-cover"
+            />
+          </div>
+        ))}
+      </div>
+
+      {/* mobile carousel */}
+      <div className="flex md:hidden space-x-4 overflow-x-auto snap-x snap-mandatory">
+        {photos.map((src, i) => (
+          <div key={i} className="snap-center shrink-0 w-full">
+            <div className="aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900">
+              <img
+                src={src}
+                alt={plant.name}
+                loading="lazy"
+                className="w-full h-full object-cover"
+              />
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  )
 }

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -1,4 +1,4 @@
-import { useParams } from 'react-router-dom'
+import { useParams, Link } from 'react-router-dom'
 import { useState, useRef } from 'react'
 import { usePlants } from '../PlantContext.jsx'
 
@@ -46,6 +46,15 @@ export default function PlantDetail() {
           {plant.light && <p><strong>Light:</strong> {plant.light}</p>}
           {plant.humidity && <p><strong>Humidity:</strong> {plant.humidity}</p>}
           {plant.difficulty && <p><strong>Difficulty:</strong> {plant.difficulty}</p>}
+        </div>
+
+        <div>
+          <Link
+            to={`/plant/${plant.id}/gallery`}
+            className="text-green-600 underline"
+          >
+            View Gallery
+          </Link>
         </div>
 
         <div>

--- a/src/pages/__tests__/Gallery.test.jsx
+++ b/src/pages/__tests__/Gallery.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import Gallery from '../Gallery.jsx'
+import plants from '../../plants.json'
+import { PlantProvider } from '../../PlantContext.jsx'
+
+test('renders gallery images for plant', () => {
+  const plant = plants[0]
+  render(
+    <PlantProvider>
+      <MemoryRouter initialEntries={[`/plant/${plant.id}/gallery`]}>
+        <Routes>
+          <Route path="/plant/:id/gallery" element={<Gallery />} />
+        </Routes>
+      </MemoryRouter>
+    </PlantProvider>
+  )
+
+  const images = screen.getAllByAltText(plant.name)
+  expect(images.length).toBeGreaterThanOrEqual(plant.photos.length)
+})

--- a/src/plants.json
+++ b/src/plants.json
@@ -4,6 +4,11 @@
     "name": "Monstera",
     "nickname": "Swiss Cheese",
     "image": "/lisa/images/monstera-plant-pot-isolated-white-background-minimal-tropical-leaves-houseplant-home-decor_787667-1395.jpg",
+    "photos": [
+      "/lisa/images/monstera-plant-pot-isolated-white-background-minimal-tropical-leaves-houseplant-home-decor_787667-1395.jpg",
+      "/lisa/images/1.jpeg",
+      "/lisa/images/f42e48178725077.64ed5063932c3.jpg"
+    ],
     "lastWatered": "2025-07-07",
     "nextWater": "2025-07-14",
     "lastFertilized": "2025-07-01",
@@ -22,6 +27,11 @@
     "name": "Snake Plant",
     "nickname": "Mother-in-Law's Tongue",
     "image": "/lisa/images/1.jpeg",
+    "photos": [
+      "/lisa/images/1.jpeg",
+      "/lisa/images/f42e48178725077.64ed5063932c3.jpg",
+      "/lisa/images/minimal-tropical-houseplant-home-decor-kentia-or-areca-palm-against-white-wall-palm-tree-in-pot-isolated-on-white-background-home-gardening-love-of-houseplants-free-photo.jpg"
+    ],
     "lastWatered": "2025-07-10",
     "nextWater": "2025-07-17",
     "lastFertilized": "2025-06-15",
@@ -40,6 +50,11 @@
     "name": "Fiddle Leaf Fig",
     "nickname": "Fiddle",
     "image": "/lisa/images/f42e48178725077.64ed5063932c3.jpg",
+    "photos": [
+      "/lisa/images/f42e48178725077.64ed5063932c3.jpg",
+      "/lisa/images/monstera-plant-pot-isolated-white-background-minimal-tropical-leaves-houseplant-home-decor_787667-1395.jpg",
+      "/lisa/images/1.jpeg"
+    ],
     "lastWatered": "2025-07-09",
     "nextWater": "2025-07-16",
     "lastFertilized": "2025-06-25",
@@ -58,6 +73,11 @@
     "name": "Peace Lily",
     "nickname": "Lily",
     "image": "/lisa/images/minimal-tropical-houseplant-home-decor-kentia-or-areca-palm-against-white-wall-palm-tree-in-pot-isolated-on-white-background-home-gardening-love-of-houseplants-free-photo.jpg",
+    "photos": [
+      "/lisa/images/minimal-tropical-houseplant-home-decor-kentia-or-areca-palm-against-white-wall-palm-tree-in-pot-isolated-on-white-background-home-gardening-love-of-houseplants-free-photo.jpg",
+      "/lisa/images/1.jpeg",
+      "/lisa/images/monstera-plant-pot-isolated-white-background-minimal-tropical-leaves-houseplant-home-decor_787667-1395.jpg"
+    ],
     "lastWatered": "2025-07-11",
     "nextWater": "2025-07-15",
     "lastFertilized": "2025-07-01",
@@ -76,6 +96,11 @@
     "name": "ZZ Plant",
     "nickname": "Zenzi",
     "image": "/lisa/images/1.jpeg",
+    "photos": [
+      "/lisa/images/1.jpeg",
+      "/lisa/images/minimal-tropical-houseplant-home-decor-kentia-or-areca-palm-against-white-wall-palm-tree-in-pot-isolated-on-white-background-home-gardening-love-of-houseplants-free-photo.jpg",
+      "/lisa/images/monstera-plant-pot-isolated-white-background-minimal-tropical-leaves-houseplant-home-decor_787667-1395.jpg"
+    ],
     "lastWatered": "2025-07-01",
     "nextWater": "2025-07-20",
     "lastFertilized": "2025-05-30",
@@ -94,6 +119,11 @@
     "name": "Aloe Vera",
     "nickname": "Medic",
     "image": "/lisa/images/f42e48178725077.64ed5063932c3.jpg",
+    "photos": [
+      "/lisa/images/f42e48178725077.64ed5063932c3.jpg",
+      "/lisa/images/1.jpeg",
+      "/lisa/images/minimal-tropical-houseplant-home-decor-kentia-or-areca-palm-against-white-wall-palm-tree-in-pot-isolated-on-white-background-home-gardening-love-of-houseplants-free-photo.jpg"
+    ],
     "lastWatered": "2025-07-02",
     "nextWater": "2025-07-16",
     "lastFertilized": "2025-06-01",
@@ -112,6 +142,11 @@
     "name": "Pothos",
     "nickname": "Devil's Ivy",
     "image": "/lisa/images/minimal-tropical-houseplant-home-decor-kentia-or-areca-palm-against-white-wall-palm-tree-in-pot-isolated-on-white-background-home-gardening-love-of-houseplants-free-photo.jpg",
+    "photos": [
+      "/lisa/images/minimal-tropical-houseplant-home-decor-kentia-or-areca-palm-against-white-wall-palm-tree-in-pot-isolated-on-white-background-home-gardening-love-of-houseplants-free-photo.jpg",
+      "/lisa/images/monstera-plant-pot-isolated-white-background-minimal-tropical-leaves-houseplant-home-decor_787667-1395.jpg",
+      "/lisa/images/1.jpeg"
+    ],
     "lastWatered": "2025-07-06",
     "nextWater": "2025-07-13",
     "lastFertilized": "2025-06-20",
@@ -130,6 +165,11 @@
     "name": "Calathea Orbifolia",
     "nickname": "Prayer Plant",
     "image": "/lisa/images/1.jpeg",
+    "photos": [
+      "/lisa/images/1.jpeg",
+      "/lisa/images/monstera-plant-pot-isolated-white-background-minimal-tropical-leaves-houseplant-home-decor_787667-1395.jpg",
+      "/lisa/images/f42e48178725077.64ed5063932c3.jpg"
+    ],
     "lastWatered": "2025-07-08",
     "nextWater": "2025-07-12",
     "lastFertilized": "2025-06-25",
@@ -148,6 +188,11 @@
     "name": "Rubber Plant",
     "nickname": "Ficus Elastica",
     "image": "/lisa/images/f42e48178725077.64ed5063932c3.jpg",
+    "photos": [
+      "/lisa/images/f42e48178725077.64ed5063932c3.jpg",
+      "/lisa/images/1.jpeg",
+      "/lisa/images/monstera-plant-pot-isolated-white-background-minimal-tropical-leaves-houseplant-home-decor_787667-1395.jpg"
+    ],
     "lastWatered": "2025-07-05",
     "nextWater": "2025-07-12",
     "lastFertilized": "2025-06-20",
@@ -166,6 +211,11 @@
     "name": "Chinese Evergreen",
     "nickname": "Aglaonema",
     "image": "/lisa/images/1.jpeg",
+    "photos": [
+      "/lisa/images/1.jpeg",
+      "/lisa/images/f42e48178725077.64ed5063932c3.jpg",
+      "/lisa/images/minimal-tropical-houseplant-home-decor-kentia-or-areca-palm-against-white-wall-palm-tree-in-pot-isolated-on-white-background-home-gardening-love-of-houseplants-free-photo.jpg"
+    ],
     "lastWatered": "2025-07-04",
     "nextWater": "2025-07-11",
     "lastFertilized": "2025-06-15",


### PR DESCRIPTION
## Summary
- add Gallery page with card grid and swipe carousel
- link from PlantDetail to Gallery
- store photo arrays on each plant
- mount Gallery in router
- test gallery route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687309c5c8fc8324912bb654dd9a74fb