### PR TITLE
Fix pointer swipe handlers for plant and task items

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -42,13 +42,15 @@ export default function PlantCard({ plant }) {
   return (
     <div
       data-testid="card-wrapper"
-      onMouseDown={createRipple}
+      onMouseDown={e => { createRipple(e); handlePointerDown(e) }}
       onTouchStart={e => { createRipple(e); handlePointerDown(e) }}
       className="relative overflow-hidden"
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerEnd}
       onPointerCancel={handlePointerEnd}
+      onMouseMove={handlePointerMove}
+      onMouseUp={handlePointerEnd}
       onTouchMove={handlePointerMove}
       onTouchEnd={handlePointerEnd}
     >

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -49,12 +49,14 @@ export default function TaskItem({ task, onComplete }) {
 
   return (
     <div
-      onMouseDown={createRipple}
+      onMouseDown={e => { createRipple(e); handlePointerDown(e) }}
       onTouchStart={e => { createRipple(e); handlePointerDown(e) }}
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerEnd}
       onPointerCancel={handlePointerEnd}
+      onMouseMove={handlePointerMove}
+      onMouseUp={handlePointerEnd}
       className="relative flex items-center gap-2 p-2 border rounded-lg bg-white dark:bg-gray-800 overflow-hidden"
       style={{ transform: `translateX(${deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
     >


### PR DESCRIPTION
## Summary
- add fallback mouse events to `PlantCard` and `TaskItem` so swipe gestures work in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68740ec14d248324817a93203615b815