### PR TITLE
Add weather context

### DIFF
--- a/src/WeatherContext.jsx
+++ b/src/WeatherContext.jsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const WeatherContext = createContext()
+
+export function WeatherProvider({ children }) {
+  const [forecast, setForecast] = useState(null)
+
+  useEffect(() => {
+    const key = import.meta.env.VITE_WEATHER_API_KEY
+    if (!key) return
+    const url = `https://api.openweathermap.org/data/2.5/forecast?q=London&units=metric&appid=${key}`
+    fetch(url)
+      .then(res => res.json())
+      .then(data => {
+        if (data && data.list && data.list.length > 0) {
+          const next = data.list[0]
+          const rainfall = next.pop ? Math.round(next.pop * 100) : 0
+          setForecast({
+            temp: Math.round(next.main.temp) + '°C',
+            condition: next.weather?.[0]?.main,
+            rainfall,
+          })
+        }
+      })
+      .catch(err => console.error(err))
+  }, [])
+
+  return (
+    <WeatherContext.Provider value={{ forecast }}>
+      {children}
+    </WeatherContext.Provider>
+  )
+}
+
+export const useWeather = () => useContext(WeatherContext)

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -4,16 +4,19 @@ import { BrowserRouter } from 'react-router-dom'
 import App from './App.jsx'
 import { PlantProvider } from './PlantContext.jsx'
 import { ThemeProvider } from './ThemeContext.jsx'
+import { WeatherProvider } from './WeatherContext.jsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <ThemeProvider>
-      <PlantProvider>
-        <BrowserRouter basename="/lisa">
-          <App />
-        </BrowserRouter>
-      </PlantProvider>
+      <WeatherProvider>
+        <PlantProvider>
+          <BrowserRouter basename="/lisa">
+            <App />
+          </BrowserRouter>
+        </PlantProvider>
+      </WeatherProvider>
     </ThemeProvider>
   </React.StrictMode>
 )

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,5 +1,6 @@
 import TaskItem from '../components/TaskItem'
 import { usePlants } from '../PlantContext.jsx'
+import { useWeather } from '../WeatherContext.jsx'
 
 export default function Home() {
   const { plants } = usePlants()
@@ -10,8 +11,7 @@ export default function Home() {
     day: 'numeric',
   })
 
-  // placeholder weather data
-  const weather = { temp: '72°F', condition: 'Sunny' }
+  const { forecast: weather } = useWeather()
 
   return (
     <div className="space-y-4">
@@ -19,7 +19,7 @@ export default function Home() {
         <div>
           <h1 className="text-xl font-bold">{today}</h1>
           <p className="text-sm text-gray-600">
-            {weather.temp} - {weather.condition}
+            {weather ? `${weather.temp} - ${weather.condition}` : 'Loading...'}
           </p>
         </div>
       </header>


### PR DESCRIPTION
## Summary
- add `WeatherContext` for fetching forecast data
- wrap app in `<WeatherProvider>`
- show forecast on home page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687310574cec83248d4739284ee178c4