### PR TITLE
Add relative date helper & show task urgency

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -3,6 +3,7 @@ import { Link } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
 import actionIcons from './ActionIcons.jsx'
 import useRipple from '../utils/useRipple.js'
+import { relativeDate } from '../utils/relativeDate.js'
 
 export default function TaskCard({ task, onComplete }) {
   const { markWatered } = usePlants()
@@ -37,6 +38,24 @@ export default function TaskCard({ task, onComplete }) {
         <img src={task.image} alt={task.plantName} className="w-16 h-16 object-cover rounded" />
         <div className="flex-1">
           <p className="font-medium">{task.type} {task.plantName}</p>
+          {task.date && (
+            <p
+              className={`text-xs ${
+                (() => {
+                  const d = Math.round(
+                    (new Date(task.date) - new Date()) / (1000 * 60 * 60 * 24)
+                  )
+                  return d < 0
+                    ? 'text-red-600'
+                    : d <= 2
+                    ? 'text-orange-600'
+                    : 'text-green-600'
+                })()
+              }`}
+            >
+              {relativeDate(task.date)}
+            </p>
+          )}
           {task.reason && (
             <p className="text-xs text-gray-500">{task.reason}</p>
           )}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -32,6 +32,7 @@ export default function Home() {
         image: p.image,
         type: 'Water',
         reason,
+        date,
       })
     }
     if (p.nextFertilize && p.nextFertilize <= todayIso) {
@@ -41,6 +42,7 @@ export default function Home() {
         plantName: p.name,
         image: p.image,
         type: 'Fertilize',
+        date: p.nextFertilize,
       })
     }
   })

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react'
 import { usePlants } from '../PlantContext.jsx'
 import { useWeather } from '../WeatherContext.jsx'
 import { getNextWateringDate } from '../utils/watering.js'
+import { relativeDate } from '../utils/relativeDate.js'
 
 export default function Tasks() {
   const { plants } = usePlants()
@@ -44,24 +45,33 @@ export default function Tasks() {
     water: 'bg-blue-500',
     fertilize: 'bg-orange-500',
   }
-
-  const today = new Date().toISOString().slice(0, 10)
-
   return (
     <div className="overflow-y-auto max-h-full p-4">
       <ul className="relative border-l border-gray-300 pl-4 space-y-6">
         {events.map((e, i) => {
-          const overdue = e.type === 'task' && e.date < today
-          const color = colors[e.taskType] || 'bg-green-500'
+          const diff = Math.round(
+            (new Date(e.date) - new Date()) / (1000 * 60 * 60 * 24)
+          )
+          const overdue = e.type === 'task' && diff < 0
+          const dueSoon = e.type === 'task' && diff >= 0 && diff <= 2
+          const baseColor = colors[e.taskType] || 'bg-green-500'
+          const dotColor = overdue
+            ? 'bg-red-500 animate-pulse'
+            : dueSoon
+            ? 'bg-orange-500'
+            : baseColor
+          const textColor = overdue
+            ? 'text-red-600 font-medium'
+            : dueSoon
+            ? 'text-orange-600 font-medium'
+            : 'text-green-600'
           return (
             <li key={i} className="relative animate-fade-in-up">
               <span
-                className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${
-                  overdue ? 'bg-red-500 animate-pulse' : color
-                }`}
+                className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${dotColor}`}
               ></span>
-              <p className="text-xs text-gray-500">{e.date}</p>
-              <p className={overdue ? 'text-red-600 font-medium' : ''}>{e.label}</p>
+              <p className={`text-xs ${textColor}`}>{relativeDate(e.date)}</p>
+              <p className={textColor}>{e.label}</p>
               {e.reason && (
                 <p className="text-xs text-gray-500">{e.reason}</p>
               )}

--- a/src/utils/__tests__/relativeDate.test.js
+++ b/src/utils/__tests__/relativeDate.test.js
@@ -1,0 +1,16 @@
+import { relativeDate } from '../relativeDate.js'
+
+test('future dates return in X days', () => {
+  const base = new Date('2025-07-10')
+  expect(relativeDate('2025-07-15', base)).toBe('in 5 days')
+})
+
+test('past dates return X days ago', () => {
+  const base = new Date('2025-07-10')
+  expect(relativeDate('2025-07-05', base)).toBe('5 days ago')
+})
+
+test('today returns today', () => {
+  const base = new Date('2025-07-10')
+  expect(relativeDate('2025-07-10', base)).toBe('today')
+})

--- a/src/utils/relativeDate.js
+++ b/src/utils/relativeDate.js
@@ -1,0 +1,14 @@
+export function relativeDate(targetDate, baseDate = new Date()) {
+  const target = new Date(targetDate)
+  // Zero out time for accurate day comparison
+  const base = new Date(baseDate)
+  target.setHours(0, 0, 0, 0)
+  base.setHours(0, 0, 0, 0)
+  const msPerDay = 1000 * 60 * 60 * 24
+  const diff = Math.round((target - base) / msPerDay)
+  if (diff === 0) return 'today'
+  if (diff === 1) return 'in 1 day'
+  if (diff === -1) return '1 day ago'
+  if (diff > 1) return `in ${diff} days`
+  return `${Math.abs(diff)} days ago`
+}


### PR DESCRIPTION
## Summary
- add `relativeDate` utility and tests
- show relative due dates in TaskCard and Tasks views
- color tasks red when overdue, orange when due soon, and green otherwise

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68744c36db048324a55579f288eb1885