### PR TITLE
Fix ripple container detection

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -8,7 +8,7 @@ export default function PlantCard({ plant }) {
   const { markWatered, removePlant } = usePlants()
   const startX = useRef(0)
   const [deltaX, setDeltaX] = useState(0)
-  const [rippleRef, createRipple] = useRipple()
+  const [, createRipple] = useRipple()
 
   const handleWatered = () => {
     const note = window.prompt('Optional note') || ''
@@ -41,20 +41,20 @@ export default function PlantCard({ plant }) {
   return (
     <div
       data-testid="card-wrapper"
-      ref={rippleRef}
       onMouseDown={createRipple}
+      onTouchStart={e => { createRipple(e); handlePointerDown(e) }}
       className="relative overflow-hidden"
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerEnd}
       onPointerCancel={handlePointerEnd}
-      onTouchStart={handlePointerDown}
       onTouchMove={handlePointerMove}
       onTouchEnd={handlePointerEnd}
     >
       <div className="absolute inset-0 flex justify-between items-center px-4 pointer-events-none">
         <button
           onMouseDown={createRipple}
+          onTouchStart={createRipple}
           onClick={handleWatered}
           className="bg-green-600 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
         >
@@ -63,6 +63,7 @@ export default function PlantCard({ plant }) {
         <div className="flex gap-2">
           <button
             onMouseDown={createRipple}
+            onTouchStart={createRipple}
             onClick={() => navigate(`/plant/${plant.id}/edit`)}
             className="bg-blue-600 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
           >
@@ -70,6 +71,7 @@ export default function PlantCard({ plant }) {
           </button>
           <button
             onMouseDown={createRipple}
+            onTouchStart={createRipple}
             onClick={() => removePlant(plant.id)}
             className="bg-red-600 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
           >
@@ -89,6 +91,7 @@ export default function PlantCard({ plant }) {
         <p className="text-sm text-green-700 font-medium">Next: {plant.nextWater}</p>
         <button
           onMouseDown={createRipple}
+          onTouchStart={createRipple}
           onClick={handleWatered}
           className="mt-2 px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 transition relative overflow-hidden"
         >

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -12,7 +12,7 @@ export default function TaskItem({ task, onComplete }) {
   const startX = useRef(0)
   const [deltaX, setDeltaX] = useState(0)
   const [showCheck, setShowCheck] = useState(false)
-  const [rippleRef, createRipple] = useRipple()
+  const [, createRipple] = useRipple()
 
   const handleComplete = () => {
     if (onComplete) {
@@ -48,7 +48,6 @@ export default function TaskItem({ task, onComplete }) {
 
   return (
     <div
-      ref={rippleRef}
       onMouseDown={createRipple}
       onTouchStart={e => { createRipple(e); handlePointerDown(e) }}
       onPointerDown={handlePointerDown}
@@ -76,6 +75,7 @@ export default function TaskItem({ task, onComplete }) {
       </Link>
       <button
         onMouseDown={createRipple}
+        onTouchStart={createRipple}
         onClick={handleComplete}
         className="ml-2 px-3 py-1 bg-green-100 text-green-700 rounded text-sm relative overflow-hidden"
       >

--- a/src/utils/useRipple.js
+++ b/src/utils/useRipple.js
@@ -4,14 +4,16 @@ export default function useRipple() {
   const ref = useRef(null)
 
   const createRipple = e => {
-    const el = ref.current
+    const el = e.currentTarget || ref.current
     if (!el) return
     const rect = el.getBoundingClientRect()
     const circle = document.createElement('span')
     const diameter = Math.max(rect.width, rect.height)
+    const clientX = e.touches?.[0]?.clientX ?? e.clientX
+    const clientY = e.touches?.[0]?.clientY ?? e.clientY
     circle.style.width = circle.style.height = `${diameter}px`
-    circle.style.left = `${e.clientX - rect.left - diameter / 2}px`
-    circle.style.top = `${e.clientY - rect.top - diameter / 2}px`
+    circle.style.left = `${clientX - rect.left - diameter / 2}px`
+    circle.style.top = `${clientY - rect.top - diameter / 2}px`
     circle.className = 'ripple-effect'
     el.appendChild(circle)
     setTimeout(() => circle.remove(), 500)


### PR DESCRIPTION
## Summary
- support both mouse and touch events in useRipple
- use currentTarget as the ripple container
- avoid sharing ripple refs in PlantCard and TaskItem

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6873ab4e3b90832493b63f78df9fcc12