### PR TITLE
Add timezone and temperature settings

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -37,6 +37,7 @@ export function PlantProvider({ children }) {
 
   const weatherCtx = useWeather()
   const weather = { rainTomorrow: weatherCtx?.forecast?.rainfall || 0 }
+  const timezone = weatherCtx?.timezone
 
   useEffect(() => {
     if (typeof localStorage !== 'undefined') {
@@ -45,7 +46,10 @@ export function PlantProvider({ children }) {
   }, [plants])
 
   const logEvent = (id, type, note = '') => {
-    const date = new Date().toISOString().slice(0, 10)
+    const now = new Date(
+      new Date().toLocaleString('en-US', { timeZone: timezone })
+    )
+    const date = now.toISOString().slice(0, 10)
     setPlants(prev =>
       prev.map(p =>
         p.id === id
@@ -56,10 +60,13 @@ export function PlantProvider({ children }) {
   }
 
   const markWatered = (id, note) => {
+    const now = new Date(
+      new Date().toLocaleString('en-US', { timeZone: timezone })
+    )
+    const today = now.toISOString().slice(0, 10)
     setPlants(prev =>
       prev.map(p => {
         if (p.id === id) {
-          const today = new Date().toISOString().slice(0, 10)
           const { date: nextStr, reason } = getNextWateringDate(today, weather)
           return {
             ...p,

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -4,12 +4,18 @@ import { usePlants } from '../PlantContext.jsx'
 import actionIcons from './ActionIcons.jsx'
 import useRipple from '../utils/useRipple.js'
 import { relativeDate } from '../utils/relativeDate.js'
+import { useWeather } from '../WeatherContext.jsx'
 
 export default function TaskCard({ task, onComplete }) {
   const { markWatered } = usePlants()
   const Icon = actionIcons[task.type]
   const [checked, setChecked] = useState(false)
   const [, createRipple] = useRipple()
+  const { timezone } = useWeather() || {}
+  const tz = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
+  const now = new Date(
+    new Date().toLocaleString('en-US', { timeZone: tz })
+  )
 
   const handleComplete = () => {
     if (onComplete) {
@@ -43,7 +49,7 @@ export default function TaskCard({ task, onComplete }) {
               className={`text-xs ${
                 (() => {
                   const d = Math.round(
-                    (new Date(task.date) - new Date()) / (1000 * 60 * 60 * 24)
+                    (new Date(task.date) - now) / (1000 * 60 * 60 * 24)
                   )
                   return d < 0
                     ? 'text-red-600'
@@ -53,7 +59,7 @@ export default function TaskCard({ task, onComplete }) {
                 })()
               }`}
             >
-              {relativeDate(task.date)}
+              {relativeDate(task.date, now, tz)}
             </p>
           )}
           {task.reason && (

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -14,12 +14,16 @@ export default function Home() {
   const { plants } = usePlants()
   const weatherCtx = useWeather()
   const forecast = weatherCtx?.forecast
+  const timezone = weatherCtx?.timezone
   const weatherData = { rainTomorrow: forecast?.rainfall || 0 }
 
-  const hour = new Date().getHours()
+  const now = new Date(
+    new Date().toLocaleString('en-US', { timeZone: timezone })
+  )
+  const hour = now.getHours()
   const greeting = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening'
 
-  const todayIso = new Date().toISOString().slice(0, 10)
+  const todayIso = now.toISOString().slice(0, 10)
   const waterTasks = []
   const fertilizeTasks = []
   plants.forEach(p => {
@@ -51,10 +55,11 @@ export default function Home() {
   const waterCount = waterTasks.length
   const fertilizeCount = fertilizeTasks.length
 
-  const today = new Date().toLocaleDateString(undefined, {
+  const today = now.toLocaleDateString(undefined, {
     weekday: 'long',
     month: 'long',
     day: 'numeric',
+    timeZone: timezone,
   })
 
 

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -3,7 +3,14 @@ import { useWeather } from '../WeatherContext.jsx'
 
 export default function Settings() {
   const { theme, toggleTheme } = useTheme()
-  const { location, setLocation } = useWeather()
+  const {
+    location,
+    setLocation,
+    timezone,
+    setTimezone,
+    units,
+    setUnits,
+  } = useWeather()
 
   return (
     <div className="space-y-4 text-gray-700 dark:text-gray-200">
@@ -23,6 +30,28 @@ export default function Settings() {
           onChange={e => setLocation(e.target.value)}
           className="border rounded p-2"
         />
+      </div>
+      <div className="grid gap-1 max-w-xs">
+        <label htmlFor="timezone" className="font-medium">Time Zone</label>
+        <input
+          id="timezone"
+          type="text"
+          value={timezone}
+          onChange={e => setTimezone(e.target.value)}
+          className="border rounded p-2"
+        />
+      </div>
+      <div className="grid gap-1 max-w-xs">
+        <label htmlFor="units" className="font-medium">Temperature Units</label>
+        <select
+          id="units"
+          value={units}
+          onChange={e => setUnits(e.target.value)}
+          className="border rounded p-2"
+        >
+          <option value="metric">Celsius</option>
+          <option value="imperial">Fahrenheit</option>
+        </select>
       </div>
     </div>
   )

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -8,6 +8,7 @@ export default function Tasks() {
   const { plants } = usePlants()
   const weatherCtx = useWeather()
   const weather = { rainTomorrow: weatherCtx?.forecast?.rainfall || 0 }
+  const timezone = weatherCtx?.timezone
 
   const events = useMemo(() => {
     const all = []
@@ -49,8 +50,11 @@ export default function Tasks() {
     <div className="overflow-y-auto max-h-full p-4">
       <ul className="relative border-l border-gray-300 pl-4 space-y-6">
         {events.map((e, i) => {
+          const now = new Date(
+            new Date().toLocaleString('en-US', { timeZone: timezone })
+          )
           const diff = Math.round(
-            (new Date(e.date) - new Date()) / (1000 * 60 * 60 * 24)
+            (new Date(e.date) - now) / (1000 * 60 * 60 * 24)
           )
           const overdue = e.type === 'task' && diff < 0
           const dueSoon = e.type === 'task' && diff >= 0 && diff <= 2
@@ -70,7 +74,7 @@ export default function Tasks() {
               <span
                 className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${dotColor}`}
               ></span>
-              <p className={`text-xs ${textColor}`}>{relativeDate(e.date)}</p>
+              <p className={`text-xs ${textColor}`}>{relativeDate(e.date, now, timezone)}</p>
               <p className={textColor}>{e.label}</p>
               {e.reason && (
                 <p className="text-xs text-gray-500">{e.reason}</p>

--- a/src/utils/relativeDate.js
+++ b/src/utils/relativeDate.js
@@ -1,7 +1,11 @@
-export function relativeDate(targetDate, baseDate = new Date()) {
-  const target = new Date(targetDate)
+export function relativeDate(targetDate, baseDate = new Date(), timezone) {
+  const toTz = d =>
+    timezone
+      ? new Date(new Date(d).toLocaleString('en-US', { timeZone: timezone }))
+      : new Date(d)
+  const target = toTz(targetDate)
   // Zero out time for accurate day comparison
-  const base = new Date(baseDate)
+  const base = toTz(baseDate)
   target.setHours(0, 0, 0, 0)
   base.setHours(0, 0, 0, 0)
   const msPerDay = 1000 * 60 * 60 * 24


### PR DESCRIPTION
## Summary
- let users pick weather units and timezone
- persist units, timezone, and location in `WeatherContext`
- adjust time-based logic to respect selected timezone
- expose inputs for timezone and units on Settings page

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68744edf21648324873f7a398556766d