### PR TITLE
Add weather icon mapping

### DIFF
--- a/src/components/WeatherIcon.jsx
+++ b/src/components/WeatherIcon.jsx
@@ -1,0 +1,23 @@
+import {
+  Sun,
+  CloudSun,
+  CloudRain,
+  Cloud,
+  CloudLightning,
+  Snowflake,
+} from 'phosphor-react'
+import React from 'react'
+
+export const weatherIconMap = {
+  Clear: Sun,
+  Rain: CloudRain,
+  Drizzle: CloudRain,
+  Clouds: Cloud,
+  Thunderstorm: CloudLightning,
+  Snow: Snowflake,
+}
+
+export default function WeatherIcon({ condition, className }) {
+  const Icon = weatherIconMap[condition] || CloudSun
+  return <Icon aria-hidden="true" className={className} data-testid="weather-icon" />
+}

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -5,6 +5,7 @@ import { useWeather } from '../WeatherContext.jsx'
 import { getNextWateringDate } from '../utils/watering.js'
 
 import { Sun, CloudSun, Moon } from 'phosphor-react'
+import WeatherIcon from '../components/WeatherIcon.jsx'
 
 import SummaryStrip from '../components/SummaryStrip.jsx'
 
@@ -84,7 +85,10 @@ export default function Home() {
         </h1>
 
         <p className="flex items-center text-sm text-gray-600">
-          <CloudSun className="w-5 h-5 mr-1 text-green-600" />
+          <WeatherIcon
+            condition={forecast?.condition}
+            className="w-5 h-5 mr-1 text-green-600 animate-bounce"
+          />
           {forecast ? `${forecast.temp} - ${forecast.condition}` : 'Loading...'}
         </p>
         <p className="text-sm text-gray-500">{today}</p>

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -2,8 +2,9 @@ import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Home from '../Home.jsx'
 
+let mockForecast = { rainfall: 0, condition: 'Clear', temp: '70\u00B0F' }
 jest.mock('../../WeatherContext.jsx', () => ({
-  useWeather: () => ({ forecast: { rainfall: 0 } }),
+  useWeather: () => ({ forecast: mockForecast }),
 }))
 
 const mockPlants = []
@@ -13,6 +14,7 @@ jest.mock('../../PlantContext.jsx', () => ({
 }))
 
 test('shows messages when there are no tasks', () => {
+  mockForecast.condition = 'Clear'
   render(
     <MemoryRouter>
       <Home />
@@ -23,6 +25,7 @@ test('shows messages when there are no tasks', () => {
 })
 
 test('summary items render when tasks exist', () => {
+  mockForecast.condition = 'Clear'
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
   mockPlants.splice(0, mockPlants.length, {
     id: 1,
@@ -44,6 +47,7 @@ test('summary items render when tasks exist', () => {
 })
 
 test('renders correct greeting icon for morning time', () => {
+  mockForecast.condition = 'Clear'
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10T08:00:00Z'))
 
   render(
@@ -54,5 +58,16 @@ test('renders correct greeting icon for morning time', () => {
 
   const icon = screen.getByTestId('greeting-icon')
   expect(icon.innerHTML).toContain('<circle')
+})
+
+test('renders weather icon for forecast condition', () => {
+  mockForecast.condition = 'Rain'
+  render(
+    <MemoryRouter>
+      <Home />
+    </MemoryRouter>
+  )
+  const icon = screen.getByTestId('weather-icon')
+  expect(icon.innerHTML).toContain('x1="128" y1="240"')
 })
 


### PR DESCRIPTION
## Summary
- map forecast conditions to Phosphor icons via new `WeatherIcon` component
- show the mapped icon on Home page with a bounce animation
- verify icon selection in new unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874640c29b88324a8b7cf098ad2ae4d