### PR TITLE
Dynamic To-Do count in BottomNav

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -10,11 +10,13 @@ import Settings from './pages/Settings'
 import PlantDetail from './pages/PlantDetail'
 import EditPlant from './pages/EditPlant'
 import BottomNav from './components/BottomNav'
+import useDueTasksCount from './utils/useDueTasksCount.js'
 import NotFound from './pages/NotFound'
 
 export default function App() {
   const location = useLocation()
   const nodeRef = useRef(null)
+  const dueCount = useDueTasksCount()
   return (
     <div className="pb-16 p-4 font-body overflow-hidden">{/* bottom padding for nav */}
 
@@ -47,7 +49,7 @@ export default function App() {
       </SwitchTransition>
 
 
-      <BottomNav />
+      <BottomNav dueCount={dueCount} />
     </div>
   )
 }

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -20,11 +20,11 @@ const GalleryIcon = () => <ImageIcon {...iconProps} />
 const AddIcon = () => <PlusIcon {...iconProps} />
 const UserIcon = () => <PersonIcon {...iconProps} />
 
-export default function BottomNav() {
+export default function BottomNav({ dueCount = 0 }) {
   const items = [
     { to: '/', label: 'Home', icon: HomeIconComponent },
     { to: '/myplants', label: 'My Plants', icon: ListIcon },
-    { to: '/tasks', label: 'Tasks', icon: CheckIcon },
+    { to: '/tasks', label: `To-Do (${dueCount})`, icon: CheckIcon },
     { to: '/gallery', label: 'Gallery', icon: GalleryIcon },
     { to: '/add', label: 'Add', icon: AddIcon },
     { to: '/settings', label: 'Profile', icon: UserIcon },

--- a/src/components/__tests__/BottomNav.test.jsx
+++ b/src/components/__tests__/BottomNav.test.jsx
@@ -5,7 +5,7 @@ import BottomNav from '../BottomNav.jsx'
 test('all icons are aria-hidden', () => {
   const { container } = render(
     <MemoryRouter>
-      <BottomNav />
+      <BottomNav dueCount={2} />
     </MemoryRouter>
   )
   const svgs = container.querySelectorAll('svg')
@@ -17,9 +17,18 @@ test('all icons are aria-hidden', () => {
 test('renders gallery link', () => {
   const { container } = render(
     <MemoryRouter>
-      <BottomNav />
+      <BottomNav dueCount={0} />
     </MemoryRouter>
   )
   const galleryLink = container.querySelector('a[href="/gallery"]')
   expect(galleryLink).not.toBeNull()
+})
+
+test('shows dynamic tasks label', () => {
+  const { getByText } = render(
+    <MemoryRouter>
+      <BottomNav dueCount={3} />
+    </MemoryRouter>
+  )
+  expect(getByText('To-Do (3)')).toBeInTheDocument()
 })

--- a/src/utils/useDueTasksCount.js
+++ b/src/utils/useDueTasksCount.js
@@ -1,0 +1,27 @@
+import { usePlants } from '../PlantContext.jsx'
+import { useWeather } from '../WeatherContext.jsx'
+import { useMemo } from 'react'
+import { getNextWateringDate } from './watering.js'
+
+export default function useDueTasksCount() {
+  const { plants } = usePlants()
+  const weatherCtx = useWeather()
+  const weatherData = { rainTomorrow: weatherCtx?.forecast?.rainfall || 0 }
+  const timezone = weatherCtx?.timezone
+
+  return useMemo(() => {
+    const now = new Date(
+      new Date().toLocaleString('en-US', { timeZone: timezone })
+    )
+    const todayIso = now.toISOString().slice(0, 10)
+    let count = 0
+    plants.forEach(p => {
+      if (p.lastWatered) {
+        const { date } = getNextWateringDate(p.lastWatered, weatherData)
+        if (date <= todayIso) count++
+      }
+      if (p.nextFertilize && p.nextFertilize <= todayIso) count++
+    })
+    return count
+  }, [plants, weatherData.rainTomorrow, timezone])
+}


### PR DESCRIPTION
## Summary
- compute upcoming tasks with `useDueTasksCount`
- show task count in BottomNav
- display BottomNav with task count from App
- test dynamic BottomNav label

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687463a0de388324bb96fe149f4e49b4