### PR TITLE
Add lightbox feature to single plant gallery

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -92,6 +92,7 @@ export default function Gallery() {
   }
 
   const photos = plant.photos || []
+  const [index, setIndex] = useState(null)
 
   return (
     <div className="space-y-4">
@@ -100,9 +101,10 @@ export default function Gallery() {
       {/* desktop grid */}
       <div className="hidden md:grid grid-cols-2 md:grid-cols-3 gap-4">
         {photos.map((src, i) => (
-          <div
+          <button
             key={i}
-            className="aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900"
+            onClick={() => setIndex(i)}
+            className="aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900 focus:outline-none"
           >
             <img
               src={src}
@@ -110,7 +112,7 @@ export default function Gallery() {
               loading="lazy"
               className="w-full h-full object-cover transition-transform transform hover:scale-105 active:scale-105"
             />
-          </div>
+          </button>
         ))}
       </div>
 
@@ -118,17 +120,27 @@ export default function Gallery() {
       <div className="flex md:hidden space-x-4 overflow-x-auto snap-x snap-mandatory">
         {photos.map((src, i) => (
           <div key={i} className="snap-center shrink-0 w-full">
-            <div className="aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900">
+            <button
+              onClick={() => setIndex(i)}
+              className="aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900 w-full h-full focus:outline-none"
+            >
               <img
                 src={src}
                 alt={plant.name}
                 loading="lazy"
                 className="w-full h-full object-cover transition-transform transform hover:scale-105 active:scale-105"
               />
-            </div>
+            </button>
           </div>
         ))}
       </div>
+      {index !== null && (
+        <Lightbox
+          images={photos}
+          startIndex={index}
+          onClose={() => setIndex(null)}
+        />
+      )}
 
     </div>
   )

--- a/src/pages/__tests__/Gallery.test.jsx
+++ b/src/pages/__tests__/Gallery.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import Gallery from '../Gallery.jsx'
 import plants from '../../plants.json'
@@ -18,4 +18,22 @@ test('renders gallery images for plant', () => {
 
   const images = screen.getAllByAltText(plant.name)
   expect(images.length).toBeGreaterThanOrEqual(plant.photos.length)
+})
+
+test('lightbox opens when image clicked', () => {
+  const plant = plants[0]
+  render(
+    <PlantProvider>
+      <MemoryRouter initialEntries={[`/plant/${plant.id}/gallery`]}>
+        <Routes>
+          <Route path="/plant/:id/gallery" element={<Gallery />} />
+        </Routes>
+      </MemoryRouter>
+    </PlantProvider>
+  )
+
+  const img = screen.getAllByAltText(plant.name)[0]
+  fireEvent.click(img)
+
+  expect(screen.getByRole('dialog')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- enable lightbox for individual plant galleries
- update gallery tests to check lightbox behaviour

## Testing
- `npm test` *(fails: PlantCard.test.jsx and TaskItem.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_6873c02995f88324aef1a0d61c0955bb