### PR TITLE
Add monthly grouping to timeline

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -2,6 +2,7 @@ import { useParams, Link } from 'react-router-dom'
 import { useState, useRef, useMemo } from 'react'
 import { usePlants } from '../PlantContext.jsx'
 import actionIcons from '../components/ActionIcons.jsx'
+import { formatMonth } from '../utils/date.js'
 
 export default function PlantDetail() {
   const { id } = useParams()
@@ -38,6 +39,16 @@ export default function PlantDetail() {
     })
     return list.sort((a, b) => new Date(a.date) - new Date(b.date))
   }, [plant])
+
+  const groupedEvents = useMemo(() => {
+    const map = new Map()
+    events.forEach(e => {
+      const key = e.date.slice(0, 7)
+      if (!map.has(key)) map.set(key, [])
+      map.get(key).push(e)
+    })
+    return Array.from(map.entries())
+  }, [events])
 
   const colors = {
     water: 'bg-blue-500',
@@ -194,26 +205,35 @@ export default function PlantDetail() {
               <div>{plant.advancedCare || 'No advanced care info.'}</div>
             )}
             {tab === 'timeline' && (
-              <ul className="relative border-l border-gray-300 pl-4 space-y-6">
-                {events.map((e, i) => {
-                  const Icon = actionIcons[e.type]
-                  return (
-                    <li key={`${e.date}-${i}`} className="relative">
-                      <span
-                        className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
-                      ></span>
-                      <p className="text-xs text-gray-500">{e.date}</p>
-                      <p className="flex items-center gap-1">
-                        {Icon && <Icon />}
-                        {e.label}
-                      </p>
-                      {e.note && (
-                        <p className="text-xs text-gray-500 italic">{e.note}</p>
-                      )}
-                    </li>
-                  )
-                })}
-              </ul>
+              <div>
+                {groupedEvents.map(([monthKey, list]) => (
+                  <div key={monthKey}>
+                    <h3 className="mt-4 text-sm font-semibold text-gray-500">
+                      {formatMonth(monthKey)}
+                    </h3>
+                    <ul className="relative border-l border-gray-300 pl-4 space-y-6">
+                      {list.map((e, i) => {
+                        const Icon = actionIcons[e.type]
+                        return (
+                          <li key={`${e.date}-${i}`} className="relative">
+                            <span
+                              className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
+                            ></span>
+                            <p className="text-xs text-gray-500">{e.date}</p>
+                            <p className="flex items-center gap-1">
+                              {Icon && <Icon />}
+                              {e.label}
+                            </p>
+                            {e.note && (
+                              <p className="text-xs text-gray-500 italic">{e.note}</p>
+                            )}
+                          </li>
+                        )
+                      })}
+                    </ul>
+                  </div>
+                ))}
+              </div>
             )}
         </div>
       </div>

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -1,6 +1,7 @@
 import { usePlants } from '../PlantContext.jsx'
 import { useMemo } from 'react'
 import actionIcons from '../components/ActionIcons.jsx'
+import { formatMonth } from '../utils/date.js'
 
 export default function Timeline() {
   const { plants } = usePlants()
@@ -44,6 +45,16 @@ export default function Timeline() {
     return all.sort((a, b) => new Date(a.date) - new Date(b.date))
   }, [plants])
 
+  const groupedEvents = useMemo(() => {
+    const map = new Map()
+    events.forEach(e => {
+      const key = e.date.slice(0, 7)
+      if (!map.has(key)) map.set(key, [])
+      map.get(key).push(e)
+    })
+    return Array.from(map.entries())
+  }, [events])
+
   const colors = {
     water: 'bg-blue-500',
     fertilize: 'bg-yellow-500',
@@ -53,26 +64,33 @@ export default function Timeline() {
 
   return (
     <div className="overflow-y-auto max-h-full p-4 text-gray-700 dark:text-gray-200">
-      <ul className="relative border-l border-gray-300 pl-4 space-y-6">
-        {events.map((e, i) => {
-          const Icon = actionIcons[e.type]
-          return (
-            <li key={`${e.date}-${e.label}-${i}`} className="relative">
-              <span
-                className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
-              ></span>
-              <p className="text-xs text-gray-500">{e.date}</p>
-              <p className="flex items-center gap-1">
-                {Icon && <Icon />}
-                {e.label}
-              </p>
-              {e.note && (
-                <p className="text-xs text-gray-500 italic">{e.note}</p>
-              )}
-            </li>
-          )
-        })}
-      </ul>
+      {groupedEvents.map(([monthKey, list]) => (
+        <div key={monthKey}>
+          <h3 className="mt-4 text-sm font-semibold text-gray-500">
+            {formatMonth(monthKey)}
+          </h3>
+          <ul className="relative border-l border-gray-300 pl-4 space-y-6">
+            {list.map((e, i) => {
+              const Icon = actionIcons[e.type]
+              return (
+                <li key={`${e.date}-${e.label}-${i}`} className="relative">
+                  <span
+                    className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
+                  ></span>
+                  <p className="text-xs text-gray-500">{e.date}</p>
+                  <p className="flex items-center gap-1">
+                    {Icon && <Icon />}
+                    {e.label}
+                  </p>
+                  {e.note && (
+                    <p className="text-xs text-gray-500 italic">{e.note}</p>
+                  )}
+                </li>
+              )
+            })}
+          </ul>
+        </div>
+      ))}
     </div>
   )
 }

--- a/src/pages/__tests__/Timeline.test.jsx
+++ b/src/pages/__tests__/Timeline.test.jsx
@@ -60,3 +60,17 @@ test('renders an icon for events', () => {
   const svg = container.querySelector('svg[aria-hidden="true"]')
   expect(svg).toBeInTheDocument()
 })
+
+test('displays month headers when events span months', () => {
+  mockPlants = [
+    { id: 1, name: 'A', lastWatered: '2025-07-01' },
+    { id: 2, name: 'B', lastWatered: '2025-08-02' },
+  ]
+
+  render(<Timeline />)
+
+  const headings = screen.getAllByRole('heading', { level: 3 })
+  expect(headings).toHaveLength(2)
+  expect(headings[0]).toHaveTextContent('July 2025')
+  expect(headings[1]).toHaveTextContent('August 2025')
+})

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -1,0 +1,18 @@
+export function formatMonth(key) {
+  const [year, month] = key.split('-')
+  const months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ]
+  return `${months[Number(month) - 1]} ${year}`
+}


### PR DESCRIPTION
## Summary
- group timeline events by month
- show monthly headers in the plant detail timeline as well
- add `formatMonth` date utility
- test timeline headers when events span months

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68732c3b30c8832493e48cc25dc5481c