### PR TITLE
Switch icons to phosphor and radix

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,8 @@
       "version": "0.0.2",
       "license": "MIT",
       "dependencies": {
+        "@radix-ui/react-icons": "^1.3.2",
+        "phosphor-react": "^1.4.1",
         "react": "^19.0.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^6.22.3",
@@ -3212,6 +3214,15 @@
       "optional": true,
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/@radix-ui/react-icons": {
+      "version": "1.3.2",
+      "resolved": "https://registry.npmjs.org/@radix-ui/react-icons/-/react-icons-1.3.2.tgz",
+      "integrity": "sha512-fyQIhGDhzfc9pK2kH6Pl9c4BDJGfMkPqkyIgYDthyNYoNg3wVhoJMMh19WS4Up/1KMPFVpNsT2q3WmXn2N1m6g==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^16.x || ^17.x || ^18.x || ^19.0.0 || ^19.0.0-rc"
       }
     },
     "node_modules/@remix-run/router": {
@@ -8301,6 +8312,18 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
+    },
+    "node_modules/phosphor-react": {
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/phosphor-react/-/phosphor-react-1.4.1.tgz",
+      "integrity": "sha512-gO5j7U0xZrdglTAYDYPACU4xDOFBTJmptrrB/GeR+tHhCZF3nUMyGmV/0hnloKjuTrOmpSFlbfOY78H39rgjUQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "react": ">=16"
+      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,8 @@
     "test": "jest"
   },
   "dependencies": {
+    "@radix-ui/react-icons": "^1.3.2",
+    "phosphor-react": "^1.4.1",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^6.22.3",

--- a/src/components/ActionIcons.jsx
+++ b/src/components/ActionIcons.jsx
@@ -1,70 +1,25 @@
-import React from 'react'
+import {
+  ArrowCounterClockwise,
+  Drop,
+  Image,
+  Notebook,
+  Note,
+  Sun,
+} from 'phosphor-react'
 
-export function IconWrapper({ children }) {
-  return (
-    <svg
-      className="w-6 h-6 text-gray-500 dark:text-gray-400"
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      {children}
-    </svg>
-  )
+const iconProps = {
+  className: 'w-6 h-6 text-gray-500 dark:text-gray-400',
+  'aria-hidden': 'true',
 }
+export const WaterIcon = () => <Drop {...iconProps} />
 
-export const WaterIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="m15 11.25 1.5 1.5.75-.75V8.758l2.276-.61a3 3 0 1 0-3.675-3.675l-.61 2.277H12l-.75.75 1.5 1.5M15 11.25l-8.47 8.47c-.34.34-.8.53-1.28.53s-.94.19-1.28.53l-.97.97-.75-.75.97-.97c.34-.34.53-.8.53-1.28s.19-.94.53-1.28L12.75 9M15 11.25 12.75 9"
-    />
-  </IconWrapper>
-)
+export const FertilizeIcon = () => <Sun {...iconProps} />
 
-export const FertilizeIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M9.75 3.104v5.714a2.25 2.25 0 0 1-.659 1.591L5 14.5M9.75 3.104c-.251.023-.501.05-.75.082m.75-.082a24.301 24.301 0 0 1 4.5 0m0 0v5.714c0 .597.237 1.17.659 1.591L19.8 15.3M14.25 3.104c.251.023.501.05.75.082M19.8 15.3l-1.57.393A9.065 9.065 0 0 1 12 15a9.065 9.065 0 0 0-6.23-.693L5 14.5m14.8.8 1.402 1.402c1.232 1.232.65 3.318-1.067 3.611A48.309 48.309 0 0 1 12 21c-2.773 0-5.491-.235-8.135-.687-1.718-.293-2.3-2.379-1.067-3.61L5 14.5"
-    />
-  </IconWrapper>
-)
+export const RotateIcon = () => <ArrowCounterClockwise {...iconProps} />
 
-export const RotateIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M16.023 9.348h4.992v-.001M2.985 19.644v-4.992m0 0h4.992m-4.993 0 3.183 3.183a8.25 8.25 0 0 0 13.803-3.7M4.031 9.865a8.25 8.25 0 0 1 13.803-3.7l3.183 3.182m0-4.991v4.99"
-    />
-  </IconWrapper>
-)
+export const NoteIcon = () => <Note {...iconProps} />
 
