### PR TITLE
Update accent color and fonts, add bounce interaction

### DIFF
--- a/index.html
+++ b/index.html
@@ -10,7 +10,7 @@
       href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;700&display=swap"
       rel="stylesheet"
     />
-    <link href="https://api.fontshare.com/v2/css?f[]=clash-display@300,400,500,600,700&display=swap" rel="stylesheet">
+    <link href="https://api.fontshare.com/v2/css?f[]=cabinet-grotesk@300,400,500,600,700&f[]=recoleta@300,400,500,600,700&display=swap" rel="stylesheet">
     <title>Kaymaria Plant Tracker</title>
   </head>
   <body>

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -11,6 +11,7 @@ export default function TaskCard({ task, onComplete }) {
   const { markWatered } = usePlants()
   const Icon = actionIcons[task.type]
   const [checked, setChecked] = useState(false)
+  const [bouncing, setBouncing] = useState(false)
   const [, createRipple] = useRipple()
   const { timezone } = useWeather() || {}
   const tz = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -26,7 +27,11 @@ export default function TaskCard({ task, onComplete }) {
       markWatered(task.plantId, note)
     }
     setChecked(true)
-    setTimeout(() => setChecked(false), 400)
+    setBouncing(true)
+    setTimeout(() => {
+      setChecked(false)
+      setBouncing(false)
+    }, 400)
   }
 
   const pillColors = {
@@ -42,7 +47,11 @@ export default function TaskCard({ task, onComplete }) {
       onTouchStart={createRipple}
     >
       <Link to={`/plant/${task.plantId}`} className="flex items-center flex-1 gap-3">
-        <img src={task.image} alt={task.plantName} className="w-16 h-16 object-cover rounded" />
+        <img
+          src={task.image}
+          alt={task.plantName}
+          className={`w-16 h-16 object-cover rounded ${bouncing ? 'bounce-once' : ''}`}
+        />
         <div className="flex-1">
           <p className="font-medium">{task.type} {task.plantName}</p>
           {task.date && (

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -20,6 +20,7 @@ export default function PlantDetail() {
   const [toast, setToast] = useState('')
   const [showModal, setShowModal] = useState(false)
   const [modalType, setModalType] = useState('Note')
+  const [bouncing, setBouncing] = useState(false)
 
   const events = useMemo(() => {
     if (!plant) return []
@@ -97,6 +98,8 @@ export default function PlantDetail() {
   const handleWatered = () => {
     markWatered(plant.id, '')
     showTempToast('Watered')
+    setBouncing(true)
+    setTimeout(() => setBouncing(false), 300)
   }
 
   const handleLogEvent = () => {
@@ -137,7 +140,7 @@ export default function PlantDetail() {
             src={plant.image}
             alt={plant.name}
             loading="lazy"
-            className="w-full h-64 object-cover"
+            className={`w-full h-64 object-cover ${bouncing ? 'bounce-once' : ''}`}
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent flex flex-col justify-end p-4 space-y-1">
             <h1 className="text-headline font-bold font-display text-white">{plant.name}</h1>

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -7,11 +7,11 @@ export default {
         offwhite: '#f9faf8',
         sage: '#eaf4ec',
         stone: '#f2f2f2',
-        accent: '#7fb77e',
+        accent: '#87a96b',
       },
       fontFamily: {
         sans: ['Inter', 'ui-sans-serif', 'system-ui', 'sans-serif'],
-        display: ['"Clash Display"', 'sans-serif'],
+        display: ['"Cabinet Grotesk"', 'Recoleta', 'sans-serif'],
         body: ['Inter', 'system-ui', 'sans-serif'],
       },
       fontSize: {


### PR DESCRIPTION
## Summary
- apply softer accent color
- switch heading font stack to Cabinet Grotesk & Recoleta
- load new fonts in `index.html`
- bounce plant image when watering in tasks and details

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687461909ed88324970c189d14983384