### PR TITLE
Add gallery link to BottomNav

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -2,6 +2,7 @@ import { NavLink } from 'react-router-dom'
 import {
   CheckCircledIcon,
   HomeIcon,
+  ImageIcon,
   ListBulletIcon,
   PersonIcon,
   PlusIcon,
@@ -15,6 +16,7 @@ const iconProps = {
 const HomeIconComponent = () => <HomeIcon {...iconProps} />
 const ListIcon = () => <ListBulletIcon {...iconProps} />
 const CheckIcon = () => <CheckCircledIcon {...iconProps} />
+const GalleryIcon = () => <ImageIcon {...iconProps} />
 const AddIcon = () => <PlusIcon {...iconProps} />
 const UserIcon = () => <PersonIcon {...iconProps} />
 
@@ -23,6 +25,7 @@ export default function BottomNav() {
     { to: '/', label: 'Home', icon: HomeIconComponent },
     { to: '/myplants', label: 'My Plants', icon: ListIcon },
     { to: '/tasks', label: 'Tasks', icon: CheckIcon },
+    { to: '/gallery', label: 'Gallery', icon: GalleryIcon },
     { to: '/add', label: 'Add', icon: AddIcon },
     { to: '/settings', label: 'Profile', icon: UserIcon },
   ]

--- a/src/components/__tests__/BottomNav.test.jsx
+++ b/src/components/__tests__/BottomNav.test.jsx
@@ -2,14 +2,24 @@ import { render } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import BottomNav from '../BottomNav.jsx'
 
- test('all icons are aria-hidden', () => {
-   const { container } = render(
-     <MemoryRouter>
-       <BottomNav />
-     </MemoryRouter>
-   )
-   const svgs = container.querySelectorAll('svg')
-   svgs.forEach(svg => {
-     expect(svg).toHaveAttribute('aria-hidden', 'true')
-   })
- })
+test('all icons are aria-hidden', () => {
+  const { container } = render(
+    <MemoryRouter>
+      <BottomNav />
+    </MemoryRouter>
+  )
+  const svgs = container.querySelectorAll('svg')
+  svgs.forEach(svg => {
+    expect(svg).toHaveAttribute('aria-hidden', 'true')
+  })
+})
+
+test('renders gallery link', () => {
+  const { container } = render(
+    <MemoryRouter>
+      <BottomNav />
+    </MemoryRouter>
+  )
+  const galleryLink = container.querySelector('a[href="/gallery"]')
+  expect(galleryLink).not.toBeNull()
+})


### PR DESCRIPTION
## Summary
- show gallery link in `BottomNav`
- test that gallery link renders

## Testing
- `npm test` *(fails: 2 failed, 31 passed)*

------
https://chatgpt.com/codex/tasks/task_e_6873c027e4a88324a13bc7499a288538