### PR TITLE
Fix alt text for gallery images

### DIFF
--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from 'react'
 
-export default function Lightbox({ images, startIndex = 0, onClose }) {
+export default function Lightbox({ images, descriptions = [], startIndex = 0, onClose }) {
   const [index, setIndex] = useState(startIndex)
 
   useEffect(() => {
@@ -40,7 +40,7 @@ export default function Lightbox({ images, startIndex = 0, onClose }) {
       </button>
       <img
         src={images[index]}
-        alt="Gallery image"
+        alt={descriptions[index] || 'Gallery image'}
         className="max-w-full max-h-full object-contain"
       />
       <button

--- a/src/components/__tests__/Lightbox.test.jsx
+++ b/src/components/__tests__/Lightbox.test.jsx
@@ -3,17 +3,22 @@ import Lightbox from '../Lightbox.jsx'
 
 test('keyboard navigation and close', () => {
   const images = ['a.jpg', 'b.jpg']
+  const descriptions = ['Image A', 'Image B']
   const onClose = jest.fn()
-  render(<Lightbox images={images} startIndex={0} onClose={onClose} />)
+  render(
+    <Lightbox images={images} descriptions={descriptions} startIndex={0} onClose={onClose} />
+  )
 
-  const img = screen.getByAltText(/gallery image/i)
+  const img = screen.getByAltText(descriptions[0])
   expect(img).toHaveAttribute('src', 'a.jpg')
 
   fireEvent.keyDown(window, { key: 'ArrowRight' })
   expect(img).toHaveAttribute('src', 'b.jpg')
+  expect(img).toHaveAttribute('alt', descriptions[1])
 
   fireEvent.keyDown(window, { key: 'ArrowLeft' })
   expect(img).toHaveAttribute('src', 'a.jpg')
+  expect(img).toHaveAttribute('alt', descriptions[0])
 
   fireEvent.keyDown(window, { key: 'Escape' })
   expect(onClose).toHaveBeenCalled()

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -6,18 +6,18 @@ import Lightbox from '../components/Lightbox.jsx'
 
 export function AllGallery() {
   const { plants } = usePlants()
-  const images = plants.map(p => p.image)
+  const galleryItems = plants.map(p => ({ src: p.image, name: p.name }))
   const [index, setIndex] = useState(null)
 
   return (
     <div>
       <h1 className="text-xl font-bold mb-4">Gallery</h1>
       <div className="grid grid-cols-3 gap-2">
-        {images.map((src, i) => (
+        {galleryItems.map(({ src, name }, i) => (
           <button key={i} onClick={() => setIndex(i)} className="focus:outline-none">
             <img
               src={src}
-              alt={`Plant ${i + 1}`}
+              alt={name}
               loading="lazy"
               className="w-full h-32 object-cover rounded"
             />
@@ -25,7 +25,12 @@ export function AllGallery() {
         ))}
       </div>
       {index !== null && (
-        <Lightbox images={images} startIndex={index} onClose={() => setIndex(null)} />
+        <Lightbox
+          images={galleryItems.map(i => i.src)}
+          descriptions={galleryItems.map(i => i.name)}
+          startIndex={index}
+          onClose={() => setIndex(null)}
+        />
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- display each plant name as alt text in Gallery
- pass image descriptions to Lightbox
- verify descriptions in Lightbox test

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_6873243224508324af7503834a33f128