### PR TITLE
Add droplet animation to tasks

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,4 +1,5 @@
 import { useState } from 'react'
+import { Drop } from 'phosphor-react'
 import { Link } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
 import actionIcons from './ActionIcons.jsx'
@@ -79,17 +80,7 @@ export default function TaskCard({ task, onComplete }) {
       </button>
       {checked && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-          <svg
-            className="w-8 h-8 text-green-600 check-pop"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth="1.5"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-          </svg>
+          <Drop aria-hidden="true" className="w-8 h-8 text-blue-600 water-drop" />
         </div>
       )}
     </div>

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -34,9 +34,9 @@ test('icon svg is aria-hidden', () => {
   expect(svg).toHaveAttribute('aria-hidden', 'true')
 })
 
-test('mark as done does not navigate', () => {
+test('mark as done does not navigate and shows animation', () => {
   jest.spyOn(window, 'prompt').mockReturnValue('')
-  render(
+  const { container } = render(
     <PlantProvider>
       <MemoryRouter initialEntries={['/']}>
         <Routes>
@@ -48,6 +48,7 @@ test('mark as done does not navigate', () => {
   )
   fireEvent.click(screen.getByRole('checkbox'))
   expect(screen.queryByText('Plant Page')).not.toBeInTheDocument()
+  expect(container.querySelector('.water-drop')).toBeInTheDocument()
 })
 
 test('clicking card adds ripple effect', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -90,3 +90,18 @@ body {
 .task-checkbox {
   accent-color: theme('colors.green.600');
 }
+
+@keyframes water-drop {
+  from {
+    transform: scale(0);
+    opacity: 1;
+  }
+  to {
+    transform: scale(1.5);
+    opacity: 0;
+  }
+}
+
+.water-drop {
+  animation: water-drop 0.4s ease-out;
+}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -1,6 +1,7 @@
 import { useParams, Link } from 'react-router-dom'
 import { useState, useRef, useMemo } from 'react'
 import { usePlants } from '../PlantContext.jsx'
+import { Drop } from 'phosphor-react'
 import actionIcons from '../components/ActionIcons.jsx'
 import { formatMonth } from '../utils/date.js'
 
@@ -112,7 +113,11 @@ export default function PlantDetail() {
     <div className="space-y-2 relative">
       {toast && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-          <div className="w-8 h-8 border-4 border-green-600 rounded-full ring-pop"></div>
+          {toast === 'Watered' ? (
+            <Drop aria-hidden="true" className="w-8 h-8 text-blue-600 water-drop" />
+          ) : (
+            <div className="w-8 h-8 border-4 border-green-600 rounded-full ring-pop"></div>
+          )}
         </div>
       )}
       <div aria-live="polite" className="sr-only">{toast}</div>


### PR DESCRIPTION
## Summary
- add `water-drop` keyframes and class to global CSS
- show animated droplet when completing tasks
- reuse droplet animation for PlantDetail toast
- check that droplet is rendered in TaskCard test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874534e6aa48324bf9155df0ddd62e1