### PR TITLE
Confirm before deleting plant

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -16,6 +16,12 @@ export default function PlantCard({ plant }) {
     markWatered(plant.id, note)
   }
 
+  const handleDelete = () => {
+    if (window.confirm('Delete this plant?')) {
+      removePlant(plant.id)
+    }
+  }
+
   const handlePointerDown = e => {
     startX.current = e.clientX ?? e.touches?.[0]?.clientX ?? 0
   }
@@ -34,7 +40,7 @@ export default function PlantCard({ plant }) {
     if (diff > 75) {
       handleWatered()
     } else if (diff < -150) {
-      removePlant(plant.id)
+      handleDelete()
     } else if (diff < -75) {
       navigate(`/plant/${plant.id}/edit`)
     }
@@ -83,7 +89,7 @@ export default function PlantCard({ plant }) {
           <button
             onMouseDown={createRipple}
             onTouchStart={createRipple}
-            onClick={() => removePlant(plant.id)}
+            onClick={handleDelete}
             className="bg-red-600 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
           >
             Delete

--- a/src/components/__tests__/PlantCard.test.jsx
+++ b/src/components/__tests__/PlantCard.test.jsx
@@ -79,14 +79,30 @@ test('edit button navigates to edit page', () => {
   expect(navigateMock).toHaveBeenCalledWith('/plant/1/edit')
 })
 
-test('delete button removes plant', () => {
+test('delete button confirms before removing plant', () => {
+  const confirmMock = jest.spyOn(window, 'confirm').mockReturnValue(true)
   render(
     <MemoryRouter>
       <PlantCard plant={plant} />
     </MemoryRouter>
   )
   fireEvent.click(screen.getByText('Delete'))
+  expect(confirmMock).toHaveBeenCalled()
   expect(removePlant).toHaveBeenCalledWith(1)
+  confirmMock.mockRestore()
+})
+
+test('delete cancelled does not remove plant', () => {
+  const confirmMock = jest.spyOn(window, 'confirm').mockReturnValue(false)
+  render(
+    <MemoryRouter>
+      <PlantCard plant={plant} />
+    </MemoryRouter>
+  )
+  fireEvent.click(screen.getByText('Delete'))
+  expect(confirmMock).toHaveBeenCalled()
+  expect(removePlant).not.toHaveBeenCalled()
+  confirmMock.mockRestore()
 })
 
 test('clicking card adds ripple effect', () => {
@@ -143,7 +159,8 @@ test('swipe left navigates to edit page', async () => {
   expect(navigateMock).toHaveBeenCalledWith('/plant/1/edit')
 })
 
-test('swipe far left removes plant', async () => {
+test('swipe far left confirms before removing plant', async () => {
+  const confirmMock = jest.spyOn(window, 'confirm').mockReturnValue(true)
   render(
     <MemoryRouter>
       <PlantCard plant={plant} />
@@ -160,5 +177,7 @@ test('swipe far left removes plant', async () => {
     fireEvent.touchMove(wrapper, { touches: [{ clientX: 0 }] })
     fireEvent.touchEnd(wrapper)
   })
+  expect(confirmMock).toHaveBeenCalled()
   expect(removePlant).toHaveBeenCalledWith(1)
+  confirmMock.mockRestore()
 })


### PR DESCRIPTION
## Summary
- add confirmation step before deleting a plant
- update delete handler for drag gesture
- test confirmations for delete button and swipe gesture

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874385cc12083248d10351495017432