### PR TITLE
Add swipe actions and modal for tasks

### DIFF
--- a/src/components/TaskActions.jsx
+++ b/src/components/TaskActions.jsx
@@ -1,0 +1,50 @@
+import useRipple from '../utils/useRipple.js'
+
+export default function TaskActions({ onWater, onSkip, onSnooze, onView, visible }) {
+  const [, createRipple] = useRipple()
+  return (
+    <div
+      data-testid="task-actions"
+      className={`absolute inset-0 flex justify-between items-center px-4 transition ${visible ? 'opacity-100 pointer-events-auto' : 'opacity-0 pointer-events-none'}`}
+    >
+      <button
+        onMouseDown={createRipple}
+        onTouchStart={createRipple}
+        onClick={onWater}
+        className="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
+        aria-label="Water"
+      >
+        Water
+      </button>
+      <div className="flex gap-2">
+        <button
+          onMouseDown={createRipple}
+          onTouchStart={createRipple}
+          onClick={onSkip}
+          className="bg-gray-200 dark:bg-gray-700 px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
+          aria-label="Skip"
+        >
+          Skip
+        </button>
+        <button
+          onMouseDown={createRipple}
+          onTouchStart={createRipple}
+          onClick={onSnooze}
+          className="bg-orange-600 hover:bg-orange-700 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
+          aria-label="Snooze"
+        >
+          Snooze
+        </button>
+        <button
+          onMouseDown={createRipple}
+          onTouchStart={createRipple}
+          onClick={onView}
+          className="bg-blue-600 hover:bg-blue-700 text-white px-2 py-1 rounded pointer-events-auto relative overflow-hidden"
+          aria-label="View plant"
+        >
+          View
+        </button>
+      </div>
+    </div>
+  )
+}

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,16 +1,23 @@
-import { useState } from 'react'
+import { useRef, useState } from 'react'
 import { Drop } from 'phosphor-react'
-import { Link } from 'react-router-dom'
+import { Link, useNavigate } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
 import actionIcons from './ActionIcons.jsx'
 import useRipple from '../utils/useRipple.js'
 import { relativeDate } from '../utils/relativeDate.js'
 import { useWeather } from '../WeatherContext.jsx'
