### PR TITLE
Rename task action labels

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -84,7 +84,7 @@ export default function PlantCard({ plant }) {
           onClick={handleWatered}
           className="mt-2 px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 transition"
         >
-          Mark as Watered
+          Watered
         </button>
       </div>
     </div>

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -90,7 +90,7 @@ export default function TaskItem({ task, onComplete }) {
         onClick={handleComplete}
         className="ml-2 px-3 py-1 bg-green-100 text-green-700 rounded text-sm"
       >
-        Mark as Done
+        Done
       </button>
     </div>
   )

--- a/src/components/__tests__/TaskItem.test.jsx
+++ b/src/components/__tests__/TaskItem.test.jsx
@@ -46,7 +46,7 @@ test('mark as done does not navigate', () => {
       </MemoryRouter>
     </PlantProvider>
   )
-  fireEvent.click(screen.getByText('Mark as Done'))
+  fireEvent.click(screen.getByText('Done'))
   expect(screen.queryByText('Plant Page')).not.toBeInTheDocument()
 
 });


### PR DESCRIPTION
## Summary
- shorten "Mark as" labels for task actions
- update tests to match new button label

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6873245d4e8c83248c346bcee30dd303