### PR TITLE
Add gallery lightbox

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,6 +3,7 @@ import Home from './pages/Home'
 import MyPlants from './pages/MyPlants'
 import Tasks from './pages/Tasks'
 import Add from './pages/Add'
+import Gallery from './pages/Gallery'
 import Settings from './pages/Settings'
 import PlantDetail from './pages/PlantDetail'
 import BottomNav from './components/BottomNav'
@@ -16,6 +17,7 @@ export default function App() {
         <Route path="/myplants" element={<MyPlants />} />
         <Route path="/tasks" element={<Tasks />} />
         <Route path="/add" element={<Add />} />
+        <Route path="/gallery" element={<Gallery />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/plant/:id" element={<PlantDetail />} />
       </Routes>

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -1,0 +1,55 @@
+import { useEffect, useState } from 'react'
+
+export default function Lightbox({ images, startIndex = 0, onClose }) {
+  const [index, setIndex] = useState(startIndex)
+
+  useEffect(() => {
+    const handleKey = e => {
+      if (e.key === 'Escape') {
+        onClose()
+      } else if (e.key === 'ArrowRight') {
+        setIndex(i => (i + 1) % images.length)
+      } else if (e.key === 'ArrowLeft') {
+        setIndex(i => (i - 1 + images.length) % images.length)
+      }
+    }
+
+    window.addEventListener('keydown', handleKey)
+    document.body.style.overflow = 'hidden'
+    return () => {
+      window.removeEventListener('keydown', handleKey)
+      document.body.style.overflow = ''
+    }
+  }, [images.length, onClose])
+
+  return (
+    <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50">
+      <button
+        aria-label="Close"
+        onClick={onClose}
+        className="absolute top-4 right-4 text-white text-3xl"
+      >
+        &times;
+      </button>
+      <button
+        aria-label="Previous image"
+        className="absolute left-4 text-white text-3xl"
+        onClick={() => setIndex((index - 1 + images.length) % images.length)}
+      >
+        ‹
+      </button>
+      <img
+        src={images[index]}
+        alt="Gallery image"
+        className="max-w-full max-h-full object-contain"
+      />
+      <button
+        aria-label="Next image"
+        className="absolute right-4 text-white text-3xl"
+        onClick={() => setIndex((index + 1) % images.length)}
+      >
+        ›
+      </button>
+    </div>
+  )
+}

--- a/src/components/__tests__/Lightbox.test.jsx
+++ b/src/components/__tests__/Lightbox.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Lightbox from '../Lightbox.jsx'
+
+test('keyboard navigation and close', () => {
+  const images = ['a.jpg', 'b.jpg']
+  const onClose = jest.fn()
+  render(<Lightbox images={images} startIndex={0} onClose={onClose} />)
+
+  const img = screen.getByAltText(/gallery image/i)
+  expect(img).toHaveAttribute('src', 'a.jpg')
+
+  fireEvent.keyDown(window, { key: 'ArrowRight' })
+  expect(img).toHaveAttribute('src', 'b.jpg')
+
+  fireEvent.keyDown(window, { key: 'ArrowLeft' })
+  expect(img).toHaveAttribute('src', 'a.jpg')
+
+  fireEvent.keyDown(window, { key: 'Escape' })
+  expect(onClose).toHaveBeenCalled()
+})

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,3 +1,25 @@
+import { useState } from 'react'
+import { usePlants } from '../PlantContext.jsx'
+import Lightbox from '../components/Lightbox.jsx'
+
 export default function Gallery() {
-  return <div className="text-gray-700">Gallery view coming soon</div>
+  const { plants } = usePlants()
+  const images = plants.map(p => p.image)
+  const [index, setIndex] = useState(null)
+
+  return (
+    <div>
+      <h1 className="text-xl font-bold mb-4">Gallery</h1>
+      <div className="grid grid-cols-3 gap-2">
+        {images.map((src, i) => (
+          <button key={i} onClick={() => setIndex(i)} className="focus:outline-none">
+            <img src={src} alt={`Plant ${i + 1}`} loading="lazy" className="w-full h-32 object-cover rounded" />
+          </button>
+        ))}
+      </div>
+      {index !== null && (
+        <Lightbox images={images} startIndex={index} onClose={() => setIndex(null)} />
+      )}
+    </div>
+  )
 }


### PR DESCRIPTION
## Summary
- create `Lightbox` modal with keyboard navigation
- update gallery page to open images in the new modal
- expose gallery via a new route in `App.jsx`
- test lightbox behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687309c9956c8324be6ff3e15e7f736c