### PR TITLE
Add text style utilities

### DIFF
--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -20,9 +20,9 @@ export default function Add() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
-      <h1 className="text-2xl font-bold font-display">Add Plant</h1>
+      <h1 className="text-headline font-bold font-display">Add Plant</h1>
       <div className="grid gap-1">
-        <label htmlFor="name" className="font-medium">Name</label>
+        <label htmlFor="name" className="font-medium text-label">Name</label>
         <input
           id="name"
           type="text"
@@ -33,7 +33,7 @@ export default function Add() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="image" className="font-medium">Image URL</label>
+        <label htmlFor="image" className="font-medium text-label">Image URL</label>
         <input
           id="image"
           type="text"
@@ -43,7 +43,7 @@ export default function Add() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="lastWatered" className="font-medium">Last Watered</label>
+        <label htmlFor="lastWatered" className="font-medium text-label">Last Watered</label>
         <input
           id="lastWatered"
           type="date"
@@ -53,7 +53,7 @@ export default function Add() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="nextWater" className="font-medium">Next Watering</label>
+        <label htmlFor="nextWater" className="font-medium text-label">Next Watering</label>
         <input
           id="nextWater"
           type="date"

--- a/src/pages/EditPlant.jsx
+++ b/src/pages/EditPlant.jsx
@@ -34,9 +34,9 @@ export default function EditPlant() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
-      <h1 className="text-2xl font-bold font-display">Edit Plant</h1>
+      <h1 className="text-headline font-bold font-display">Edit Plant</h1>
       <div className="grid gap-1">
-        <label htmlFor="name" className="font-medium">Name</label>
+        <label htmlFor="name" className="font-medium text-label">Name</label>
         <input
           id="name"
           type="text"
@@ -47,7 +47,7 @@ export default function EditPlant() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="image" className="font-medium">Image URL</label>
+        <label htmlFor="image" className="font-medium text-label">Image URL</label>
         <input
           id="image"
           type="text"
@@ -57,7 +57,7 @@ export default function EditPlant() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="lastWatered" className="font-medium">Last Watered</label>
+        <label htmlFor="lastWatered" className="font-medium text-label">Last Watered</label>
         <input
           id="lastWatered"
           type="date"