+import TaskActions from './TaskActions.jsx'
+import TaskModal from './TaskModal.jsx'
 
 export default function TaskCard({ task, onComplete }) {
-  const { markWatered } = usePlants()
+  const { markWatered, updatePlant } = usePlants()
+  const navigate = useNavigate()
   const Icon = actionIcons[task.type]
   const [checked, setChecked] = useState(false)
+  const [showActions, setShowActions] = useState(false)
+  const [showModal, setShowModal] = useState(false)
+  const startX = useRef(0)
+  const [deltaX, setDeltaX] = useState(0)
   const [, createRipple] = useRipple()
   const { timezone } = useWeather() || {}
   const tz = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -22,8 +29,8 @@ export default function TaskCard({ task, onComplete }) {
     if (onComplete) {
       onComplete(task)
     } else if (task.type === 'Water') {
-      const note = window.prompt('Optional note') || ''
-      markWatered(task.plantId, note)
+      setShowModal(true)
+      return
     }
     setChecked(true)
     setTimeout(() => setChecked(false), 400)
@@ -35,11 +42,72 @@ export default function TaskCard({ task, onComplete }) {
   }
   const pillClass = pillColors[task.type] || 'bg-green-100 text-green-700'
 
+  const handlePointerDown = e => {
+    startX.current = e.clientX ?? e.touches?.[0]?.clientX ?? 0
+  }
+
+  const handlePointerMove = e => {
+    if (!startX.current) return
+    const currentX = e.clientX ?? e.touches?.[0]?.clientX ?? 0
+    setDeltaX(currentX - startX.current)
+  }
+
+  const handlePointerEnd = e => {
+    const currentX = e?.clientX ?? e?.changedTouches?.[0]?.clientX ?? startX.current
+    const diff = deltaX || currentX - startX.current
+    setDeltaX(0)
+    startX.current = 0
+    if (Math.abs(diff) > 75) {
+      setShowActions(true)
+    }
+  }
+
+  const handleWater = () => {
+    setShowActions(false)
+    setShowModal(true)
+  }
+
+  const handleSkip = () => {
+    handleComplete()
+    setShowActions(false)
+  }
+
+  const handleSnooze = () => {
+    const tomorrow = new Date(now)
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    updatePlant(task.plantId, { nextWater: tomorrow.toISOString().slice(0, 10) })
+    setShowActions(false)
+  }
+
+  const handleView = () => {
+    navigate(`/plant/${task.plantId}`)
+  }
+
+  const handleSaveModal = ({ note }) => {
+    markWatered(task.plantId, note)
+  }
+
   return (
     <div
+      data-testid="task-wrapper"
       className="relative flex items-center gap-3 p-5 rounded-2xl shadow-sm bg-white dark:bg-gray-800 overflow-hidden"
-      onMouseDown={createRipple}
-      onTouchStart={createRipple}
+      onMouseDown={e => { createRipple(e); handlePointerDown(e) }}
+      onTouchStart={e => { createRipple(e); handlePointerDown(e) }}
+      onPointerDown={handlePointerDown}
+      onPointerMove={handlePointerMove}
+      onPointerUp={handlePointerEnd}
+      onPointerCancel={handlePointerEnd}
+      onMouseMove={handlePointerMove}
+      onMouseUp={handlePointerEnd}
+      onTouchMove={handlePointerMove}
+      onTouchEnd={handlePointerEnd}
+      tabIndex="0"
+      onKeyDown={e => {
+        if (e.key === 'Enter' || e.key === ' ') {
+          e.preventDefault()
+          setShowActions(true)
+        }
+      }}
     >
       <Link to={`/plant/${task.plantId}`} className="flex items-center flex-1 gap-3">
         <img src={task.image} alt={task.plantName} className="w-16 h-16 object-cover rounded" />
@@ -82,6 +150,19 @@ export default function TaskCard({ task, onComplete }) {
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <Drop aria-hidden="true" className="w-8 h-8 text-blue-600 water-drop" />
         </div>
+      )}
+      <TaskActions
+        visible={showActions}
+        onWater={handleWater}
+        onSkip={handleSkip}
+        onSnooze={handleSnooze}
+        onView={handleView}
+      />
+      {showModal && (
+        <TaskModal
+          onSave={handleSaveModal}
+          onClose={() => setShowModal(false)}
+        />
       )}
     </div>
   )

--- a/src/components/TaskModal.jsx
+++ b/src/components/TaskModal.jsx
@@ -1,0 +1,61 @@
+import { useEffect, useRef, useState } from 'react'
+
+export default function TaskModal({ onSave, onClose }) {
+  const [amount, setAmount] = useState('')
+  const [note, setNote] = useState('')
+  const dialogRef = useRef(null)
+
+  useEffect(() => {
+    const handleKey = e => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    dialogRef.current?.focus()
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    onSave({ amount, note })
+    onClose()
+  }
+
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center"
+    >
+      <form
+        ref={dialogRef}
+        onSubmit={handleSubmit}
+        className="bg-white dark:bg-gray-800 p-4 rounded shadow space-y-3 focus:outline-none"
+      >
+        <div>
+          <label className="block text-sm font-medium" htmlFor="water-amount">Amount (ml)</label>
+          <input
+            id="water-amount"
+            type="number"
+            className="border rounded p-1 w-full"
+            value={amount}
+            onChange={e => setAmount(e.target.value)}
+          />
+        </div>
+        <div>
+          <label className="block text-sm font-medium" htmlFor="water-note">Note</label>
+          <textarea
+            id="water-note"
+            className="border rounded p-1 w-full"
+            value={note}
+            onChange={e => setNote(e.target.value)}
+            rows="3"
+          />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700">Cancel</button>
+          <button type="submit" className="px-3 py-1 rounded bg-green-600 text-white">Save</button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -1,7 +1,39 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import { MemoryRouter, Routes, Route, useNavigate } from 'react-router-dom'
 import TaskCard from '../TaskCard.jsx'
-import { PlantProvider } from '../../PlantContext.jsx'
+import { usePlants } from '../../PlantContext.jsx'
+
+beforeAll(() => {
+  if (typeof PointerEvent === 'undefined') {
+    window.PointerEvent = window.MouseEvent
+  }
+})
+
+jest.mock('react-router-dom', () => {
+  const actual = jest.requireActual('react-router-dom')
+  return { ...actual, useNavigate: jest.fn() }
+})
+
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: jest.fn(),
+}))
+
+const navigateMock = jest.fn()
+const markWatered = jest.fn()
+const updatePlant = jest.fn()
+const usePlantsMock = usePlants
+
+beforeEach(() => {
+  navigateMock.mockClear()
+  markWatered.mockClear()
+  updatePlant.mockClear()
+  useNavigate.mockReturnValue(navigateMock)
+  usePlantsMock.mockReturnValue({
+    plants: [],
+    markWatered,
+    updatePlant,
+  })
+})
 
 const task = {
   id: 1,
@@ -13,53 +45,76 @@ const task = {
 
 test('renders task text', () => {
   render(
-    <PlantProvider>
-      <MemoryRouter>
-        <TaskCard task={task} />
-      </MemoryRouter>
-    </PlantProvider>
+    <MemoryRouter>
+      <TaskCard task={task} />
+    </MemoryRouter>
   )
   expect(screen.getByText('Water Monstera')).toBeInTheDocument()
 })
 
 test('icon svg is aria-hidden', () => {
   const { container } = render(
-    <PlantProvider>
-      <MemoryRouter>
-        <TaskCard task={task} />
-      </MemoryRouter>
-    </PlantProvider>
+    <MemoryRouter>
+      <TaskCard task={task} />
+    </MemoryRouter>
   )
   const svg = container.querySelector('svg')
   expect(svg).toHaveAttribute('aria-hidden', 'true')
 })
 
-test('mark as done does not navigate and shows animation', () => {
-  jest.spyOn(window, 'prompt').mockReturnValue('')
-  const { container } = render(
-    <PlantProvider>
-      <MemoryRouter initialEntries={['/']}>
-        <Routes>
-          <Route path="/" element={<TaskCard task={task} />} />
-          <Route path="/plant/:id" element={<div>Plant Page</div>} />
-        </Routes>
-      </MemoryRouter>
-    </PlantProvider>
+test('mark as done opens modal', () => {
+  render(
+    <MemoryRouter initialEntries={['/']}>
+      <Routes>
+        <Route path="/" element={<TaskCard task={task} />} />
+        <Route path="/plant/:id" element={<div>Plant Page</div>} />
+      </Routes>
+    </MemoryRouter>
   )
   fireEvent.click(screen.getByRole('checkbox'))
   expect(screen.queryByText('Plant Page')).not.toBeInTheDocument()
-  expect(container.querySelector('.water-drop')).toBeInTheDocument()
+  expect(screen.getByRole('dialog')).toBeInTheDocument()
 })
 
 test('clicking card adds ripple effect', () => {
   const { container } = render(
-    <PlantProvider>
-      <MemoryRouter>
-        <TaskCard task={task} />
-      </MemoryRouter>
-    </PlantProvider>
+    <MemoryRouter>
+      <TaskCard task={task} />
+    </MemoryRouter>
   )
   const wrapper = container.firstChild
   fireEvent.mouseDown(wrapper)
   expect(container.querySelector('.ripple-effect')).toBeInTheDocument()
+})
+
+test('swipe reveals action buttons', () => {
+  render(
+    <MemoryRouter>
+      <TaskCard task={task} />
+    </MemoryRouter>
+  )
+  const wrapper = screen.getByTestId('task-wrapper')
+  fireEvent.pointerDown(wrapper, { clientX: 100, buttons: 1 })
+  fireEvent.pointerMove(wrapper, { clientX: 0, buttons: 1 })
+  fireEvent.pointerUp(wrapper, { clientX: 0 })
+  const actions = screen.getByTestId('task-actions')
+  expect(actions.className).toMatch(/opacity-100/)
+})
+
+test('water action opens modal and saves note', () => {
+  render(
+    <MemoryRouter>
+      <TaskCard task={task} />
+    </MemoryRouter>
+  )
+  const wrapper = screen.getByTestId('task-wrapper')
+  fireEvent.pointerDown(wrapper, { clientX: 100, buttons: 1 })
+  fireEvent.pointerMove(wrapper, { clientX: 0, buttons: 1 })
+  fireEvent.pointerUp(wrapper, { clientX: 0 })
+  fireEvent.click(screen.getByRole('button', { name: /water/i }))
+  fireEvent.change(screen.getByLabelText(/note/i), {
+    target: { value: 'test note' },
+  })
+  fireEvent.click(screen.getByText('Save'))
+  expect(markWatered).toHaveBeenCalledWith(1, 'test note')
 })


### PR DESCRIPTION
## Summary
- create TaskActions overlay with water/skip/snooze/view
- create TaskModal for entering amount and notes
- add swipe detection and modal logic to TaskCard
- replace prompt usage with modal
- test swipe behaviour and modal interactions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874642d212c83249c70db145d3acd3c