### PR TITLE
Align plant image field

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -9,7 +9,7 @@ export function PlantProvider({ children }) {
   const [plants, setPlants] = useState(() => {
     const mapPlant = p => ({
       ...p,
-      gallery: p.gallery || [],
+      photos: p.photos || p.gallery || [],
       careLog: p.careLog || [],
     })
 
@@ -70,7 +70,7 @@ export function PlantProvider({ children }) {
       const nextId = prev.reduce((m, p) => Math.max(m, p.id), 0) + 1
       return [
         ...prev,
-        { id: nextId, ...plant, gallery: [], careLog: [] },
+        { id: nextId, ...plant, photos: [], careLog: [] },
       ]
     })
   }
@@ -87,7 +87,7 @@ export function PlantProvider({ children }) {
     setPlants(prev =>
       prev.map(p =>
         p.id === id
-          ? { ...p, gallery: [...(p.gallery || []), url] }
+          ? { ...p, photos: [...(p.photos || []), url] }
           : p
       )
     )
@@ -97,8 +97,8 @@ export function PlantProvider({ children }) {
     setPlants(prev =>
       prev.map(p => {
         if (p.id === id) {
-          const updated = (p.gallery || []).filter((_, i) => i !== index)
-          return { ...p, gallery: updated }
+          const updated = (p.photos || []).filter((_, i) => i !== index)
+          return { ...p, photos: updated }
         }
         return p
       })

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -185,7 +185,7 @@ export default function PlantDetail() {
       <div className="space-y-2">
         <h2 className="text-lg font-semibold">Gallery</h2>
         <div className="grid grid-cols-3 gap-2">
-          {(plant.gallery || []).map((src, i) => (
+          {(plant.photos || []).map((src, i) => (
             <div key={i} className="relative">
               <img
                 src={src}

--- a/src/pages/__tests__/PlantDetailCareLog.test.jsx
+++ b/src/pages/__tests__/PlantDetailCareLog.test.jsx
@@ -20,7 +20,7 @@ beforeEach(() => {
       careLog: [
         { date: '2025-07-02', type: 'Watered', note: 'deep soak' },
       ],
-      gallery: [],
+      photos: [],
     },
   ]
 })


### PR DESCRIPTION
## Summary
- normalize image property to `photos`
- load persisted plants with old `gallery` field
- use `photos` in plant detail view
- update tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68732428449c83248c4d785b1b0fa33a