### PR TITLE
Fix environment variable usage in Vite build

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -3,5 +3,10 @@ import react from '@vitejs/plugin-react'
 
 export default defineConfig({
   base: '/lisa/',
+  define: {
+    'process.env.VITE_WEATHER_API_KEY': JSON.stringify(
+      process.env.VITE_WEATHER_API_KEY
+    ),
+  },
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- define `process.env.VITE_WEATHER_API_KEY` in `vite.config.js` so the weather API key is available at runtime

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68731c22bbd48324aa97c6de6f263263