### PR TITLE
Set US central defaults

### DIFF
--- a/src/WeatherContext.jsx
+++ b/src/WeatherContext.jsx
@@ -9,21 +9,24 @@ export function WeatherProvider({ children }) {
       const stored = localStorage.getItem('weatherLocation')
       if (stored) return stored
     }
-    return 'London'
+    // default to Saint Paul, Minnesota
+    return 'Saint Paul, Minnesota'
   })
   const [timezone, setTimezone] = useState(() => {
     if (typeof localStorage !== 'undefined') {
       const stored = localStorage.getItem('timezone')
       if (stored) return stored
     }
-    return Intl.DateTimeFormat().resolvedOptions().timeZone
+    // default to US central time
+    return 'America/Chicago'
   })
   const [units, setUnits] = useState(() => {
     if (typeof localStorage !== 'undefined') {
       const stored = localStorage.getItem('tempUnits')
       if (stored) return stored
     }
-    return 'metric'
+    // use Fahrenheit by default
+    return 'imperial'
   })
 
   useEffect(() => {


### PR DESCRIPTION
## Summary
- default weather location is now set to Saint Paul, Minnesota
- default timezone is set to America/Chicago
- Fahrenheit (imperial) units are used by default

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68745b14359883248f065d74c4e2d49d