### PR TITLE
Improve Lightbox accessibility

### DIFF
--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -1,7 +1,9 @@
-import { useEffect, useState } from 'react'
+import { useEffect, useRef, useState } from 'react'
 
 export default function Lightbox({ images, startIndex = 0, onClose }) {
   const [index, setIndex] = useState(startIndex)
+  const closeBtnRef = useRef(null)
+  const prevFocusRef = useRef(null)
 
   useEffect(() => {
     const handleKey = e => {
@@ -16,15 +18,23 @@ export default function Lightbox({ images, startIndex = 0, onClose }) {
 
     window.addEventListener('keydown', handleKey)
     document.body.style.overflow = 'hidden'
+    prevFocusRef.current = document.activeElement
+    closeBtnRef.current?.focus()
     return () => {
       window.removeEventListener('keydown', handleKey)
       document.body.style.overflow = ''
+      prevFocusRef.current?.focus()
     }
   }, [images.length, onClose])
 
   return (
-    <div className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50">
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50"
+    >
       <button
+        ref={closeBtnRef}
         aria-label="Close"
         onClick={onClose}
         className="absolute top-4 right-4 text-white text-3xl"

--- a/src/components/__tests__/Lightbox.test.jsx
+++ b/src/components/__tests__/Lightbox.test.jsx
@@ -6,6 +6,9 @@ test('keyboard navigation and close', () => {
   const onClose = jest.fn()
   render(<Lightbox images={images} startIndex={0} onClose={onClose} />)
 
+  const dialog = screen.getByRole('dialog')
+  expect(dialog).toHaveAttribute('aria-modal', 'true')
+
   const img = screen.getByAltText(/gallery image/i)
   expect(img).toHaveAttribute('src', 'a.jpg')
 


### PR DESCRIPTION
## Summary
- add `role="dialog"` and `aria-modal` to the Lightbox container
- restore focus to previous element when closing the Lightbox
- move focus to the close button when opened
- test for the dialog role

## Testing
- `npm install`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687329c505908324b05fa3f087bdade5