### PR TITLE
Add configurable base path

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,9 +61,11 @@ Open that URL in your browser to view the app.
 npm run build
 ```
 
-When deploying to a subdirectory (for example `/lisa/`), set `base` in
-`vite.config.js` and pass the same value as the router `basename` so asset paths
-resolve correctly.
+When deploying to a subdirectory (for example `/lisa/`), set the
+`VITE_BASE_PATH` environment variable to that path. `vite.config.js` reads this
+variable to configure the build `base` option, and the router uses the same
+value via `basename` so asset paths resolve correctly. If the variable is not
+set, it defaults to `/`.
 
 After building you can preview the production build with:
 ```bash

--- a/src/__tests__/RouterBase.test.js
+++ b/src/__tests__/RouterBase.test.js
@@ -1,0 +1,6 @@
+const fs = require('fs');
+
+test('BrowserRouter uses VITE_BASE_PATH', () => {
+  const contents = fs.readFileSync('src/main.jsx', 'utf8');
+  expect(contents).toContain('basename={import.meta.env.VITE_BASE_PATH}');
+});

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -12,7 +12,7 @@ ReactDOM.createRoot(document.getElementById('root')).render(
     <ThemeProvider>
       <WeatherProvider>
         <PlantProvider>
-          <BrowserRouter basename="/lisa">
+          <BrowserRouter basename={import.meta.env.VITE_BASE_PATH}>
             <App />
           </BrowserRouter>
         </PlantProvider>

--- a/vite.config.js
+++ b/vite.config.js
@@ -1,12 +1,15 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
+const basePath = process.env.VITE_BASE_PATH || '/'
+
 export default defineConfig({
-  base: '/lisa/',
+  base: basePath,
   define: {
     'process.env.VITE_WEATHER_API_KEY': JSON.stringify(
       process.env.VITE_WEATHER_API_KEY
     ),
+    'import.meta.env.VITE_BASE_PATH': JSON.stringify(basePath),
   },
   plugins: [react()],
 })


### PR DESCRIPTION
## Summary
- allow configuring base path through `VITE_BASE_PATH`
- pass that base path into the router
- document deployment environment variable
- add test to verify router uses env var

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687329cf0a648324a995d622c57c8f0c