### PR TITLE
Move gallery route before wildcard

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -37,9 +37,9 @@ export default function App() {
             <Route path="/plant/:id" element={<PlantDetail />} />
             <Route path="/plant/:id/edit" element={<EditPlant />} />
 
-            <Route path="*" element={<NotFound />} />
-
             <Route path="/plant/:id/gallery" element={<Gallery />} />
+
+            <Route path="*" element={<NotFound />} />
 
           </Routes>
           </div>


### PR DESCRIPTION
## Summary
- reorder the gallery route so it registers before the wildcard route

## Testing
- `npm test --silent` *(fails: PlantCard.test.jsx, TaskItem.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_6873c02acbf483249c82b81702d49761