### PR TITLE
Fix filter sets for MyPlants

### DIFF
--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -8,9 +8,9 @@ export default function MyPlants() {
   const [lightFilter, setLightFilter] = useState('All')
   const [urgencyFilter, setUrgencyFilter] = useState('All')
 
-  const rooms = [...new Set(plants.map(p => p.room))]
-  const lights = [...new Set(plants.map(p => p.light))]
-  const urgencies = [...new Set(plants.map(p => p.urgency))]
+  const rooms = [...new Set(plants.map(p => p.room).filter(Boolean))]
+  const lights = [...new Set(plants.map(p => p.light).filter(Boolean))]
+  const urgencies = [...new Set(plants.map(p => p.urgency).filter(Boolean))]
 
   const filtered = plants.filter(p =>
     (roomFilter === 'All' || p.room === roomFilter) &&


### PR DESCRIPTION
## Summary
- ignore falsy values when creating the filter option sets in `MyPlants`
- run the unit test suite

## Testing
- `npm test > /tmp/test.log 2>&1 && tail -n 20 /tmp/test.log`

------
https://chatgpt.com/codex/tasks/task_e_68731022cf1c8324930f5f8b598af58b