-export const NoteIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M16.8617 4.48667L18.5492 2.79917C19.2814 2.06694 20.4686 2.06694 21.2008 2.79917C21.9331 3.53141 21.9331 4.71859 21.2008 5.45083L10.5822 16.0695C10.0535 16.5981 9.40144 16.9868 8.68489 17.2002L6 18L6.79978 15.3151C7.01323 14.5986 7.40185 13.9465 7.93052 13.4178L16.8617 4.48667ZM16.8617 4.48667L19.5 7.12499M18 14V18.75C18 19.9926 16.9926 21 15.75 21H5.25C4.00736 21 3 19.9926 3 18.75V8.24999C3 7.00735 4.00736 5.99999 5.25 5.99999H10"
-    />
-  </IconWrapper>
-)
-
-export const LogIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M19.5 14.25V11.625C19.5 9.76104 17.989 8.25 16.125 8.25H14.625C14.0037 8.25 13.5 7.74632 13.5 7.125V5.625C13.5 3.76104 11.989 2.25 10.125 2.25H8.25M8.25 15H15.75M8.25 18H12M10.5 2.25H5.625C5.00368 2.25 4.5 2.75368 4.5 3.375V20.625C4.5 21.2463 5.00368 21.75 5.625 21.75H18.375C18.9963 21.75 19.5 21.2463 19.5 20.625V11.25C19.5 6.27944 15.4706 2.25 10.5 2.25Z"
-    />
-  </IconWrapper>
-)
+export const LogIcon = () => <Notebook {...iconProps} />
 
 export const icons = {
   Water: WaterIcon,

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -1,77 +1,29 @@
 import { NavLink } from 'react-router-dom'
+import {
+  CheckCircledIcon,
+  HomeIcon,
+  ListBulletIcon,
+  PersonIcon,
+  PlusIcon,
+} from '@radix-ui/react-icons'
 
-function IconWrapper({ children, className }) {
-  return (
-    <svg
-      className={`w-6 h-6 ${className}`}
-      xmlns="http://www.w3.org/2000/svg"
-      fill="none"
-      viewBox="0 0 24 24"
-      strokeWidth="1.5"
-      stroke="currentColor"
-      aria-hidden="true"
-    >
-      {children}
-    </svg>
-  )
+const iconProps = {
+  className: 'w-6 h-6',
+  'aria-hidden': 'true',
 }
 
-const HomeIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="m2.25 12 8.954-8.955c.44-.439 1.152-.439 1.591 0L21.75 12M4.5 9.75v10.125c0 .621.504 1.125 1.125 1.125H9.75v-4.875c0-.621.504-1.125 1.125-1.125h2.25c.621 0 1.125.504 1.125 1.125V21h4.125c.621 0 1.125-.504 1.125-1.125V9.75M8.25 21h8.25"
-    />
-  </IconWrapper>
-)
-
-const ListIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M8.25 6.75h12M8.25 12h12m-12 5.25h12M3.75 6.75h.007v.008H3.75V6.75Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0ZM3.75 12h.007v.008H3.75V12Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Zm-.375 5.25h.007v.008H3.75v-.008Zm.375 0a.375.375 0 1 1-.75 0 .375.375 0 0 1 .75 0Z"
-    />
-  </IconWrapper>
-)
-
-const CheckCircleIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M9 12.75 11.25 15 15 9.75M21 12a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-    />
-  </IconWrapper>
-)
-
-const PlusCircleIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M12 9v6m3-3H9m12 0a9 9 0 1 1-18 0 9 9 0 0 1 18 0Z"
-    />
-  </IconWrapper>
-)
-
-const UserIcon = () => (
-  <IconWrapper>
-    <path
-      strokeLinecap="round"
-      strokeLinejoin="round"
-      d="M15.75 6a3.75 3.75 0 1 1-7.5 0 3.75 3.75 0 0 1 7.5 0ZM4.501 20.118a7.5 7.5 0 0 1 14.998 0A17.933 17.933 0 0 1 12 21.75c-2.676 0-5.216-.584-7.499-1.632Z"
-    />
-  </IconWrapper>
-)
+const HomeIconComponent = () => <HomeIcon {...iconProps} />
+const ListIcon = () => <ListBulletIcon {...iconProps} />
+const CheckIcon = () => <CheckCircledIcon {...iconProps} />
+const AddIcon = () => <PlusIcon {...iconProps} />
+const UserIcon = () => <PersonIcon {...iconProps} />
 
 export default function BottomNav() {
   const items = [
-    { to: '/', label: 'Home', icon: HomeIcon },
+    { to: '/', label: 'Home', icon: HomeIconComponent },
     { to: '/myplants', label: 'My Plants', icon: ListIcon },
-    { to: '/tasks', label: 'Tasks', icon: CheckCircleIcon },
-    { to: '/add', label: 'Add', icon: PlusCircleIcon },
+    { to: '/tasks', label: 'Tasks', icon: CheckIcon },
+    { to: '/add', label: 'Add', icon: AddIcon },
     { to: '/settings', label: 'Profile', icon: UserIcon },
   ]
 


### PR DESCRIPTION
## Summary
- add phosphor-react and @radix-ui/react-icons packages
- remove custom inline SVGs for action and nav icons
- use Phosphor icons in `ActionIcons.jsx`
- use Radix icons in `BottomNav.jsx`

## Testing
- `npm test --silent` *(fails: 2 failed, 12 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6873b0a313a0832496a6e863143ce9a9