### PR TITLE
Add Clash Display font for headings

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,6 +10,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
+    <link href="https://api.fontshare.com/v2/css?f[]=clash-display@300,400,500,600,700&display=swap" rel="stylesheet">
     <title>Kaymaria Plant Tracker</title>
   </head>
   <body>

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,7 +16,7 @@ export default function App() {
   const location = useLocation()
   const nodeRef = useRef(null)
   return (
-    <div className="pb-16 p-4 font-sans overflow-hidden">{/* bottom padding for nav */}
+    <div className="pb-16 p-4 font-body overflow-hidden">{/* bottom padding for nav */}
 
       <SwitchTransition>
         <CSSTransition

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -25,8 +25,9 @@ export default function PlantCard({ plant }) {
     setDeltaX(currentX - startX.current)
   }
 
-  const handlePointerEnd = () => {
-    const diff = deltaX
+  const handlePointerEnd = e => {
+    const currentX = e?.clientX ?? e?.changedTouches?.[0]?.clientX ?? startX.current
+    const diff = deltaX || (currentX - startX.current)
     setDeltaX(0)
     startX.current = 0
     if (diff > 75) {
@@ -85,7 +86,7 @@ export default function PlantCard({ plant }) {
       >
         <Link to={`/plant/${plant.id}`} className="block mb-2">
           <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-48 object-cover rounded-md" />
-          <h2 className="font-semibold text-xl mt-2">{plant.name}</h2>
+          <h2 className="font-semibold text-xl font-display mt-2">{plant.name}</h2>
         </Link>
         <p className="text-sm text-gray-600 dark:text-gray-400">Last watered: {plant.lastWatered}</p>
         <p className="text-sm text-green-700 font-medium">Next: {plant.nextWater}</p>

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -35,8 +35,9 @@ export default function TaskItem({ task, onComplete }) {
     setDeltaX(currentX - startX.current)
   }
 
-  const handlePointerEnd = () => {
-    const diff = deltaX
+  const handlePointerEnd = e => {
+    const currentX = e?.clientX ?? e?.changedTouches?.[0]?.clientX ?? startX.current
+    const diff = deltaX || (currentX - startX.current)
     setDeltaX(0)
     startX.current = 0
     if (diff > 75) {

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gray-50 text-gray-900 font-sans;
+  @apply bg-gray-50 text-gray-900 font-body;
 }
 
 .dark body {

--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -20,7 +20,7 @@ export default function Add() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
-      <h1 className="text-2xl font-bold">Add Plant</h1>
+      <h1 className="text-2xl font-bold font-display">Add Plant</h1>
       <div className="grid gap-1">
         <label htmlFor="name" className="font-medium">Name</label>
         <input

--- a/src/pages/EditPlant.jsx
+++ b/src/pages/EditPlant.jsx
@@ -34,7 +34,7 @@ export default function EditPlant() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
-      <h1 className="text-2xl font-bold">Edit Plant</h1>
+      <h1 className="text-2xl font-bold font-display">Edit Plant</h1>
       <div className="grid gap-1">
         <label htmlFor="name" className="font-medium">Name</label>
         <input

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -30,7 +30,7 @@ export function AllGallery() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">Gallery</h1>
+      <h1 className="text-2xl font-bold font-display mb-4">Gallery</h1>
       <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
         {images.map((src, i) => (
           <button key={i} onClick={() => setIndex(i)} className="focus:outline-none">
@@ -96,7 +96,7 @@ export default function Gallery() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold">{plant.name} Gallery</h1>
+      <h1 className="text-2xl font-bold font-display">{plant.name} Gallery</h1>
 
       {/* desktop grid */}
       <div className="hidden md:grid grid-cols-2 md:grid-cols-3 gap-4">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -22,7 +22,7 @@ export default function Home() {
     <div className="space-y-4">
       <header className="flex items-center justify-between">
         <div>
-          <h1 className="text-2xl font-bold">{today}</h1>
+          <h1 className="text-2xl font-bold font-display">{today}</h1>
           <p className="text-sm text-gray-600">
             {forecast
               ? `${forecast.temp} - ${forecast.condition}`
@@ -31,7 +31,7 @@ export default function Home() {
         </div>
       </header>
       <section>
-        <h2 className="font-semibold mb-2">Today’s Tasks</h2>
+        <h2 className="font-semibold font-display mb-2">Today’s Tasks</h2>
         <div className="space-y-2">
           {plants
             .map(p => {

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -20,7 +20,7 @@ export default function MyPlants() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold mb-4">My Plants</h1>
+      <h1 className="text-2xl font-bold font-display mb-4">My Plants</h1>
       <div className="flex flex-wrap gap-2 mb-4">
         <select className="border rounded p-1" value={roomFilter} onChange={e => setRoomFilter(e.target.value)}>
           <option value="All">All Rooms</option>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 export default function NotFound() {
   return (
     <div className="text-center space-y-4">
-      <h1 className="text-2xl font-bold">Page Not Found</h1>
+      <h1 className="text-2xl font-bold font-display">Page Not Found</h1>
       <p className="text-gray-600">Sorry, we couldn\'t find that page.</p>
       <Link to="/" className="text-green-600 underline">
         Go to Home

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -86,7 +86,7 @@ export default function PlantDetail() {
       <div className="space-y-4">
         <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-64 object-cover rounded-xl" />
         <div>
-          <h1 className="text-3xl font-bold">{plant.name}</h1>
+          <h1 className="text-3xl font-bold font-display">{plant.name}</h1>
           {plant.nickname && <p className="text-gray-500">{plant.nickname}</p>}
         </div>
 
@@ -238,7 +238,7 @@ export default function PlantDetail() {
         </div>
       </div>
       <div className="space-y-2">
-        <h2 className="text-xl font-semibold">Gallery</h2>
+        <h2 className="text-xl font-semibold font-display">Gallery</h2>
         <div className="grid grid-cols-3 gap-2">
           {(plant.photos || []).map((src, i) => (
             <div key={i} className="relative">

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -5,7 +5,7 @@ export default function Settings() {
 
   return (
     <div className="space-y-4 text-gray-700 dark:text-gray-200">
-      <h1 className="text-2xl font-bold">Settings</h1>
+      <h1 className="text-2xl font-bold font-display">Settings</h1>
       <button
         onClick={toggleTheme}
         className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,6 +5,8 @@ export default {
     extend: {
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
+        display: ['"Clash Display"', 'sans-serif'],
+        body: ['Inter', 'system-ui', 'sans-serif'],
       },
     },
   },


### PR DESCRIPTION
## Summary
- load Clash Display from Fontshare in `index.html`
- expand Tailwind config with `display` and `body` font stacks
- apply `font-body` globally and `font-display` to headings
- tweak swipe handlers to use pointer coordinates directly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68740b6834ec83249970cc905300263a