### PR TITLE
Suppress React Router warnings in tests

### DIFF
--- a/setupTests.js
+++ b/setupTests.js
@@ -1,1 +1,16 @@
 import '@testing-library/jest-dom';
+
+const originalWarn = console.warn;
+
+beforeAll(() => {
+  jest.spyOn(console, 'warn').mockImplementation((...args) => {
+    if (args.some(arg => typeof arg === 'string' && arg.includes('React Router Future Flag Warning'))) {
+      return;
+    }
+    originalWarn(...args);
+  });
+});
+
+afterAll(() => {
+  console.warn.mockRestore();
+});


### PR DESCRIPTION
## Summary
- filter noisy `React Router Future Flag Warning` messages in Jest setup

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68744e42bbf88324ba3d73d9f2458e3f