### PR TITLE
Add NotFound page and catch-all route

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Add from './pages/Add'
 import Settings from './pages/Settings'
 import PlantDetail from './pages/PlantDetail'
 import BottomNav from './components/BottomNav'
+import NotFound from './pages/NotFound'
 
 export default function App() {
   return (
@@ -18,6 +19,7 @@ export default function App() {
         <Route path="/add" element={<Add />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/plant/:id" element={<PlantDetail />} />
+        <Route path="*" element={<NotFound />} />
       </Routes>
 
 

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -1,0 +1,13 @@
+import { Link } from 'react-router-dom'
+
+export default function NotFound() {
+  return (
+    <div className="text-center space-y-4">
+      <h1 className="text-2xl font-bold">Page Not Found</h1>
+      <p className="text-gray-600">Sorry, we couldn\'t find that page.</p>
+      <Link to="/" className="text-green-600 underline">
+        Go to Home
+      </Link>
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary
- add a simple `NotFound` component with a link back home
- import and use `NotFound` in `App.jsx` to handle unmatched routes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687309cc0b5083249055bb0cc53668b8