### PR TITLE
Enhanced navigation animations and task interactions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,8 @@
       "dependencies": {
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
-        "react-router-dom": "^6.22.3"
+        "react-router-dom": "^6.22.3",
+        "react-transition-group": "^4.4.5"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.23.9",
@@ -1899,7 +1900,6 @@
       "version": "7.27.6",
       "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.27.6.tgz",
       "integrity": "sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=6.9.0"
@@ -4803,10 +4803,7 @@
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.1.3.tgz",
       "integrity": "sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "peer": true
+      "license": "MIT"
     },
     "node_modules/data-urls": {
       "version": "5.0.0",
@@ -4933,6 +4930,16 @@
       "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/dom-helpers": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.2.1.tgz",
+      "integrity": "sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.8.7",
+        "csstype": "^3.0.2"
+      }
     },
     "node_modules/domexception": {
       "version": "4.0.0",
@@ -7642,7 +7649,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
       "integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/js-yaml": {
@@ -7799,6 +7805,18 @@
       "integrity": "sha512-FT1yDzDYEoYWhnSGnpE/4Kj1fLZkDFyqRb7fNt6FdYOSxlUWAtp42Eh6Wb0rGIv/m9Bgo7x4GhQbm5Ys4SG5ow==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/loose-envify": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+      "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^3.0.0 || ^4.0.0"
+      },
+      "bin": {
+        "loose-envify": "cli.js"
+      }
     },
     "node_modules/lru-cache": {
       "version": "5.1.1",
@@ -8073,7 +8091,6 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
       "integrity": "sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
@@ -8528,6 +8545,23 @@
         "node": ">= 6"
       }
     },
