### PR TITLE
Add action icons module and timeline icons

### DIFF
--- a/src/components/ActionIcons.jsx
+++ b/src/components/ActionIcons.jsx
@@ -1,0 +1,58 @@
+import React from 'react'
+
+export function IconWrapper({ children }) {
+  return (
+    <svg
+      className="w-6 h-6 text-gray-500 dark:text-gray-400"
+      xmlns="http://www.w3.org/2000/svg"
+      fill="none"
+      viewBox="0 0 24 24"
+      strokeWidth="1.5"
+      stroke="currentColor"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  )
+}
+
+export const WaterIcon = () => (
+  <IconWrapper>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="m15 11.25 1.5 1.5.75-.75V8.758l2.276-.61a3 3 0 1 0-3.675-3.675l-.61 2.277H12l-.75.75 1.5 1.5M15 11.25l-8.47 8.47c-.34.34-.8.53-1.28.53s-.94.19-1.28.53l-.97.97-.75-.75.97-.97c.34-.34.53-.8.53-1.28s.19-.94.53-1.28L12.75 9M15 11.25 12.75 9"
+    />
+  </IconWrapper>
+)
+
+export const FertilizeIcon = () => (
+  <IconWrapper>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"
+    />
+  </IconWrapper>
+)
+
+export const RotateIcon = () => (
+  <IconWrapper>
+    <path
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.183 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.183 3.182m0-4.991v4.99"
+    />
+  </IconWrapper>
+)
+
+export const icons = {
+  Water: WaterIcon,
+  Fertilize: FertilizeIcon,
+  Rotate: RotateIcon,
+  water: WaterIcon,
+  fertilize: FertilizeIcon,
+  rotate: RotateIcon,
+}
+
+export default icons

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -1,61 +1,11 @@
 import { Link } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
+import actionIcons from './ActionIcons.jsx'
 
-function IconWrapper({ children }) {
-  return (
-    <svg
-      className="w-6 h-6 text-gray-500 dark:text-gray-400"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      {children}
-    </svg>
-  )
-}
-
-const WaterIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="m15 11.25 1.5 1.5.75-.75V8.758l2.276-.61a3 3 0 1 0-3.675-3.675l-.61 2.277H12l-.75.75 1.5 1.5M15 11.25l-8.47 8.47c-.34.34-.8.53-1.28.53s-.94.19-1.28.53l-.97.97-.75-.75.97-.97c.34-.34.53-.8.53-1.28s.19-.94.53-1.28L12.75 9M15 11.25 12.75 9"
-    />
-  </IconWrapper>
-)
-
-const FertilizeIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"
-    />
-  </IconWrapper>
-)
-
-const RotateIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.181 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.181 3.182m0-4.991v4.99"
-    />
-  </IconWrapper>
-)
-
-const icons = {
-  Water: WaterIcon,
-  Fertilize: FertilizeIcon,
-  Rotate: RotateIcon,
-}
 
 export default function TaskItem({ task, onComplete }) {
   const { markWatered } = usePlants()
-  const Icon = icons[task.type]
+  const Icon = actionIcons[task.type]
 
   const handleComplete = e => {
     e.preventDefault()

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -1,6 +1,7 @@
 import { useParams, Link } from 'react-router-dom'
 import { useState, useRef, useMemo } from 'react'
 import { usePlants } from '../PlantContext.jsx'
+import actionIcons from '../components/ActionIcons.jsx'
 
 export default function PlantDetail() {
   const { id } = useParams()
@@ -166,18 +167,24 @@ export default function PlantDetail() {
             )}
             {tab === 'timeline' && (
               <ul className="relative border-l border-gray-300 pl-4 space-y-6">
-                {events.map((e, i) => (
-                  <li key={`${e.date}-${i}`} className="relative">
-                    <span
-                      className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
-                    ></span>
-                    <p className="text-xs text-gray-500">{e.date}</p>
-                    <p>{e.label}</p>
-                    {e.note && (
-                      <p className="text-xs text-gray-500 italic">{e.note}</p>
-                    )}
-                  </li>
-                ))}
+                {events.map((e, i) => {
+                  const Icon = actionIcons[e.type]
+                  return (
+                    <li key={`${e.date}-${i}`} className="relative">
+                      <span
+                        className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
+                      ></span>
+                      <p className="text-xs text-gray-500">{e.date}</p>
+                      <p className="flex items-center gap-1">
+                        {Icon && <Icon />}
+                        {e.label}
+                      </p>
+                      {e.note && (
+                        <p className="text-xs text-gray-500 italic">{e.note}</p>
+                      )}
+                    </li>
+                  )
+                })}
               </ul>
             )}
         </div>

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -1,5 +1,6 @@
 import { usePlants } from '../PlantContext.jsx'
 import { useMemo } from 'react'
+import actionIcons from '../components/ActionIcons.jsx'
 
 export default function Timeline() {
   const { plants } = usePlants()
@@ -53,18 +54,24 @@ export default function Timeline() {
   return (
     <div className="overflow-y-auto max-h-full p-4 text-gray-700 dark:text-gray-200">
       <ul className="relative border-l border-gray-300 pl-4 space-y-6">
-        {events.map((e, i) => (
-          <li key={`${e.date}-${e.label}-${i}`} className="relative">
-            <span
-              className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
-            ></span>
-            <p className="text-xs text-gray-500">{e.date}</p>
-            <p>{e.label}</p>
-            {e.note && (
-              <p className="text-xs text-gray-500 italic">{e.note}</p>
-            )}
-          </li>
-        ))}
+        {events.map((e, i) => {
+          const Icon = actionIcons[e.type]
+          return (
+            <li key={`${e.date}-${e.label}-${i}`} className="relative">
+              <span
+                className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
+              ></span>
+              <p className="text-xs text-gray-500">{e.date}</p>
+              <p className="flex items-center gap-1">
+                {Icon && <Icon />}
+                {e.label}
+              </p>
+              {e.note && (
+                <p className="text-xs text-gray-500 italic">{e.note}</p>
+              )}
+            </li>
+          )
+        })}
       </ul>
     </div>
   )

--- a/src/pages/__tests__/Timeline.test.jsx
+++ b/src/pages/__tests__/Timeline.test.jsx
@@ -54,3 +54,9 @@ test('renders care log notes', () => {
   expect(screen.getByText('Watered Plant A')).toBeInTheDocument()
   expect(screen.getByText('deep soak')).toBeInTheDocument()
 })
+
+test('renders an icon for events', () => {
+  const { container } = render(<Timeline />)
+  const svg = container.querySelector('svg[aria-hidden="true"]')
+  expect(svg).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- move TaskItem icons into `ActionIcons` module
- reuse icons for tasks, timeline and plant detail screens
- show icons next to timeline events
- check that timeline events have accessible icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68732440ce9c8324984c4eed6514fe42