### PR TITLE
Refine styling with natural palette

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -97,11 +97,11 @@ export default function PlantCard({ plant }) {
         </div>
       </div>
       <div
-        className="p-4 border rounded-xl shadow-sm bg-white dark:bg-gray-800"
+        className="p-4 border rounded-2xl shadow-sm bg-white dark:bg-gray-800"
         style={{ transform: `translateX(${deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
       >
         <Link to={`/plant/${plant.id}`} className="block mb-2">
-          <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-48 object-cover rounded-md" />
+          <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-48 object-cover rounded-xl" />
           <h2 className="font-semibold text-xl font-display mt-2">{plant.name}</h2>
         </Link>
         <p className="text-sm text-gray-600 dark:text-gray-400">Last watered: {plant.lastWatered}</p>

--- a/src/components/SummaryStrip.jsx
+++ b/src/components/SummaryStrip.jsx
@@ -7,11 +7,13 @@ export default function SummaryStrip({ total, watered, fertilized }) {
     { label: 'Fertilize', count: fertilized },
   ]
   return (
-    <div className="flex flex-wrap gap-2 rounded-xl shadow-sm bg-white p-2">
+    <div className="flex flex-wrap gap-2 rounded-2xl shadow-sm bg-white p-3">
       {items.map(item => (
-        <div key={item.label} className="flex-1 text-center">
-          <p className="text-xs text-gray-500">{item.label}</p>
-          <p className="text-lg font-semibold" data-testid={`summary-${item.label.toLowerCase()}`}>{item.count}</p>
+        <div key={item.label} className="flex-1">
+          <div className="bg-sage rounded-full text-center py-2">
+            <p className="text-xs text-gray-500">{item.label}</p>
+            <p className="text-lg font-semibold" data-testid={`summary-${item.label.toLowerCase()}`}>{item.count}</p>
+          </div>
         </div>
       ))}
     </div>

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -23,7 +23,7 @@ export default function TaskCard({ task, onComplete }) {
 
   return (
     <div
-      className="relative flex items-center gap-3 p-4 rounded-xl shadow-sm bg-white dark:bg-gray-800 overflow-hidden"
+      className="relative flex items-center gap-3 p-4 rounded-2xl shadow-sm bg-white dark:bg-gray-800 overflow-hidden"
       onMouseDown={createRipple}
       onTouchStart={createRipple}
     >

--- a/src/components/TaskItem.jsx
+++ b/src/components/TaskItem.jsx
@@ -57,7 +57,7 @@ export default function TaskItem({ task, onComplete }) {
       onPointerCancel={handlePointerEnd}
       onMouseMove={handlePointerMove}
       onMouseUp={handlePointerEnd}
-      className="relative flex items-center gap-2 p-2 border rounded-lg bg-white dark:bg-gray-800 overflow-hidden"
+      className="relative flex items-center gap-2 p-2 border rounded-2xl bg-white dark:bg-gray-800 overflow-hidden"
       style={{ transform: `translateX(${deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
     >
       <Link to={`/plant/${task.plantId}`} className="flex items-center flex-1 gap-1">

--- a/src/index.css
+++ b/src/index.css
@@ -3,7 +3,7 @@
 @tailwind utilities;
 
 body {
-  @apply bg-gray-50 text-gray-900 font-body;
+  @apply bg-offwhite text-gray-900 font-body;
 }
 
 .dark body {

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -119,7 +119,7 @@ export default function PlantDetail() {
       )}
       <div aria-live="polite" className="sr-only">{toast}</div>
       <div className="space-y-4">
-        <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-64 object-cover rounded-xl" />
+        <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-64 object-cover" />
         <div>
           <h1 className="text-3xl font-bold font-display">{plant.name}</h1>
           {plant.nickname && <p className="text-gray-500">{plant.nickname}</p>}
@@ -136,14 +136,14 @@ export default function PlantDetail() {
           <button
             type="button"
             onClick={handleWatered}
-            className="px-3 py-1 bg-green-600 text-white rounded"
+            className="px-4 py-1 bg-accent text-white rounded-full"
           >
             Watered
           </button>
           <button
             type="button"
             onClick={handleLogEvent}
-            className="px-3 py-1 bg-blue-600 text-white rounded"
+            className="px-4 py-1 bg-accent text-white rounded-full"
           >
             Add Note
           </button>
@@ -177,7 +177,7 @@ export default function PlantDetail() {
         </div>
 
         <div className="space-y-2">
-          <div className="border rounded">
+          <div className="border rounded-xl">
             <h3 id="activity-header">
               <button
                 ref={el => (sectionRefs.current[0] = el)}
@@ -212,7 +212,7 @@ export default function PlantDetail() {
             )}
           </div>
 
-          <div className="border rounded">
+          <div className="border rounded-xl">
             <h3 id="notes-header">
               <button
                 ref={el => (sectionRefs.current[1] = el)}
@@ -253,7 +253,7 @@ export default function PlantDetail() {
             )}
           </div>
 
-          <div className="border rounded">
+          <div className="border rounded-xl">
             <h3 id="care-header">
               <button
                 ref={el => (sectionRefs.current[2] = el)}
@@ -281,7 +281,7 @@ export default function PlantDetail() {
             )}
           </div>
 
-          <div className="border rounded">
+          <div className="border rounded-xl">
             <h3 id="timeline-header">
               <button
                 ref={el => (sectionRefs.current[3] = el)}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -3,6 +3,12 @@ export default {
   content: ["./index.html", "./src/**/*.{js,jsx}"],
   theme: {
     extend: {
+      colors: {
+        offwhite: '#f9faf8',
+        sage: '#eaf4ec',
+        stone: '#f2f2f2',
+        accent: '#7fb77e',
+      },
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
         display: ['"Clash Display"', 'sans-serif'],


### PR DESCRIPTION
## Summary
- soften the color palette via new Tailwind colors
- apply off‑white background
- use pill boxes in `SummaryStrip`
- round task and plant cards for a more organic look
- update Plant Detail actions with accent color

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687440d4f9e88324ae3a07e4b2c1431e