### PR TITLE
Fix gitignore to track lockfile

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -149,6 +149,5 @@ Thumbs.db
 # editor directories
 .vscode/
 
-package-lock.json
 node_modules/.package-lock.json
 node_modules/.vite/deps/_metadata.json


### PR DESCRIPTION
## Summary
- stop ignoring `package-lock.json`

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687463f293a8832488674a6040051a97