### PR TITLE
Add fade-in animation to PlantCard actions

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -8,6 +8,7 @@ export default function PlantCard({ plant }) {
   const { markWatered, removePlant } = usePlants()
   const startX = useRef(0)
   const [deltaX, setDeltaX] = useState(0)
+  const [showActions, setShowActions] = useState(false)
   const [, createRipple] = useRipple()
 
   const handleWatered = () => {
@@ -44,15 +45,22 @@ export default function PlantCard({ plant }) {
       data-testid="card-wrapper"
       onMouseDown={createRipple}
       onTouchStart={e => { createRipple(e); handlePointerDown(e) }}
-      className="relative overflow-hidden"
+      className="relative overflow-hidden group"
       onPointerDown={handlePointerDown}
       onPointerMove={handlePointerMove}
       onPointerUp={handlePointerEnd}
       onPointerCancel={handlePointerEnd}
       onTouchMove={handlePointerMove}
       onTouchEnd={handlePointerEnd}
+      onClick={() => setShowActions(true)}
     >
-      <div className="absolute inset-0 flex justify-between items-center px-4 pointer-events-none">
+      <div
+        className={`absolute inset-0 flex justify-between items-center px-4 transition
+        pointer-events-none opacity-0
+        group-hover:opacity-100 group-hover:pointer-events-auto group-hover:animate-fade-in-up
+        group-focus-within:opacity-100 group-focus-within:pointer-events-auto group-focus-within:animate-fade-in-up
+        ${showActions ? 'opacity-100 pointer-events-auto animate-fade-in-up' : ''}`}
+      >
         <button
           onMouseDown={createRipple}
           onTouchStart={createRipple}


### PR DESCRIPTION
## Summary
- animate PlantCard action overlay with fade-in-up effect
- show overlay on hover, focus or card click

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68740ec068b0832490a605132664a258