### PR TITLE
Add summary strip for today tasks

### DIFF
--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -1,0 +1,19 @@
+import React from 'react'
+
+export default function SummaryStrip({ total, watered, fertilized }) {
+  const items = [
+    { label: 'Total', count: total },
+    { label: 'Water', count: watered },
+    { label: 'Fertilize', count: fertilized },
+  ]
+  return (
+    <div className="flex flex-wrap gap-2 rounded-xl shadow-sm bg-white p-2">
+      {items.map(item => (
+        <div key={item.label} className="flex-1 text-center">
+          <p className="text-xs text-gray-500">{item.label}</p>
+          <p className="text-lg font-semibold" data-testid={`summary-${item.label.toLowerCase()}`}>{item.count}</p>
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -3,6 +3,7 @@ import { usePlants } from '../PlantContext.jsx'
 
 import { useWeather } from '../WeatherContext.jsx'
 import { getNextWateringDate } from '../utils/watering.js'
+import SummaryStrip from '../components/SummaryStrip.jsx'
 
 
 export default function Home() {
@@ -11,23 +12,35 @@ export default function Home() {
   const forecast = weatherCtx?.forecast
   const weatherData = { rainTomorrow: forecast?.rainfall || 0 }
 
-  const tasks = plants
-    .map(p => {
-      const { date, reason } = getNextWateringDate(p.lastWatered, weatherData)
-      const todayIso = new Date().toISOString().slice(0, 10)
-      if (date <= todayIso) {
-        return {
-          id: p.id,
-          plantId: p.id,
-          plantName: p.name,
-          image: p.image,
-          type: 'Water',
-          reason,
-        }
-      }
-      return null
-    })
-    .filter(Boolean)
+  const todayIso = new Date().toISOString().slice(0, 10)
+  const waterTasks = []
+  const fertilizeTasks = []
+  plants.forEach(p => {
+    const { date, reason } = getNextWateringDate(p.lastWatered, weatherData)
+    if (date <= todayIso) {
+      waterTasks.push({
+        id: `w-${p.id}`,
+        plantId: p.id,
+        plantName: p.name,
+        image: p.image,
+        type: 'Water',
+        reason,
+      })
+    }
+    if (p.nextFertilize && p.nextFertilize <= todayIso) {
+      fertilizeTasks.push({
+        id: `f-${p.id}`,
+        plantId: p.id,
+        plantName: p.name,
+        image: p.image,
+        type: 'Fertilize',
+      })
+    }
+  })
+  const tasks = [...waterTasks, ...fertilizeTasks]
+  const totalCount = tasks.length
+  const waterCount = waterTasks.length
+  const fertilizeCount = fertilizeTasks.length
 
   const today = new Date().toLocaleDateString(undefined, {
     weekday: 'long',
@@ -48,6 +61,7 @@ export default function Home() {
           </p>
         </div>
       </header>
+      <SummaryStrip total={totalCount} watered={waterCount} fertilized={fertilizeCount} />
       <section>
         <h2 className="font-semibold font-display mb-2">Today’s Tasks</h2>
         <div className="space-y-2">

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -2,12 +2,14 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Home from '../Home.jsx'
 
-jest.mock('../../PlantContext.jsx', () => ({
-  usePlants: () => ({ plants: [] }),
-}))
-
 jest.mock('../../WeatherContext.jsx', () => ({
   useWeather: () => ({ forecast: { rainfall: 0 } }),
+}))
+
+const mockPlants = []
+
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: () => ({ plants: mockPlants }),
 }))
 
 test('shows upbeat message when there are no tasks', () => {
@@ -18,3 +20,25 @@ test('shows upbeat message when there are no tasks', () => {
   )
   expect(screen.getByText(/all plants are happy/i)).toBeInTheDocument()
 })
+
+test('summary items render when tasks exist', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
+  mockPlants.splice(0, mockPlants.length, {
+    id: 1,
+    name: 'Plant A',
+    image: 'a.jpg',
+    lastWatered: '2025-07-03',
+    nextFertilize: '2025-07-10',
+  })
+
+  render(
+    <MemoryRouter>
+      <Home />
+    </MemoryRouter>
+  )
+
+  expect(screen.getByTestId('summary-total')).toHaveTextContent('2')
+  expect(screen.getByTestId('summary-water')).toHaveTextContent('1')
+  expect(screen.getByTestId('summary-fertilize')).toHaveTextContent('1')
+})
+


### PR DESCRIPTION
## Summary
- compute today's watering & fertilizing tasks in Home page
- show counts with new `SummaryStrip` component
- render the strip below the header
- test that summary renders when tasks exist

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68743952ab1c83248947281d67005f81