### PR TITLE
Add plant gallery feature

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -4,12 +4,23 @@ import { usePlants } from '../PlantContext.jsx'
 
 export default function PlantDetail() {
   const { id } = useParams()
-  const { plants } = usePlants()
+  const { plants, addPhoto, removePhoto } = usePlants()
   const plant = plants.find(p => p.id === Number(id))
 
   const tabNames = ['activity', 'notes', 'care']
   const tabRefs = useRef([])
   const [tab, setTab] = useState('activity')
+  const fileInputRef = useRef()
+
+  const handleFiles = e => {
+    const files = Array.from(e.target.files || [])
+    files.forEach(file => {
+      const reader = new FileReader()
+      reader.onload = ev => addPhoto(plant.id, ev.target.result)
+      reader.readAsDataURL(file)
+    })
+    e.target.value = ''
+  }
 
   const handleKeyDown = (e, index) => {
     if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
@@ -98,9 +109,44 @@ export default function PlantDetail() {
             {tab === 'care' && (
               <div>{plant.advancedCare || 'No advanced care info.'}</div>
             )}
-          </div>
         </div>
       </div>
+      <div className="space-y-2">
+        <h2 className="text-lg font-semibold">Gallery</h2>
+        <div className="grid grid-cols-3 gap-2">
+          {(plant.gallery || []).map((src, i) => (
+            <div key={i} className="relative">
+              <img
+                src={src}
+                alt={`${plant.name} ${i}`}
+                className="object-cover w-full h-24 rounded"
+              />
+              <button
+                className="absolute top-1 right-1 bg-white bg-opacity-70 rounded px-1 text-xs"
+                onClick={() => removePhoto(plant.id, i)}
+              >
+                ✕
+              </button>
+            </div>
+          ))}
+        </div>
+        <button
+          type="button"
+          onClick={() => fileInputRef.current.click()}
+          className="mt-2 px-3 py-1 bg-green-600 text-white rounded"
+        >
+          Add Photo
+        </button>
+        <input
+          type="file"
+          accept="image/*"
+          multiple
+          ref={fileInputRef}
+          onChange={handleFiles}
+          className="hidden"
+        />
+      </div>
     </div>
-  )
+  </div>
+)
 }


### PR DESCRIPTION
## Summary
- persist plant data to localStorage and initialize gallery arrays
- provide `addPhoto` and `removePhoto` utilities in `PlantContext`
- allow uploading images and removing them in `PlantDetail`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687309c7b60c8324bd23dcf6b8d50bd4