### PR TITLE
Add floating photo upload for gallery

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,13 +1,25 @@
 
-import { useState } from 'react'
+import { useState, useRef } from 'react'
 import { useParams } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
 import Lightbox from '../components/Lightbox.jsx'
 
 export function AllGallery() {
-  const { plants } = usePlants()
-  const images = plants.map(p => p.image)
+  const { plants, addPhoto } = usePlants()
+  const images = plants.flatMap(p => [p.image, ...(p.gallery || [])])
   const [index, setIndex] = useState(null)
+  const [selected, setSelected] = useState(plants[0]?.id || '')
+  const fileInputRef = useRef()
+
+  const handleFiles = e => {
+    const files = Array.from(e.target.files || [])
+    files.forEach(file => {
+      const reader = new FileReader()
+      reader.onload = ev => addPhoto(Number(selected), ev.target.result)
+      reader.readAsDataURL(file)
+    })
+    e.target.value = ''
+  }
 
   return (
     <div>
@@ -27,6 +39,35 @@ export function AllGallery() {
       {index !== null && (
         <Lightbox images={images} startIndex={index} onClose={() => setIndex(null)} />
       )}
+
+      <select
+        aria-label="Select plant"
+        className="fixed bottom-20 right-4 bg-white dark:bg-gray-800 border rounded p-1"
+        value={selected}
+        onChange={e => setSelected(e.target.value)}
+      >
+        {plants.map(p => (
+          <option key={p.id} value={p.id}>
+            {p.name}
+          </option>
+        ))}
+      </select>
+      <button
+        type="button"
+        aria-label="Add photos"
+        onClick={() => fileInputRef.current.click()}
+        className="fixed bottom-4 right-4 bg-green-600 text-white rounded-full w-12 h-12 flex items-center justify-center shadow-lg"
+      >
+        +
+      </button>
+      <input
+        type="file"
+        accept="image/*"
+        multiple
+        ref={fileInputRef}
+        onChange={handleFiles}
+        className="hidden"
+      />
     </div>
   )
 }

--- a/src/pages/__tests__/AllGallery.test.jsx
+++ b/src/pages/__tests__/AllGallery.test.jsx
@@ -1,0 +1,21 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { PlantProvider } from '../../PlantContext.jsx'
+import { AllGallery } from '../Gallery.jsx'
+
+test('clicking add photos button opens file dialog', () => {
+  const clickSpy = jest
+    .spyOn(window.HTMLInputElement.prototype, 'click')
+    .mockImplementation(() => {})
+
+  render(
+    <PlantProvider>
+      <MemoryRouter>
+        <AllGallery />
+      </MemoryRouter>
+    </PlantProvider>
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /add photos/i }))
+  expect(clickSpy).toHaveBeenCalled()
+})


### PR DESCRIPTION
## Summary
- allow selecting a plant and adding photos on the all gallery page
- keep upload button visible as you scroll
- test file dialog opens from the new button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873242e45e08324a4e55318b7ebb5d1