### PR TITLE
Add dynamic greeting icon

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -4,7 +4,7 @@ import { usePlants } from '../PlantContext.jsx'
 import { useWeather } from '../WeatherContext.jsx'
 import { getNextWateringDate } from '../utils/watering.js'
 
-import { CloudSun } from 'phosphor-react'
+import { Sun, CloudSun, Moon } from 'phosphor-react'
 
 import SummaryStrip from '../components/SummaryStrip.jsx'
 
@@ -21,7 +21,15 @@ export default function Home() {
     new Date().toLocaleString('en-US', { timeZone: timezone })
   )
   const hour = now.getHours()
-  const greeting = hour < 12 ? 'Good morning' : hour < 18 ? 'Good afternoon' : 'Good evening'
+  let greeting = 'Good evening'
+  let GreetingIcon = Moon
+  if (hour < 12) {
+    greeting = 'Good morning'
+    GreetingIcon = Sun
+  } else if (hour < 18) {
+    greeting = 'Good afternoon'
+    GreetingIcon = CloudSun
+  }
 
   const todayIso = now.toISOString().slice(0, 10)
   const waterTasks = []
@@ -66,7 +74,13 @@ export default function Home() {
   return (
     <div className="space-y-4">
       <header className="flex flex-col items-start space-y-1">
-        <h1 className="text-2xl font-bold font-display">{greeting}</h1>
+        <h1 className="text-2xl font-bold font-display flex items-center">
+          {greeting}
+          <GreetingIcon
+            data-testid="greeting-icon"
+            className="w-5 h-5 ml-2 animate-fade-in-up"
+          />
+        </h1>
         <p className="flex items-center text-sm text-gray-600">
           <CloudSun className="w-5 h-5 mr-1 text-green-600" />
           {forecast ? `${forecast.temp} - ${forecast.condition}` : 'Loading...'}

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -43,3 +43,16 @@ test('summary items render when tasks exist', () => {
   expect(screen.getByTestId('summary-fertilize')).toHaveTextContent('1')
 })
 
+test('renders correct greeting icon for morning time', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-10T08:00:00Z'))
+
+  render(
+    <MemoryRouter>
+      <Home />
+    </MemoryRouter>
+  )
+
+  const icon = screen.getByTestId('greeting-icon')
+  expect(icon.innerHTML).toContain('<circle')
+})
+


### PR DESCRIPTION
## Summary
- show a greeting icon that changes with the time of day
- animate the icon with `animate-fade-in-up`
- test that the correct icon renders when morning time is mocked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68745347e62c8324800c784f89b3b8e3