### PR TITLE
Add timeline tab to PlantDetail

### DIFF
--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -36,7 +36,7 @@ test('tab keyboard navigation works', () => {
   )
 
   const tabs = screen.getAllByRole('tab')
-  expect(tabs).toHaveLength(3)
+  expect(tabs).toHaveLength(4)
   expect(tabs[0]).toHaveAttribute('aria-selected', 'true')
 
   tabs[0].focus()


### PR DESCRIPTION
## Summary
- introduce timeline tab on plant detail view
- generate per-plant timeline events
- test update for extra tab

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68731d3aa46883248d1fdf9ce569cda3