### PR TITLE
Add Inter font and adjust text hierarchy

### DIFF
--- a/index.html
+++ b/index.html
@@ -4,6 +4,12 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/favicon.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link
+      href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
+      rel="stylesheet"
+    />
     <title>Kaymaria Plant Tracker</title>
   </head>
   <body>

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -76,7 +76,7 @@ export default function PlantCard({ plant }) {
       >
         <Link to={`/plant/${plant.id}`} className="block mb-2">
           <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-48 object-cover rounded-md" />
-          <h2 className="font-semibold text-lg mt-2">{plant.name}</h2>
+          <h2 className="font-semibold text-xl mt-2">{plant.name}</h2>
         </Link>
         <p className="text-sm text-gray-600 dark:text-gray-400">Last watered: {plant.lastWatered}</p>
         <p className="text-sm text-green-700 font-medium">Next: {plant.nextWater}</p>

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gray-50 text-gray-900;
+  @apply bg-gray-50 text-gray-900 font-sans;
 }
 
 .dark body {

--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -20,7 +20,7 @@ export default function Add() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
-      <h1 className="text-xl font-bold">Add Plant</h1>
+      <h1 className="text-2xl font-bold">Add Plant</h1>
       <div className="grid gap-1">
         <label htmlFor="name" className="font-medium">Name</label>
         <input

--- a/src/pages/EditPlant.jsx
+++ b/src/pages/EditPlant.jsx
@@ -34,7 +34,7 @@ export default function EditPlant() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
-      <h1 className="text-xl font-bold">Edit Plant</h1>
+      <h1 className="text-2xl font-bold">Edit Plant</h1>
       <div className="grid gap-1">
         <label htmlFor="name" className="font-medium">Name</label>
         <input

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -23,7 +23,7 @@ export function AllGallery() {
 
   return (
     <div>
-      <h1 className="text-xl font-bold mb-4">Gallery</h1>
+      <h1 className="text-2xl font-bold mb-4">Gallery</h1>
       <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
         {images.map((src, i) => (
           <button key={i} onClick={() => setIndex(i)} className="focus:outline-none">
@@ -85,7 +85,7 @@ export default function Gallery() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-xl font-bold">{plant.name} Gallery</h1>
+      <h1 className="text-2xl font-bold">{plant.name} Gallery</h1>
 
       {/* desktop grid */}
       <div className="hidden md:grid grid-cols-2 md:grid-cols-3 gap-4">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -22,7 +22,7 @@ export default function Home() {
     <div className="space-y-4">
       <header className="flex items-center justify-between">
         <div>
-          <h1 className="text-xl font-bold">{today}</h1>
+          <h1 className="text-2xl font-bold">{today}</h1>
           <p className="text-sm text-gray-600">
             {forecast
               ? `${forecast.temp} - ${forecast.condition}`

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -20,7 +20,7 @@ export default function MyPlants() {
 
   return (
     <div>
-      <h1 className="text-xl font-bold mb-4">My Plants</h1>
+      <h1 className="text-2xl font-bold mb-4">My Plants</h1>
       <div className="flex flex-wrap gap-2 mb-4">
         <select className="border rounded p-1" value={roomFilter} onChange={e => setRoomFilter(e.target.value)}>
           <option value="All">All Rooms</option>

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -86,7 +86,7 @@ export default function PlantDetail() {
       <div className="space-y-4">
         <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-64 object-cover rounded-xl" />
         <div>
-          <h1 className="text-2xl font-bold">{plant.name}</h1>
+          <h1 className="text-3xl font-bold">{plant.name}</h1>
           {plant.nickname && <p className="text-gray-500">{plant.nickname}</p>}
         </div>
 
@@ -238,7 +238,7 @@ export default function PlantDetail() {
         </div>
       </div>
       <div className="space-y-2">
-        <h2 className="text-lg font-semibold">Gallery</h2>
+        <h2 className="text-xl font-semibold">Gallery</h2>
         <div className="grid grid-cols-3 gap-2">
           {(plant.photos || []).map((src, i) => (
             <div key={i} className="relative">

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -5,7 +5,7 @@ export default function Settings() {
 
   return (
     <div className="space-y-4 text-gray-700 dark:text-gray-200">
-      <h1 className="text-xl font-bold">Settings</h1>
+      <h1 className="text-2xl font-bold">Settings</h1>
       <button
         onClick={toggleTheme}
         className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -2,7 +2,11 @@ export default {
   darkMode: 'class',
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
-    extend: {},
+    extend: {
+      fontFamily: {
+        sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+      },
+    },
   },
   plugins: [],
 };


### PR DESCRIPTION
## Summary
- load Inter from Google Fonts
- set Inter as default font in Tailwind
- apply font globally
- enlarge headings across pages
- tweak PlantCard and PlantDetail typography

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68733b526c148324b709132497c7379d