### PR TITLE
Handle missing plant images

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -7,6 +7,7 @@ export default function PlantCard({ plant }) {
   const navigate = useNavigate()
   const { markWatered, removePlant } = usePlants()
   const startX = useRef(0)
+  const deltaRef = useRef(0)
   const [deltaX, setDeltaX] = useState(0)
   const [showActions, setShowActions] = useState(false)
   const [, createRipple] = useRipple()
@@ -23,13 +24,16 @@ export default function PlantCard({ plant }) {
   const handlePointerMove = e => {
     if (!startX.current) return
     const currentX = e.clientX ?? e.touches?.[0]?.clientX ?? 0
-    setDeltaX(currentX - startX.current)
+    const diff = currentX - startX.current
+    deltaRef.current = diff
+    setDeltaX(diff)
   }
 
   const handlePointerEnd = e => {
-    const currentX = e?.clientX ?? e?.changedTouches?.[0]?.clientX ?? startX.current
-    const diff = deltaX || (currentX - startX.current)
+    const currentX = e?.clientX ?? e?.changedTouches?.[0]?.clientX ?? startX.current + deltaRef.current
+    const diff = deltaRef.current || (currentX - startX.current)
     setDeltaX(0)
+    deltaRef.current = 0
     startX.current = 0
     if (diff > 75) {
       handleWatered()

--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -14,7 +14,9 @@ export default function Add() {
   const handleSubmit = e => {
     e.preventDefault()
     if (!name) return
-    addPlant({ name, image, lastWatered, nextWater })
+    const newPlant = { name, lastWatered, nextWater }
+    if (image.trim()) newPlant.image = image.trim()
+    addPlant(newPlant)
     navigate('/myplants')
   }
 

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -12,6 +12,8 @@ export default function MyPlants() {
   const lights = [...new Set(plants.map(p => p.light).filter(Boolean))]
   const urgencies = [...new Set(plants.map(p => p.urgency).filter(Boolean))]
 
+  const base = (process.env.VITE_BASE_PATH || '/').replace(/\/$/, '')
+
   const filtered = plants.filter(p =>
     (roomFilter === 'All' || p.room === roomFilter) &&
     (lightFilter === 'All' || p.light === lightFilter) &&
@@ -42,12 +44,20 @@ export default function MyPlants() {
         </select>
       </div>
       <div className="grid grid-cols-2 gap-4">
-        {filtered.map(plant => (
-          <Link key={plant.id} to={`/plant/${plant.id}`} className="block">
-            <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-40 object-cover rounded-lg" />
-            <p className="mt-1 text-center text-sm">{plant.name}</p>
-          </Link>
-        ))}
+        {filtered.map(plant => {
+          const src = plant.image || `${base}/placeholder.svg`
+          return (
+            <Link key={plant.id} to={`/plant/${plant.id}`} className="block">
+              <img
+                src={src}
+                alt={plant.name}
+                loading="lazy"
+                className="w-full h-40 object-cover rounded-lg"
+              />
+              <p className="mt-1 text-center text-sm">{plant.name}</p>
+            </Link>
+          )
+        })}
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- skip adding blank image URLs when creating plants
- show a placeholder image in MyPlants when no image is provided
- keep track of swipe distance via ref in PlantCard

## Testing
- `npm test`
- `npm test src/components/__tests__/PlantCard.test.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68741a2d38108324a8b927646a3267e1