### PR TITLE
Fix duplicate Gallery import and component

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -3,10 +3,9 @@ import Home from './pages/Home'
 import MyPlants from './pages/MyPlants'
 import Tasks from './pages/Tasks'
 import Add from './pages/Add'
-import Gallery from './pages/Gallery'
+import Gallery, { AllGallery } from './pages/Gallery'
 import Settings from './pages/Settings'
 import PlantDetail from './pages/PlantDetail'
-import Gallery from './pages/Gallery'
 import BottomNav from './components/BottomNav'
 import NotFound from './pages/NotFound'
 
@@ -19,7 +18,7 @@ export default function App() {
         <Route path="/myplants" element={<MyPlants />} />
         <Route path="/tasks" element={<Tasks />} />
         <Route path="/add" element={<Add />} />
-        <Route path="/gallery" element={<Gallery />} />
+        <Route path="/gallery" element={<AllGallery />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/plant/:id" element={<PlantDetail />} />
 

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,9 +1,10 @@
 
 import { useState } from 'react'
+import { useParams } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
 import Lightbox from '../components/Lightbox.jsx'
 
-export default function Gallery() {
+export function AllGallery() {
   const { plants } = usePlants()
   const images = plants.map(p => p.image)
   const [index, setIndex] = useState(null)
@@ -14,16 +15,21 @@ export default function Gallery() {
       <div className="grid grid-cols-3 gap-2">
         {images.map((src, i) => (
           <button key={i} onClick={() => setIndex(i)} className="focus:outline-none">
-            <img src={src} alt={`Plant ${i + 1}`} loading="lazy" className="w-full h-32 object-cover rounded" />
+            <img
+              src={src}
+              alt={`Plant ${i + 1}`}
+              loading="lazy"
+              className="w-full h-32 object-cover rounded"
+            />
           </button>
         ))}
       </div>
       {index !== null && (
         <Lightbox images={images} startIndex={index} onClose={() => setIndex(null)} />
       )}
-
-import { useParams } from 'react-router-dom'
-import { usePlants } from '../PlantContext.jsx'
+    </div>
+  )
+}
 
 export default function Gallery() {
   const { id } = useParams()


### PR DESCRIPTION
## Summary
- remove duplicate Gallery import in `App.jsx`
- create `AllGallery` component for overall lightbox view
- use `AllGallery` for `/gallery` route and keep plant-specific `Gallery` for `/plant/:id/gallery`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68730dfe732c8324b899ab77cc4c6ab6