### PR TITLE
Fix env variables loading for Vite

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -1,16 +1,17 @@
-import { defineConfig } from 'vite'
+import { defineConfig, loadEnv } from 'vite'
 import react from '@vitejs/plugin-react'
 
-const basePath = process.env.VITE_BASE_PATH || '/'
+export default defineConfig(({ mode }) => {
+  const env = loadEnv(mode, process.cwd(), '')
+  const basePath = env.VITE_BASE_PATH || '/'
 
-export default defineConfig({
-  base: basePath,
-  define: {
-    'process.env.VITE_WEATHER_API_KEY': JSON.stringify(
-      process.env.VITE_WEATHER_API_KEY
-    ),
-    'process.env.VITE_BASE_PATH': JSON.stringify(basePath),
-    'import.meta.env.VITE_BASE_PATH': JSON.stringify(basePath),
-  },
-  plugins: [react()],
+  return {
+    base: basePath,
+    define: {
+      'process.env.VITE_WEATHER_API_KEY': JSON.stringify(env.VITE_WEATHER_API_KEY),
+      'process.env.VITE_BASE_PATH': JSON.stringify(basePath),
+      'import.meta.env.VITE_BASE_PATH': JSON.stringify(basePath),
+    },
+    plugins: [react()],
+  }
 })


### PR DESCRIPTION
## Summary
- load `.env` vars in `vite.config.js` so the weather key is available

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874309309b08324886d86be682ec35c