### PR TITLE
Add label support to Lightbox

### DIFF
--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -1,6 +1,6 @@
 import { useEffect, useRef, useState } from 'react'
 
-export default function Lightbox({ images, startIndex = 0, onClose }) {
+export default function Lightbox({ images, startIndex = 0, onClose, label = 'Image viewer' }) {
   const [index, setIndex] = useState(startIndex)
   const closeBtnRef = useRef(null)
   const prevFocusRef = useRef(null)
@@ -31,6 +31,7 @@ export default function Lightbox({ images, startIndex = 0, onClose }) {
     <div
       role="dialog"
       aria-modal="true"
+      aria-label={label}
       className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50"
     >
       <button

--- a/src/components/__tests__/Lightbox.test.jsx
+++ b/src/components/__tests__/Lightbox.test.jsx
@@ -4,10 +4,13 @@ import Lightbox from '../Lightbox.jsx'
 test('keyboard navigation and close', () => {
   const images = ['a.jpg', 'b.jpg']
   const onClose = jest.fn()
-  render(<Lightbox images={images} startIndex={0} onClose={onClose} />)
-
-  const dialog = screen.getByRole('dialog')
+  const label = 'Photo viewer'
+  render(
+    <Lightbox images={images} startIndex={0} onClose={onClose} label={label} />
+  )
+  const dialog = screen.getByRole('dialog', { name: label })
   expect(dialog).toHaveAttribute('aria-modal', 'true')
+  expect(dialog).toHaveAttribute('aria-label', label)
 
   const img = screen.getByAltText(/gallery image/i)
   expect(img).toHaveAttribute('src', 'a.jpg')

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -44,7 +44,12 @@ export function AllGallery() {
         ))}
       </div>
       {index !== null && (
-        <Lightbox images={images} startIndex={index} onClose={() => setIndex(null)} />
+        <Lightbox
+          images={images}
+          startIndex={index}
+          onClose={() => setIndex(null)}
+          label="Photo viewer"
+        />
       )}
 
       <select
@@ -139,6 +144,7 @@ export default function Gallery() {
           images={photos}
           startIndex={index}
           onClose={() => setIndex(null)}
+          label="Photo viewer"
         />
       )}
 


### PR DESCRIPTION
## Summary
- allow passing a `label` to `Lightbox` for accessibility
- label the lightbox dialog with `aria-label`
- update gallery pages to pass `Photo viewer`
- verify new behavior in lightbox tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874385df7408324b408550b0be45a71