@@ -67,7 +67,7 @@ export default function EditPlant() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="nextWater" className="font-medium">Next Watering</label>
+        <label htmlFor="nextWater" className="font-medium text-label">Next Watering</label>
         <input
           id="nextWater"
           type="date"

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -30,7 +30,7 @@ export function AllGallery() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold font-display mb-4">Gallery</h1>
+      <h1 className="text-headline font-bold font-display mb-4">Gallery</h1>
       <div className="grid grid-cols-2 md:grid-cols-3 gap-1">
         {images.map((src, i) => (
           <button key={i} onClick={() => setIndex(i)} className="focus:outline-none">
@@ -101,7 +101,7 @@ export default function Gallery() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-2xl font-bold font-display">{plant.name} Gallery</h1>
+      <h1 className="text-headline font-bold font-display">{plant.name} Gallery</h1>
 
       {/* desktop grid */}
       <div className="hidden md:grid grid-cols-2 md:grid-cols-3 gap-4">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -66,7 +66,7 @@ export default function Home() {
   return (
     <div className="space-y-4">
       <header className="flex flex-col items-start space-y-1">
-        <h1 className="text-2xl font-bold font-display">{greeting}</h1>
+        <h1 className="text-headline font-bold font-display">{greeting}</h1>
         <p className="flex items-center text-sm text-gray-600">
           <CloudSun className="w-5 h-5 mr-1 text-green-600" />
           {forecast ? `${forecast.temp} - ${forecast.condition}` : 'Loading...'}
@@ -85,7 +85,7 @@ export default function Home() {
       </div>
       <SummaryStrip total={totalCount} watered={waterCount} fertilized={fertilizeCount} />
       <section>
-        <h2 className="font-semibold font-display mb-2">Watering</h2>
+        <h2 className="font-semibold font-display text-subhead mb-2">Watering</h2>
         <div className="space-y-4">
           {waterTasks.length > 0 ? (
             waterTasks.map(task => <TaskCard key={task.id} task={task} />)
@@ -95,7 +95,7 @@ export default function Home() {
         </div>
       </section>
       <section>
-        <h2 className="font-semibold font-display mb-2 mt-4">Fertilizing</h2>
+        <h2 className="font-semibold font-display text-subhead mb-2 mt-4">Fertilizing</h2>
         <div className="space-y-4">
           {fertilizeTasks.length > 0 ? (
             fertilizeTasks.map(task => <TaskCard key={task.id} task={task} />)

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -45,7 +45,7 @@ export default function MyPlants() {
 
   return (
     <div>
-      <h1 className="text-2xl font-bold font-display mb-4">My Plants</h1>
+      <h1 className="text-headline font-bold font-display mb-4">My Plants</h1>
 
       <div className="flex justify-center gap-2 mb-4">
         {['Sites', 'Plants', 'Pictures'].map(v => (
@@ -102,7 +102,7 @@ export default function MyPlants() {
           {roomData.map(r => (
             <div key={r.room} className="border rounded-xl p-3 shadow-sm">
               <div className="flex justify-between items-center mb-2">
-                <h2 className="font-semibold">{r.room}</h2>
+                <h2 className="font-semibold text-subhead">{r.room}</h2>
                 <span className="px-2 py-0.5 text-xs rounded-full bg-green-100 text-green-800">{r.taskCount} tasks</span>
               </div>
               <div className="grid grid-cols-2 gap-1">

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 export default function NotFound() {
   return (
     <div className="text-center space-y-4">
-      <h1 className="text-2xl font-bold font-display">Page Not Found</h1>
+      <h1 className="text-headline font-bold font-display">Page Not Found</h1>
       <p className="text-gray-600">Sorry, we couldn\'t find that page.</p>
       <Link to="/" className="text-green-600 underline">
         Go to Home

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -125,7 +125,7 @@ export default function PlantDetail() {
             className="w-full h-64 object-cover"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent flex flex-col justify-end p-4 space-y-1">
-            <h1 className="text-3xl font-bold font-display text-white">{plant.name}</h1>
+            <h1 className="text-headline font-bold font-display text-white">{plant.name}</h1>
             {plant.nickname && <p className="text-white text-sm">{plant.nickname}</p>}
             <div className="flex flex-wrap gap-2 text-xs">
               {plant.light && (
@@ -189,7 +189,7 @@ export default function PlantDetail() {
                 ref={el => (sectionRefs.current[0] = el)}
                 aria-expanded={openSection === 'activity'}
                 aria-controls="activity-panel"
-                className="w-full text-left flex justify-between items-center p-2"
+                className="w-full text-left flex justify-between items-center p-2 text-subhead"
                 onClick={() =>
                   setOpenSection(openSection === 'activity' ? null : 'activity')
                 }
@@ -224,7 +224,7 @@ export default function PlantDetail() {
                 ref={el => (sectionRefs.current[1] = el)}
                 aria-expanded={openSection === 'notes'}
                 aria-controls="notes-panel"
-                className="w-full text-left flex justify-between items-center p-2"
+                className="w-full text-left flex justify-between items-center p-2 text-subhead"
                 onClick={() =>
                   setOpenSection(openSection === 'notes' ? null : 'notes')
                 }
@@ -265,7 +265,7 @@ export default function PlantDetail() {
                 ref={el => (sectionRefs.current[2] = el)}
                 aria-expanded={openSection === 'care'}
                 aria-controls="care-panel"
-                className="w-full text-left flex justify-between items-center p-2"
+                className="w-full text-left flex justify-between items-center p-2 text-subhead"
                 onClick={() =>
                   setOpenSection(openSection === 'care' ? null : 'care')
                 }
@@ -293,7 +293,7 @@ export default function PlantDetail() {
                 ref={el => (sectionRefs.current[3] = el)}
                 aria-expanded={openSection === 'timeline'}
                 aria-controls="timeline-panel"
-                className="w-full text-left flex justify-between items-center p-2"
+                className="w-full text-left flex justify-between items-center p-2 text-subhead"
                 onClick={() =>
                   setOpenSection(openSection === 'timeline' ? null : 'timeline')
                 }
@@ -312,7 +312,7 @@ export default function PlantDetail() {
               >
                 {groupedEvents.map(([monthKey, list]) => (
                   <div key={monthKey}>
-                    <h3 className="mt-4 text-sm font-semibold text-gray-500">
+                    <h3 className="mt-4 text-label font-semibold text-gray-500">
                       {formatMonth(monthKey)}
                     </h3>
                     <ul className="relative border-l border-gray-300 pl-4 space-y-6">
@@ -343,7 +343,7 @@ export default function PlantDetail() {
         </div>
       </div>
       <div className="space-y-2">
-        <h2 className="text-xl font-semibold font-display">Gallery</h2>
+        <h2 className="text-subhead font-semibold font-display">Gallery</h2>
         <div className="grid grid-cols-3 gap-2">
           {(plant.photos || []).map((src, i) => (
             <div key={i} className="relative">

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -14,7 +14,7 @@ export default function Settings() {
 
   return (
     <div className="space-y-4 text-gray-700 dark:text-gray-200">
-      <h1 className="text-2xl font-bold font-display">Settings</h1>
+      <h1 className="text-headline font-bold font-display">Settings</h1>
       <button
         onClick={toggleTheme}
         className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700"
@@ -22,7 +22,7 @@ export default function Settings() {
         Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
       </button>
       <div className="grid gap-1 max-w-xs">
-        <label htmlFor="location" className="font-medium">Weather Location</label>
+        <label htmlFor="location" className="font-medium text-label">Weather Location</label>
         <input
           id="location"
           type="text"
@@ -32,7 +32,7 @@ export default function Settings() {
         />
       </div>
       <div className="grid gap-1 max-w-xs">
-        <label htmlFor="timezone" className="font-medium">Time Zone</label>
+        <label htmlFor="timezone" className="font-medium text-label">Time Zone</label>
         <input
           id="timezone"
           type="text"
@@ -42,7 +42,7 @@ export default function Settings() {
         />
       </div>
       <div className="grid gap-1 max-w-xs">
-        <label htmlFor="units" className="font-medium">Temperature Units</label>
+        <label htmlFor="units" className="font-medium text-label">Temperature Units</label>
         <select
           id="units"
           value={units}

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -66,7 +66,7 @@ export default function Timeline() {
     <div className="overflow-y-auto max-h-full p-4 text-gray-700 dark:text-gray-200">
       {groupedEvents.map(([monthKey, list]) => (
         <div key={monthKey}>
-          <h3 className="mt-4 text-sm font-semibold text-gray-500">
+          <h3 className="mt-4 text-label font-semibold text-gray-500">
             {formatMonth(monthKey)}
           </h3>
           <ul className="relative border-l border-gray-300 pl-4 space-y-6">

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -14,6 +14,12 @@ export default {
         display: ['"Clash Display"', 'sans-serif'],
         body: ['Inter', 'system-ui', 'sans-serif'],
       },
+      fontSize: {
+        headline: ['2rem', {}],
+        subhead: ['1.25rem', {}],
+        label: ['0.875rem', {}],
+        detail: ['0.75rem', {}],
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- extend `fontSize` in `tailwind.config.js` with custom sizes
- use the new text utilities for headings and labels across pages

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687453432ca083248f2f633db0570178