### PR TITLE
Fix addBase base path check

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -10,6 +10,7 @@ export function PlantProvider({ children }) {
     if (!url) return url
     if (/^https?:/.test(url) || url.startsWith('data:')) return url
     const base = (process.env.VITE_BASE_PATH || '/').replace(/\/$/, '')
+    if (url.startsWith(base)) return url
     return `${base}${url.startsWith('/') ? '' : '/'}${url}`
   }
 


### PR DESCRIPTION
## Summary
- adjust `addBase` in `PlantContext` to avoid double-appending base path

## Testing
- `npx jest`

------
https://chatgpt.com/codex/tasks/task_e_6873337b86088324a91529f001856707