+    "node_modules/prop-types": {
+      "version": "15.8.1",
+      "resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.8.1.tgz",
+      "integrity": "sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==",
+      "license": "MIT",
+      "dependencies": {
+        "loose-envify": "^1.4.0",
+        "object-assign": "^4.1.1",
+        "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/prop-types/node_modules/react-is": {
+      "version": "16.13.1",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
+      "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
+      "license": "MIT"
+    },
     "node_modules/psl": {
       "version": "1.15.0",
       "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
@@ -8665,6 +8699,22 @@
       "peerDependencies": {
         "react": ">=16.8",
         "react-dom": ">=16.8"
+      }
+    },
+    "node_modules/react-transition-group": {
+      "version": "4.4.5",
+      "resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.5.tgz",
+      "integrity": "sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==",
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "@babel/runtime": "^7.5.5",
+        "dom-helpers": "^5.0.1",
+        "loose-envify": "^1.4.0",
+        "prop-types": "^15.6.2"
+      },
+      "peerDependencies": {
+        "react": ">=16.6.0",
+        "react-dom": ">=16.6.0"
       }
     },
     "node_modules/read-cache": {

--- a/package.json
+++ b/package.json
@@ -12,22 +12,23 @@
   "dependencies": {
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
-    "react-router-dom": "^6.22.3"
+    "react-router-dom": "^6.22.3",
+    "react-transition-group": "^4.4.5"
   },
   "devDependencies": {
-    "@vitejs/plugin-react": "^4.0.0",
-    "autoprefixer": "^10.4.21",
-    "postcss": "^8.4.30",
-    "tailwindcss": "^3.4.1",
-    "vite": "^5.2.0",
-    "jest": "^29.7.0",
-    "@testing-library/react": "^16.3.0",
-    "@testing-library/jest-dom": "^6.4.2",
-    "babel-jest": "^29.7.0",
     "@babel/preset-env": "^7.23.9",
     "@babel/preset-react": "^7.22.15",
+    "@testing-library/jest-dom": "^6.4.2",
+    "@testing-library/react": "^16.3.0",
+    "@vitejs/plugin-react": "^4.0.0",
+    "autoprefixer": "^10.4.21",
+    "babel-jest": "^29.7.0",
+    "jest": "^29.7.0",
+    "jest-environment-jsdom": "^29.7.0",
     "jsdom": "^24.0.0",
-    "jest-environment-jsdom": "^29.7.0"
+    "postcss": "^8.4.30",
+    "tailwindcss": "^3.4.1",
+    "vite": "^5.2.0"
   },
   "license": "MIT"
 }

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,5 @@
-import { Routes, Route } from 'react-router-dom'
+import { Routes, Route, useLocation } from 'react-router-dom'
+import { CSSTransition, SwitchTransition } from 'react-transition-group'
 import Home from './pages/Home'
 import MyPlants from './pages/MyPlants'
 import Tasks from './pages/Tasks'
@@ -11,24 +12,29 @@ import BottomNav from './components/BottomNav'
 import NotFound from './pages/NotFound'
 
 export default function App() {
+  const location = useLocation()
   return (
-    <div className="pb-16 p-4 font-sans">{/* bottom padding for nav */}
+    <div className="pb-16 p-4 font-sans overflow-hidden">{/* bottom padding for nav */}
 
-      <Routes>
-        <Route path="/" element={<Home />} />
-        <Route path="/myplants" element={<MyPlants />} />
-        <Route path="/tasks" element={<Tasks />} />
-        <Route path="/add" element={<Add />} />
-        <Route path="/gallery" element={<AllGallery />} />
-        <Route path="/settings" element={<Settings />} />
-        <Route path="/plant/:id" element={<PlantDetail />} />
-        <Route path="/plant/:id/edit" element={<EditPlant />} />
+      <SwitchTransition>
+        <CSSTransition key={location.pathname} classNames="fade" timeout={200} unmountOnExit>
+          <Routes location={location}>
+            <Route path="/" element={<Home />} />
+            <Route path="/myplants" element={<MyPlants />} />
+            <Route path="/tasks" element={<Tasks />} />
+            <Route path="/add" element={<Add />} />
+            <Route path="/gallery" element={<AllGallery />} />
+            <Route path="/settings" element={<Settings />} />
+            <Route path="/plant/:id" element={<PlantDetail />} />
+            <Route path="/plant/:id/edit" element={<EditPlant />} />
 
-        <Route path="*" element={<NotFound />} />
+            <Route path="*" element={<NotFound />} />
 
-        <Route path="/plant/:id/gallery" element={<Gallery />} />
+            <Route path="/plant/:id/gallery" element={<Gallery />} />
 
-      </Routes>
+          </Routes>
+        </CSSTransition>
+      </SwitchTransition>
 
 
       <BottomNav />

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -82,10 +82,10 @@ export default function BottomNav() {
           key={to}
           to={to}
           className={({ isActive }) =>
-            `flex flex-col items-center text-xs ${isActive ? 'text-green-700' : 'text-gray-500'}`
+            `flex flex-col items-center text-xs transition-transform duration-150 ${isActive ? 'text-green-700 scale-110' : 'text-gray-500'}`
           }
         >
-          <Icon className="mb-1" />
+          <Icon className="mb-1 transition-colors duration-150" />
           {label}
         </NavLink>
       ))}

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from 'react-router-dom'
 import { useRef, useState } from 'react'
+import useRipple from '../utils/useRipple.js'
 import { usePlants } from '../PlantContext.jsx'
 
 export default function PlantCard({ plant }) {
@@ -7,6 +8,7 @@ export default function PlantCard({ plant }) {
   const { markWatered, removePlant } = usePlants()
   const startX = useRef(0)
   const [deltaX, setDeltaX] = useState(0)
+  const [rippleRef, createRipple] = useRipple()
 
   const handleWatered = () => {
     const note = window.prompt('Optional note') || ''
@@ -39,7 +41,9 @@ export default function PlantCard({ plant }) {
   return (
     <div
       data-testid="card-wrapper"
-      className="relative"
+      ref={rippleRef}
+      onMouseDown={createRipple}
+      className="relative overflow-hidden"
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerEnd}
@@ -50,21 +54,24 @@ export default function PlantCard({ plant }) {
     >
       <div className="absolute inset-0 flex justify-between items-center px-4 pointer-events-none">
         <button
+          onMouseDown={createRipple}
           onClick={handleWatered}
-          className="bg-green-600 text-white px-2 py-1 rounded pointer-events-auto"
+          className="bg-green-600 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
         >
           Water
         </button>
         <div className="flex gap-2">
           <button
+            onMouseDown={createRipple}
             onClick={() => navigate(`/plant/${plant.id}/edit`)}
-            className="bg-blue-600 text-white px-2 py-1 rounded pointer-events-auto"
+            className="bg-blue-600 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
           >
             Edit
           </button>
           <button
+            onMouseDown={createRipple}
             onClick={() => removePlant(plant.id)}
-            className="bg-red-600 text-white px-2 py-1 rounded pointer-events-auto"
+            className="bg-red-600 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
           >
             Delete
           </button>
@@ -81,8 +88,9 @@ export default function PlantCard({ plant }) {
         <p className="text-sm text-gray-600 dark:text-gray-400">Last watered: {plant.lastWatered}</p>
         <p className="text-sm text-green-700 font-medium">Next: {plant.nextWater}</p>
         <button
+          onMouseDown={createRipple}
           onClick={handleWatered}
-          className="mt-2 px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 transition"
+          className="mt-2 px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 transition relative overflow-hidden"
         >
           Watered
         </button>

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -1,25 +1,63 @@
-import { Link } from 'react-router-dom'
+import { useRef, useState } from 'react'
+import { Link, useNavigate } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
 import actionIcons from './ActionIcons.jsx'
+import useRipple from '../utils/useRipple.js'
 
 
 export default function TaskItem({ task, onComplete }) {
   const { markWatered } = usePlants()
+  const navigate = useNavigate()
   const Icon = actionIcons[task.type]
+  const startX = useRef(0)
+  const [deltaX, setDeltaX] = useState(0)
+  const [showCheck, setShowCheck] = useState(false)
+  const [rippleRef, createRipple] = useRipple()
 
-  const handleComplete = e => {
-    e.preventDefault()
-    e.stopPropagation()
+  const handleComplete = () => {
     if (onComplete) {
       onComplete(task)
     } else if (task.type === 'Water') {
       const note = window.prompt('Optional note') || ''
       markWatered(task.plantId, note)
     }
+    setShowCheck(true)
+    setTimeout(() => setShowCheck(false), 400)
+  }
+
+  const handlePointerDown = e => {
+    startX.current = e.clientX ?? e.touches?.[0]?.clientX ?? 0
+  }
+
+  const handlePointerMove = e => {
+    if (!startX.current) return
+    const currentX = e.clientX ?? e.touches?.[0]?.clientX ?? 0
+    setDeltaX(currentX - startX.current)
+  }
+
+  const handlePointerEnd = () => {
+    const diff = deltaX
+    setDeltaX(0)
+    startX.current = 0
+    if (diff > 75) {
+      handleComplete()
+    } else if (diff < -75) {
+      navigate(`/plant/${task.plantId}/edit`)
+    }
   }
 
   return (
-    <div className="flex items-center gap-2 p-2 border rounded-lg bg-white dark:bg-gray-800 hover:bg-gray-50 dark:hover:bg-gray-700">
+    <div
+      ref={rippleRef}
+      onMouseDown={createRipple}
+      onTouchStart={e => { createRipple(e); handlePointerDown(e) }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
+      className="relative flex items-center gap-2 p-2 border rounded-lg bg-white dark:bg-gray-800 overflow-hidden"
+      style={{ transform: `translateX(${deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
+    >
       <Link to={`/plant/${task.plantId}`} className="flex items-center flex-1 gap-1">
         <img
           src={task.image}
@@ -37,11 +75,27 @@ export default function TaskItem({ task, onComplete }) {
         {Icon && <Icon />}
       </Link>
       <button
+        onMouseDown={createRipple}
         onClick={handleComplete}
-        className="ml-2 px-3 py-1 bg-green-100 text-green-700 rounded text-sm"
+        className="ml-2 px-3 py-1 bg-green-100 text-green-700 rounded text-sm relative overflow-hidden"
       >
         Done
       </button>
+      {showCheck && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+          <svg
+            className="w-8 h-8 text-green-600 check-pop"
+            xmlns="http://www.w3.org/2000/svg"
+            fill="none"
+            viewBox="0 0 24 24"
+            strokeWidth="1.5"
+            stroke="currentColor"
+            aria-hidden="true"
+          >
+            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+          </svg>
+        </div>
+      )}
     </div>
   )
 }

--- a/src/index.css
+++ b/src/index.css
@@ -24,3 +24,45 @@ body {
 .animate-fade-in-up {
   animation: fade-in-up 0.3s ease both;
 }
+
+.fade-enter {
+  opacity: 0;
+  transform: translateX(10px);
+}
+.fade-enter-active {
+  opacity: 1;
+  transform: translateX(0);
+  transition: opacity 0.2s, transform 0.2s;
+}
+.fade-exit {
+  opacity: 1;
+}
+.fade-exit-active {
+  opacity: 0;
+  transform: translateX(-10px);
+  transition: opacity 0.2s, transform 0.2s;
+}
+
+.ripple-effect {
+  position: absolute;
+  border-radius: 9999px;
+  background-color: rgba(0,0,0,0.3);
+  transform: scale(0);
+  animation: ripple 0.5s ease-out;
+  pointer-events: none;
+}
+
+@keyframes ripple {
+  to {
+    transform: scale(4);
+    opacity: 0;
+  }
+}
+
+@keyframes pop {
+  from { transform: scale(0.5); opacity: 0; }
+  to { transform: scale(1); opacity: 1; }
+}
+.check-pop {
+  animation: pop 0.3s ease-out;
+}

--- a/src/utils/useRipple.js
+++ b/src/utils/useRipple.js
@@ -1,0 +1,21 @@
+import { useRef } from 'react'
+
+export default function useRipple() {
+  const ref = useRef(null)
+
+  const createRipple = e => {
+    const el = ref.current
+    if (!el) return
+    const rect = el.getBoundingClientRect()
+    const circle = document.createElement('span')
+    const diameter = Math.max(rect.width, rect.height)
+    circle.style.width = circle.style.height = `${diameter}px`
+    circle.style.left = `${e.clientX - rect.left - diameter / 2}px`
+    circle.style.top = `${e.clientY - rect.top - diameter / 2}px`
+    circle.className = 'ripple-effect'
+    el.appendChild(circle)
+    setTimeout(() => circle.remove(), 500)
+  }
+
+  return [ref, createRipple]
+}


### PR DESCRIPTION
## Summary
- add fade transitions and ripple animation styles
- switch routes with react-transition-group for smoother page changes
- animate active bottom navigation tabs
- swipeable task items with ripple and completion checkmark
- ripple feedback for plant cards
- add `react-transition-group` dependency

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68733be6a73c8324b9c2dce7ea28853a