### PR TITLE
Add greeting header and grouped tasks

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -21,14 +21,20 @@ export default function TaskCard({ task, onComplete }) {
     setTimeout(() => setChecked(false), 400)
   }
 
+  const pillColors = {
+    Water: 'bg-blue-100 text-blue-700',
+    Fertilize: 'bg-orange-100 text-orange-700',
+  }
+  const pillClass = pillColors[task.type] || 'bg-green-100 text-green-700'
+
   return (
     <div
-      className="relative flex items-center gap-3 p-4 rounded-2xl shadow-sm bg-white dark:bg-gray-800 overflow-hidden"
+      className="relative flex items-center gap-3 p-5 rounded-2xl shadow-sm bg-white dark:bg-gray-800 overflow-hidden"
       onMouseDown={createRipple}
       onTouchStart={createRipple}
     >
       <Link to={`/plant/${task.plantId}`} className="flex items-center flex-1 gap-3">
-        <img src={task.image} alt={task.plantName} className="w-12 h-12 object-cover rounded" />
+        <img src={task.image} alt={task.plantName} className="w-16 h-16 object-cover rounded" />
         <div className="flex-1">
           <p className="font-medium">{task.type} {task.plantName}</p>
           {task.reason && (
@@ -41,7 +47,7 @@ export default function TaskCard({ task, onComplete }) {
         onMouseDown={createRipple}
         onTouchStart={createRipple}
         onClick={handleComplete}
-        className="ml-2 bg-green-100 text-green-700 px-3 py-1 rounded relative overflow-hidden"
+        className={`ml-2 px-3 py-1 rounded relative overflow-hidden ${pillClass}`}
         aria-label="Mark complete"
       >
         <input type="checkbox" checked={checked} readOnly className="task-checkbox" />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -16,6 +16,9 @@ export default function Home() {
   const forecast = weatherCtx?.forecast
   const weatherData = { rainTomorrow: forecast?.rainfall || 0 }
 
+  const hour = new Date().getHours()
+  const greeting = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening'
+
   const todayIso = new Date().toISOString().slice(0, 10)
   const waterTasks = []
   const fertilizeTasks = []
@@ -56,20 +59,41 @@ export default function Home() {
   return (
     <div className="space-y-4">
       <header className="flex flex-col items-start space-y-1">
-        <h1 className="text-2xl font-bold font-display">{today}</h1>
+        <h1 className="text-2xl font-bold font-display">{greeting}</h1>
         <p className="flex items-center text-sm text-gray-600">
           <CloudSun className="w-5 h-5 mr-1 text-green-600" />
           {forecast ? `${forecast.temp} - ${forecast.condition}` : 'Loading...'}
         </p>
+        <p className="text-sm text-gray-500">{today}</p>
       </header>
+      <div className="flex space-x-3 overflow-x-auto py-2">
+        {plants.map(p => (
+          <img
+            key={p.id}
+            src={p.image}
+            alt={p.name}
+            className="w-24 h-24 object-cover rounded-lg flex-shrink-0"
+          />
+        ))}
+      </div>
       <SummaryStrip total={totalCount} watered={waterCount} fertilized={fertilizeCount} />
       <section>
-        <h2 className="font-semibold font-display mb-2">Today’s Tasks</h2>
+        <h2 className="font-semibold font-display mb-2">Watering</h2>
         <div className="space-y-4">
-          {tasks.length > 0 ? (
-            tasks.map(task => <TaskCard key={task.id} task={task} />)
+          {waterTasks.length > 0 ? (
+            waterTasks.map(task => <TaskCard key={task.id} task={task} />)
           ) : (
-            <p className="text-sm text-gray-500">All plants are happy today!</p>
+            <p className="text-sm text-gray-500">No watering needed</p>
+          )}
+        </div>
+      </section>
+      <section>
+        <h2 className="font-semibold font-display mb-2 mt-4">Fertilizing</h2>
+        <div className="space-y-4">
+          {fertilizeTasks.length > 0 ? (
+            fertilizeTasks.map(task => <TaskCard key={task.id} task={task} />)
+          ) : (
+            <p className="text-sm text-gray-500">No fertilizing needed</p>
           )}
         </div>
       </section>

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -12,13 +12,14 @@ jest.mock('../../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: mockPlants }),
 }))
 
-test('shows upbeat message when there are no tasks', () => {
+test('shows messages when there are no tasks', () => {
   render(
     <MemoryRouter>
       <Home />
     </MemoryRouter>
   )
-  expect(screen.getByText(/all plants are happy/i)).toBeInTheDocument()
+  expect(screen.getByText(/no watering needed/i)).toBeInTheDocument()
+  expect(screen.getByText(/no fertilizing needed/i)).toBeInTheDocument()
 })
 
 test('summary items render when tasks exist', () => {


### PR DESCRIPTION
## Summary
- greet the user with current weather info and date
- horizontally scroll featured plant photos
- group tasks by type
- enlarge avatars and add color-coded pills in TaskCard
- adjust tests for new empty-state messages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68744672fcec8324a5a655243a2be482