### PR TITLE
Add fade-in animation with IntersectionObserver

### DIFF
--- a/setupTests.js
+++ b/setupTests.js
@@ -3,13 +3,25 @@ import '@testing-library/jest-dom';
 const originalWarn = console.warn;
 
 beforeAll(() => {
+  if (!global.IntersectionObserver) {
+    global.IntersectionObserver = class {
+      constructor(callback) {
+        this.callback = callback
+      }
+      observe() {
+        this.callback([{ isIntersecting: true }])
+      }
+      unobserve() {}
+      disconnect() {}
+    }
+  }
   jest.spyOn(console, 'warn').mockImplementation((...args) => {
     if (args.some(arg => typeof arg === 'string' && arg.includes('React Router Future Flag Warning'))) {
-      return;
+      return
     }
-    originalWarn(...args);
-  });
-});
+    originalWarn(...args)
+  })
+})
 
 afterAll(() => {
   console.warn.mockRestore();

--- a/src/components/FadeInImage.jsx
+++ b/src/components/FadeInImage.jsx
@@ -1,0 +1,8 @@
+import { useRef } from 'react'
+import useInView from '../utils/useInView.js'
+
+export default function FadeInImage({ className = '', ...props }) {
+  const ref = useRef(null)
+  const visible = useInView(ref)
+  return <img ref={ref} className={`${className} ${visible ? 'animate-fade-in' : ''}`} {...props} />
+}

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -2,6 +2,7 @@ import { Link, useNavigate } from 'react-router-dom'
 import { useRef, useState } from 'react'
 import useRipple from '../utils/useRipple.js'
 import { usePlants } from '../PlantContext.jsx'
+import FadeInImage from './FadeInImage.jsx'
 
 export default function PlantCard({ plant }) {
   const navigate = useNavigate()
@@ -101,7 +102,12 @@ export default function PlantCard({ plant }) {
         style={{ transform: `translateX(${deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
       >
         <Link to={`/plant/${plant.id}`} className="block mb-2">
-          <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-48 object-cover rounded-xl" />
+          <FadeInImage
+            src={plant.image}
+            alt={plant.name}
+            loading="lazy"
+            className="w-full h-48 object-cover rounded-xl"
+          />
           <h2 className="font-semibold text-xl font-display mt-2">{plant.name}</h2>
         </Link>
         <p className="text-sm text-gray-600 dark:text-gray-400">Last watered: {plant.lastWatered}</p>

--- a/src/index.css
+++ b/src/index.css
@@ -25,6 +25,19 @@ body {
   animation: fade-in-up 0.3s ease both;
 }
 
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.animate-fade-in {
+  animation: fade-in 0.3s ease both;
+}
+
 
 @keyframes bounce-once {
   0%, 100% {

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -3,6 +3,7 @@ import { useState, useRef, useEffect } from 'react'
 import { useParams } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
 import Lightbox from '../components/Lightbox.jsx'
+import FadeInImage from '../components/FadeInImage.jsx'
 
 export function AllGallery() {
   const { plants, addPhoto } = usePlants()
@@ -34,7 +35,7 @@ export function AllGallery() {
       <div className="grid grid-cols-2 md:grid-cols-3 gap-1">
         {images.map((src, i) => (
           <button key={i} onClick={() => setIndex(i)} className="focus:outline-none">
-            <img
+            <FadeInImage
               src={src}
               alt={`Plant ${i + 1}`}
               loading="lazy"
@@ -111,7 +112,7 @@ export default function Gallery() {
             onClick={() => setIndex(i)}
             className="aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900 focus:outline-none"
           >
-            <img
+            <FadeInImage
               src={src}
               alt={plant.name}
               loading="lazy"
@@ -129,7 +130,7 @@ export default function Gallery() {
               onClick={() => setIndex(i)}
               className="aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900 w-full h-full focus:outline-none"
             >
-              <img
+              <FadeInImage
                 src={src}
                 alt={plant.name}
                 loading="lazy"

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -3,6 +3,7 @@ import { useState, useRef, useMemo } from 'react'
 import { usePlants } from '../PlantContext.jsx'
 import actionIcons from '../components/ActionIcons.jsx'
 import { formatMonth } from '../utils/date.js'
+import FadeInImage from '../components/FadeInImage.jsx'
 
 export default function PlantDetail() {
   const { id } = useParams()
@@ -118,7 +119,7 @@ export default function PlantDetail() {
       <div aria-live="polite" className="sr-only">{toast}</div>
       <div className="space-y-4">
         <div className="relative -mx-4">
-          <img
+          <FadeInImage
             src={plant.image}
             alt={plant.name}
             loading="lazy"

--- a/src/utils/useInView.js
+++ b/src/utils/useInView.js
@@ -1,0 +1,22 @@
+import { useEffect, useState } from 'react'
+
+export default function useInView(ref, options = {}) {
+  const [inView, setInView] = useState(false)
+
+  useEffect(() => {
+    const node = ref.current
+    if (!node) return
+
+    const observer = new IntersectionObserver(([entry]) => {
+      if (entry.isIntersecting) {
+        setInView(true)
+        observer.disconnect()
+      }
+    }, options)
+
+    observer.observe(node)
+    return () => observer.disconnect()
+  }, [ref, options])
+
+  return inView
+}


### PR DESCRIPTION
## Summary
- introduce `fade-in` animation in `index.css`
- create `useInView` hook and `FadeInImage` component to trigger animation on scroll
- update PlantCard, Gallery, and PlantDetail images to use new component
- polyfill IntersectionObserver for Jest

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687453496a8483248e0abb6b90d77eeb