### PR TITLE
Add plant-themed gradient background

### DIFF
--- a/src/__tests__/ThemeGradient.test.jsx
+++ b/src/__tests__/ThemeGradient.test.jsx
@@ -1,0 +1,42 @@
+import fs from 'fs'
+import { render, screen, fireEvent } from '@testing-library/react'
+import { ThemeProvider, useTheme } from '../ThemeContext.jsx'
+
+beforeAll(() => {
+  Object.defineProperty(window, 'matchMedia', {
+    writable: true,
+    value: jest.fn().mockImplementation(query => ({
+      matches: false,
+      media: query,
+      onchange: null,
+      addListener: jest.fn(),
+      removeListener: jest.fn(),
+      addEventListener: jest.fn(),
+      removeEventListener: jest.fn(),
+      dispatchEvent: jest.fn(),
+    })),
+  })
+})
+
+function ToggleButton() {
+  const { theme, toggleTheme } = useTheme()
+  return <button onClick={toggleTheme}>{theme}</button>
+}
+
+test('index.css defines plant-themed gradients for both themes', () => {
+  const css = fs.readFileSync('src/index.css', 'utf8')
+  expect(css).toMatch(/body \{[^}]*linear-gradient/)
+  expect(css).toMatch(/\.dark body \{[^}]*linear-gradient/)
+})
+
+test('ThemeProvider toggles dark mode class', () => {
+  render(
+    <ThemeProvider>
+      <ToggleButton />
+    </ThemeProvider>
+  )
+  const html = document.documentElement
+  expect(html.classList.contains('dark')).toBe(false)
+  fireEvent.click(screen.getByRole('button'))
+  expect(html.classList.contains('dark')).toBe(true)
+})

--- a/src/index.css
+++ b/src/index.css
@@ -3,11 +3,13 @@
 @tailwind utilities;
 
 body {
-  @apply bg-offwhite text-gray-900 font-body;
+  @apply text-gray-900 font-body;
+  background: linear-gradient(135deg, theme('colors.sage'), theme('colors.offwhite'));
 }
 
 .dark body {
-  @apply bg-gray-900 text-gray-100;
+  @apply text-gray-100;
+  background: linear-gradient(135deg, theme('colors.gray.800'), theme('colors.green.900'));
 }
 
 @keyframes fade-in-up {


### PR DESCRIPTION
## Summary
- apply linear gradient background for light & dark themes
- test that gradient styles exist and theme toggles correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687463fa61f8832486b4948af43be8b3