### PR TITLE
Add overdue badge styling

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -18,6 +18,18 @@ export default function TaskCard({ task, onComplete }) {
     new Date().toLocaleString('en-US', { timeZone: tz })
   )
 
+  const daysDiff = task.date
+    ? Math.round((new Date(task.date) - now) / (1000 * 60 * 60 * 24))
+    : 0
+  const overdue = task.date && daysDiff < 0
+  const dueColor = task.date
+    ? daysDiff < 0
+      ? 'text-red-600'
+      : daysDiff <= 2
+      ? 'text-orange-600'
+      : 'text-green-600'
+    : ''
+
   const handleComplete = () => {
     if (onComplete) {
       onComplete(task)
@@ -32,8 +44,11 @@ export default function TaskCard({ task, onComplete }) {
   const pillColors = {
     Water: 'bg-blue-100 text-blue-700',
     Fertilize: 'bg-orange-100 text-orange-700',
+    Overdue: 'bg-red-100 text-red-700',
   }
-  const pillClass = pillColors[task.type] || 'bg-green-100 text-green-700'
+  const pillClass = overdue
+    ? pillColors.Overdue
+    : pillColors[task.type] || 'bg-green-100 text-green-700'
 
   return (
     <div
@@ -46,22 +61,7 @@ export default function TaskCard({ task, onComplete }) {
         <div className="flex-1">
           <p className="font-medium">{task.type} {task.plantName}</p>
           {task.date && (
-            <p
-              className={`text-xs ${
-                (() => {
-                  const d = Math.round(
-                    (new Date(task.date) - now) / (1000 * 60 * 60 * 24)
-                  )
-                  return d < 0
-                    ? 'text-red-600'
-                    : d <= 2
-                    ? 'text-orange-600'
-                    : 'text-green-600'
-                })()
-              }`}
-            >
-              {relativeDate(task.date, now, tz)}
-            </p>
+            <p className={`text-xs ${dueColor}`}>{relativeDate(task.date, now, tz)}</p>
           )}
           {task.reason && (
             <p className="text-xs text-gray-500">{task.reason}</p>

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -11,6 +11,11 @@ const task = {
   type: 'Water'
 }
 
+const overdueTask = {
+  ...task,
+  date: '2000-01-01',
+}
+
 test('renders task text', () => {
   render(
     <PlantProvider>
@@ -62,4 +67,16 @@ test('clicking card adds ripple effect', () => {
   const wrapper = container.firstChild
   fireEvent.mouseDown(wrapper)
   expect(container.querySelector('.ripple-effect')).toBeInTheDocument()
+})
+
+test('overdue tasks use red badge styling', () => {
+  render(
+    <PlantProvider>
+      <MemoryRouter>
+        <TaskCard task={overdueTask} />
+      </MemoryRouter>
+    </PlantProvider>
+  )
+  const button = screen.getByRole('button', { name: /mark complete/i })
+  expect(button).toHaveClass('bg-red-100', 'text-red-700')
 })


### PR DESCRIPTION
## Summary
- add overdue styling to `TaskCard` badges
- compute overdue status using existing date logic
- show due date color using a variable
- test overdue badge styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687463f662e4832493db45fd2f4f5adb