### PR TITLE
Add interaction tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "@babel/preset-react": "^7.22.15",
         "@testing-library/jest-dom": "^6.4.2",
         "@testing-library/react": "^16.3.0",
+        "@testing-library/user-event": "^14.6.1",
         "@vitejs/plugin-react": "^4.0.0",
         "autoprefixer": "^10.4.21",
         "babel-jest": "^29.7.0",
@@ -3658,6 +3659,20 @@
         "@types/react-dom": {
           "optional": true
         }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
       }
     },
     "node_modules/@tootallnate/once": {

--- a/package.json
+++ b/package.json
@@ -20,6 +20,7 @@
     "@babel/preset-react": "^7.22.15",
     "@testing-library/jest-dom": "^6.4.2",
     "@testing-library/react": "^16.3.0",
+    "@testing-library/user-event": "^14.6.1",
     "@vitejs/plugin-react": "^4.0.0",
     "autoprefixer": "^10.4.21",
     "babel-jest": "^29.7.0",


### PR DESCRIPTION
## Summary
- add ripple and swipe gesture tests for TaskItem and PlantCard
- polyfill PointerEvent for tests
- install `@testing-library/user-event`

## Testing
- `npm test` *(fails: swipe right triggers onComplete, swipe right waters plant)*

------
https://chatgpt.com/codex/tasks/task_e_6873ab559dcc8324b9eac05ed33d5e2c