### PR TITLE
Add modal UI for care logs

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -44,12 +44,11 @@ export function PlantProvider({ children }) {
     }
   }, [plants])
 
-  const logEvent = (id, type, note = '') => {
-    const date = new Date().toISOString().slice(0, 10)
+  const logEvent = (id, type, note = '', date = new Date().toISOString().slice(0, 10), mood = '') => {
     setPlants(prev =>
       prev.map(p =>
         p.id === id
-          ? { ...p, careLog: [...(p.careLog || []), { date, type, note }] }
+          ? { ...p, careLog: [...(p.careLog || []), { date, type, note, mood }] }
           : p
       )
     )

--- a/src/components/LogModal.jsx
+++ b/src/components/LogModal.jsx
@@ -1,0 +1,99 @@
+import { useState, useEffect, useRef } from 'react'
+
+export default function LogModal({ onSave, onClose, defaultType = '', defaultDate }) {
+  const today = new Date().toISOString().slice(0, 10)
+  const [type, setType] = useState(defaultType)
+  const [note, setNote] = useState('')
+  const [date, setDate] = useState(defaultDate || today)
+  const [mood, setMood] = useState('')
+  const dialogRef = useRef(null)
+
+  useEffect(() => {
+    const handleKey = e => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    dialogRef.current?.focus()
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    onSave({ type, note, date, mood })
+    onClose()
+  }
+
+  const suggestions = ['Watered', 'Rotating', 'Pruned']
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center"
+    >
+      <form
+        ref={dialogRef}
+        onSubmit={handleSubmit}
+        className="bg-white dark:bg-gray-800 p-4 rounded shadow space-y-3 focus:outline-none"
+      >
+        <div>
+          <label className="block text-sm font-medium" htmlFor="log-date">Date</label>
+          <input
+            id="log-date"
+            type="date"
+            className="border rounded p-1 w-full"
+            value={date}
+            onChange={e => setDate(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium" htmlFor="log-type">Type</label>
+          <input
+            id="log-type"
+            list="log-type-suggestions"
+            className="border rounded p-1 w-full"
+            value={type}
+            onChange={e => setType(e.target.value)}
+            required
+          />
+          <datalist id="log-type-suggestions">
+            {suggestions.map(s => (
+              <option key={s} value={s} />
+            ))}
+          </datalist>
+        </div>
+        <div>
+          <label className="block text-sm font-medium" htmlFor="log-mood">Mood</label>
+          <select
+            id="log-mood"
+            className="border rounded p-1 w-full"
+            value={mood}
+            onChange={e => setMood(e.target.value)}
+          >
+            <option value="">--</option>
+            <option value="Happy">Happy 🌞</option>
+            <option value="Droopy">Droopy 🥀</option>
+          </select>
+        </div>
+        <div>
+          <label className="block text-sm font-medium" htmlFor="log-note">Note</label>
+          <textarea
+            id="log-note"
+            className="border rounded p-1 w-full"
+            value={note}
+            onChange={e => setNote(e.target.value)}
+            rows="3"
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700">
+            Cancel
+          </button>
+          <button type="submit" className="px-3 py-1 rounded bg-green-600 text-white">
+            Save
+          </button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/components/__tests__/LogModal.test.jsx
+++ b/src/components/__tests__/LogModal.test.jsx
@@ -1,0 +1,20 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import LogModal from '../LogModal.jsx'
+
+test('submits log data', () => {
+  const onSave = jest.fn()
+  const onClose = jest.fn()
+  render(<LogModal onSave={onSave} onClose={onClose} defaultType="Watered" />)
+
+  fireEvent.change(screen.getByLabelText(/note/i), { target: { value: 'some notes' } })
+  fireEvent.click(screen.getByText('Save'))
+
+  expect(onSave).toHaveBeenCalledWith(expect.objectContaining({ type: 'Watered', note: 'some notes' }))
+})
+
+test('escape closes modal', () => {
+  const onClose = jest.fn()
+  render(<LogModal onSave={() => {}} onClose={onClose} />)
+  fireEvent.keyDown(window, { key: 'Escape' })
+  expect(onClose).toHaveBeenCalled()
+})

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -2,6 +2,7 @@ import { useParams, Link } from 'react-router-dom'
 import { useState, useRef, useMemo } from 'react'
 import { usePlants } from '../PlantContext.jsx'
 import actionIcons from '../components/ActionIcons.jsx'
+import LogModal from '../components/LogModal.jsx'
 import { formatMonth } from '../utils/date.js'
 
 export default function PlantDetail() {
@@ -15,6 +16,8 @@ export default function PlantDetail() {
   const [showMore, setShowMore] = useState(false)
   const fileInputRef = useRef()
   const [toast, setToast] = useState('')
+  const [showModal, setShowModal] = useState(false)
+  const [modalType, setModalType] = useState('Note')
 
   const events = useMemo(() => {
     if (!plant) return []
@@ -36,7 +39,13 @@ export default function PlantDetail() {
       }
     })
     ;(plant.careLog || []).forEach(ev => {
-      list.push({ date: ev.date, label: ev.type, note: ev.note, type: 'log' })
+      list.push({
+        date: ev.date,
+        label: ev.type,
+        note: ev.note,
+        mood: ev.mood,
+        type: 'log',
+      })
     })
     return list.sort((a, b) => new Date(a.date) - new Date(b.date))
   }, [plant])
@@ -89,18 +98,18 @@ export default function PlantDetail() {
   }
 
   const handleLogEvent = () => {
-    const note = window.prompt('Note') || ''
-    if (note) {
-      logEvent(plant.id, 'Note', note)
-      showTempToast('Logged')
-    }
+    setModalType('Note')
+    setShowModal(true)
   }
 
   const handleAddCareLog = () => {
-    const type = window.prompt('Type (e.g. Watered)') || ''
+    setModalType('')
+    setShowModal(true)
+  }
+
+  const handleSaveLog = ({ type, note, date, mood }) => {
     if (!type) return
-    const note = window.prompt('Note (optional)') || ''
-    logEvent(plant.id, type, note)
+    logEvent(plant.id, type, note, date, mood)
     showTempToast('Logged')
   }
 
@@ -211,6 +220,7 @@ export default function PlantDetail() {
                     <li key={i}>
                       {ev.type} on {ev.date}
                       {ev.note ? ` - ${ev.note}` : ''}
+                      {ev.mood ? ` (${ev.mood})` : ''}
                     </li>
                   ))}
                 </ul>
@@ -331,6 +341,9 @@ export default function PlantDetail() {
                             {e.note && (
                               <p className="text-xs text-gray-500 italic">{e.note}</p>
                             )}
+                            {e.mood && (
+                              <p className="text-xs">{e.mood}</p>
+                            )}
                           </li>
                         )
                       })}
@@ -377,6 +390,13 @@ export default function PlantDetail() {
           className="hidden"
         />
       </div>
+      {showModal && (
+        <LogModal
+          onSave={handleSaveLog}
+          onClose={() => setShowModal(false)}
+          defaultType={modalType}
+        />
+      )}
   </div>
 )
 }

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -38,6 +38,7 @@ export default function Timeline() {
           date: ev.date,
           label: `${ev.type} ${p.name}`,
           note: ev.note,
+          mood: ev.mood,
           type: 'log',
         })
       })
@@ -84,6 +85,9 @@ export default function Timeline() {
                   </p>
                   {e.note && (
                     <p className="text-xs text-gray-500 italic">{e.note}</p>
+                  )}
+                  {e.mood && (
+                    <p className="text-xs">{e.mood}</p>
                   )}
                 </li>
               )

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -52,3 +52,19 @@ test('accordion keyboard navigation works', () => {
   expect(buttons[1]).toHaveAttribute('aria-expanded', 'true')
   expect(document.activeElement).toBe(buttons[1])
 })
+
+test('add note opens log modal', () => {
+  const plant = plants[0]
+  render(
+    <PlantProvider>
+      <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+        <Routes>
+          <Route path="/plant/:id" element={<PlantDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </PlantProvider>
+  )
+
+  fireEvent.click(screen.getByText('Add Note'))
+  expect(screen.getByRole('dialog')).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- introduce `LogModal` component for creating plant care notes
- support mood and custom date in `logEvent`
- switch `PlantDetail` to open the modal for notes/logs
- show mood in timeline displays
- test the new component and PlantDetail interaction

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68745245120c8324b4295524b8465d32