### PR TITLE
Add nav bounce animation

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -13,12 +13,12 @@ const iconProps = {
   'aria-hidden': 'true',
 }
 
-const HomeIconComponent = () => <HomeIcon {...iconProps} />
-const ListIcon = () => <ListBulletIcon {...iconProps} />
-const CheckIcon = () => <CheckCircledIcon {...iconProps} />
-const GalleryIcon = () => <ImageIcon {...iconProps} />
-const AddIcon = () => <PlusIcon {...iconProps} />
-const UserIcon = () => <PersonIcon {...iconProps} />
+const HomeIconComponent = props => <HomeIcon {...iconProps} {...props} />
+const ListIcon = props => <ListBulletIcon {...iconProps} {...props} />
+const CheckIcon = props => <CheckCircledIcon {...iconProps} {...props} />
+const GalleryIcon = props => <ImageIcon {...iconProps} {...props} />
+const AddIcon = props => <PlusIcon {...iconProps} {...props} />
+const UserIcon = props => <PersonIcon {...iconProps} {...props} />
 
 export default function BottomNav() {
   const items = [
@@ -40,8 +40,15 @@ export default function BottomNav() {
             `flex flex-col items-center text-xs transition-transform duration-150 ${isActive ? 'text-green-700 scale-110' : 'text-gray-500'}`
           }
         >
-          <Icon className="mb-1 transition-colors duration-150" aria-hidden="true" />
-          {label}
+          {({ isActive }) => (
+            <>
+              <Icon
+                className={`mb-1 transition-colors duration-150 ${isActive ? 'nav-bounce' : ''}`}
+                aria-hidden="true"
+              />
+              {label}
+            </>
+          )}
         </NavLink>
       ))}
     </nav>

--- a/src/components/__tests__/BottomNav.test.jsx
+++ b/src/components/__tests__/BottomNav.test.jsx
@@ -23,3 +23,14 @@ test('renders gallery link', () => {
   const galleryLink = container.querySelector('a[href="/gallery"]')
   expect(galleryLink).not.toBeNull()
 })
+
+test('active link icon has nav-bounce animation', () => {
+  const { container } = render(
+    <MemoryRouter initialEntries={["/gallery"]}>
+      <BottomNav />
+    </MemoryRouter>
+  )
+  const activeLink = container.querySelector('a[href="/gallery"]')
+  const icon = activeLink.querySelector('svg')
+  expect(icon).toHaveClass('nav-bounce')
+})

--- a/src/index.css
+++ b/src/index.css
@@ -118,3 +118,22 @@ body {
 .water-drop {
   animation: water-drop 0.4s ease-out;
 }
+
+@keyframes nav-bounce {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.1);
+  }
+}
+
+.nav-bounce {
+  animation: nav-bounce 0.2s ease;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .nav-bounce {
+    animation: none;
+  }
+}


### PR DESCRIPTION
## Summary
- add nav-bounce animation styles with motion preference support
- pass through props to nav icons and apply nav-bounce when active
- test active nav animation class

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687463a27afc8324869e0b8cb49e9423