### PR TITLE
Add timeline navigation

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -6,6 +6,7 @@ import Add from './pages/Add'
 import Gallery, { AllGallery } from './pages/Gallery'
 import Settings from './pages/Settings'
 import PlantDetail from './pages/PlantDetail'
+import Timeline from './pages/Timeline'
 import BottomNav from './components/BottomNav'
 import NotFound from './pages/NotFound'
 
@@ -21,6 +22,7 @@ export default function App() {
         <Route path="/gallery" element={<AllGallery />} />
         <Route path="/settings" element={<Settings />} />
         <Route path="/plant/:id" element={<PlantDetail />} />
+        <Route path="/timeline" element={<Timeline />} />
 
         <Route path="*" element={<NotFound />} />
 

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -46,6 +46,16 @@ const CheckCircleIcon = () => (
   </IconWrapper>
 )
 
+const ClockIcon = () => (
+  <IconWrapper>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M12 6v6l2 2m6-2a9 9 0 1 1-18 0 9 9 0 0 1 18 0z"
+    />
+  </IconWrapper>
+)
+
 const PlusCircleIcon = () => (
   <IconWrapper>
     <path
@@ -71,6 +81,7 @@ export default function BottomNav() {
     { to: '/', label: 'Home', icon: HomeIcon },
     { to: '/myplants', label: 'My Plants', icon: ListIcon },
     { to: '/tasks', label: 'Tasks', icon: CheckCircleIcon },
+    { to: '/timeline', label: 'Timeline', icon: ClockIcon },
     { to: '/add', label: 'Add', icon: PlusCircleIcon },
     { to: '/settings', label: 'Profile', icon: UserIcon },
   ]


### PR DESCRIPTION
## Summary
- include Timeline page in routing
- add Timeline tab in the bottom navigation with a clock icon

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68731099b528832488453da6fc18d55c