### PR TITLE
Update PlantCard water button color

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -56,7 +56,7 @@ export default function PlantCard({ plant }) {
           onMouseDown={createRipple}
           onTouchStart={createRipple}
           onClick={handleWatered}
-          className="bg-green-600 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
+          className="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
         >
           Water
         </button>


### PR DESCRIPTION
## Summary
- change PlantCard water button from green to blue so watering actions stand out

## Testing
- `npm test` *(fails: PlantCard and TaskItem tests)*

------
https://chatgpt.com/codex/tasks/task_e_68740d1768d08324a2cbaa95e724042b