### PR TITLE
Add care log note tracking

### DIFF
--- a/src/__tests__/PlantContext.test.jsx
+++ b/src/__tests__/PlantContext.test.jsx
@@ -1,0 +1,28 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { PlantProvider, usePlants } from '../PlantContext.jsx'
+
+function TestComponent() {
+  const { plants, markWatered } = usePlants()
+  const plant = plants[0]
+  return (
+    <div>
+      <button onClick={() => markWatered(plant.id, 'test note')}>log</button>
+      <ul>
+        {(plant.careLog || []).map((e, i) => (
+          <li key={i}>{e.note}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}
+
+test('markWatered stores notes in careLog', () => {
+  render(
+    <PlantProvider>
+      <TestComponent />
+    </PlantProvider>
+  )
+
+  fireEvent.click(screen.getByText('log'))
+  expect(screen.getByText('test note')).toBeInTheDocument()
+})

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -8,7 +8,10 @@ export default function PlantCard({ plant }) {
   const startX = useRef(0)
   const [deltaX, setDeltaX] = useState(0)
 
-  const handleWatered = () => markWatered(plant.id)
+  const handleWatered = () => {
+    const note = window.prompt('Optional note') || ''
+    markWatered(plant.id, note)
+  }
 
   const handlePointerDown = e => {
     startX.current = e.clientX ?? e.touches?.[0]?.clientX ?? 0
@@ -25,7 +28,7 @@ export default function PlantCard({ plant }) {
     setDeltaX(0)
     startX.current = 0
     if (diff > 75) {
-      markWatered(plant.id)
+      handleWatered()
     } else if (diff < -150) {
       removePlant(plant.id)
     } else if (diff < -75) {

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -63,7 +63,8 @@ export default function TaskItem({ task, onComplete }) {
     if (onComplete) {
       onComplete(task)
     } else if (task.type === 'Water') {
-      markWatered(task.plantId)
+      const note = window.prompt('Optional note') || ''
+      markWatered(task.plantId, note)
     }
   }
 

--- a/src/components/__tests__/PlantCard.test.jsx
+++ b/src/components/__tests__/PlantCard.test.jsx
@@ -52,13 +52,14 @@ test('renders plant name', () => {
 })
 
 test('water button triggers watering', () => {
+  jest.spyOn(window, 'prompt').mockReturnValue('')
   render(
     <MemoryRouter>
       <PlantCard plant={plant} />
     </MemoryRouter>
   )
   fireEvent.click(screen.getByText('Water'))
-  expect(markWatered).toHaveBeenCalledWith(1)
+  expect(markWatered).toHaveBeenCalledWith(1, '')
 })
 
 test('edit button navigates to edit page', () => {

--- a/src/components/__tests__/TaskItem.test.jsx
+++ b/src/components/__tests__/TaskItem.test.jsx
@@ -35,6 +35,7 @@ test('icon svg is aria-hidden', () => {
 });
 
 test('mark as done does not navigate', () => {
+  jest.spyOn(window, 'prompt').mockReturnValue('')
   render(
     <PlantProvider>
       <MemoryRouter initialEntries={['/']}>

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -107,8 +107,11 @@ export default function PlantDetail() {
           <div className="p-4">
             {tab === 'activity' && (
               <ul className="list-disc pl-4 space-y-1">
-                {(plant.activity || []).map((a, i) => (
-                  <li key={i}>{a}</li>
+                {(plant.careLog || []).map((ev, i) => (
+                  <li key={i}>
+                    {ev.type} on {ev.date}
+                    {ev.note ? ` - ${ev.note}` : ''}
+                  </li>
                 ))}
               </ul>
             )}

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -31,6 +31,14 @@ export default function Timeline() {
           })
         }
       })
+      ;(p.careLog || []).forEach(ev => {
+        all.push({
+          date: ev.date,
+          label: `${ev.type} ${p.name}`,
+          note: ev.note,
+          type: 'log',
+        })
+      })
     })
     return all.sort((a, b) => new Date(a.date) - new Date(b.date))
   }, [plants])
@@ -39,18 +47,22 @@ export default function Timeline() {
     water: 'bg-blue-500',
     fertilize: 'bg-yellow-500',
     note: 'bg-gray-400',
+    log: 'bg-green-400',
   }
 
   return (
     <div className="overflow-y-auto max-h-full p-4 text-gray-700 dark:text-gray-200">
       <ul className="relative border-l border-gray-300 pl-4 space-y-6">
         {events.map((e, i) => (
-          <li key={`${e.date}-${e.label}`} className="relative">
+          <li key={`${e.date}-${e.label}-${i}`} className="relative">
             <span
               className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
             ></span>
             <p className="text-xs text-gray-500">{e.date}</p>
             <p>{e.label}</p>
+            {e.note && (
+              <p className="text-xs text-gray-500 italic">{e.note}</p>
+            )}
           </li>
         ))}
       </ul>

--- a/src/pages/__tests__/PlantDetailCareLog.test.jsx
+++ b/src/pages/__tests__/PlantDetailCareLog.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import PlantDetail from '../PlantDetail.jsx'
+
+let mockPlants = []
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: () => ({
+    plants: mockPlants,
+    addPhoto: jest.fn(),
+    removePhoto: jest.fn(),
+  }),
+}))
+
+beforeEach(() => {
+  mockPlants = [
+    {
+      id: 1,
+      name: 'Plant A',
+      image: 'a.jpg',
+      careLog: [
+        { date: '2025-07-02', type: 'Watered', note: 'deep soak' },
+      ],
+      gallery: [],
+    },
+  ]
+})
+
+test('shows notes from care log in activity tab', () => {
+  render(
+    <MemoryRouter initialEntries={['/plant/1']}>
+      <Routes>
+        <Route path="/plant/:id" element={<PlantDetail />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+  expect(screen.getByText('Watered on 2025-07-02 - deep soak')).toBeInTheDocument()
+})

--- a/src/pages/__tests__/Timeline.test.jsx
+++ b/src/pages/__tests__/Timeline.test.jsx
@@ -17,9 +17,14 @@ const samplePlants = [
   },
 ]
 
+let mockPlants = samplePlants
 jest.mock('../../PlantContext.jsx', () => ({
-  usePlants: () => ({ plants: samplePlants }),
+  usePlants: () => ({ plants: mockPlants }),
 }))
+
+beforeEach(() => {
+  mockPlants = samplePlants
+})
 
 test('ignores activities without valid dates when generating events', () => {
   render(<Timeline />)
@@ -32,4 +37,20 @@ test('ignores activities without valid dates when generating events', () => {
   expect(items[1]).toHaveTextContent('Plant B: Watered on 2025-07-09')
   expect(items[2]).toHaveTextContent('Watered Plant B')
   expect(items[3]).toHaveTextContent('Watered Plant A')
+})
+
+test('renders care log notes', () => {
+  mockPlants = [
+    {
+      id: 1,
+      name: 'Plant A',
+      careLog: [
+        { date: '2025-07-02', type: 'Watered', note: 'deep soak' },
+      ],
+    },
+  ]
+
+  render(<Timeline />)
+  expect(screen.getByText('Watered Plant A')).toBeInTheDocument()
+  expect(screen.getByText('deep soak')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- allow plants to store careLog history
- log watering with optional notes
- prompt for notes in PlantCard and TaskItem
- display notes on timeline and plant detail
- add tests for note saving and rendering

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6873169a7d608324b74160fefaead9a5