### PR TITLE
Add NoteModal and replace prompts

### DIFF
--- a/src/components/NoteModal.jsx
+++ b/src/components/NoteModal.jsx
@@ -1,0 +1,36 @@
+import { useState, useEffect, useRef } from 'react'
+
+export default function NoteModal({ onSave, onClose }) {
+  const [note, setNote] = useState('')
+  const dialogRef = useRef(null)
+
+  useEffect(() => {
+    const handleKey = e => {
+      if (e.key === 'Escape') onClose()
+    }
+    window.addEventListener('keydown', handleKey)
+    dialogRef.current?.focus()
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onClose])
+
+  const handleSubmit = e => {
+    e.preventDefault()
+    onSave(note)
+    onClose()
+  }
+
+  return (
+    <div role="dialog" aria-modal="true" className="fixed inset-0 z-50 bg-black/50 backdrop-blur-sm flex items-center justify-center">
+      <form ref={dialogRef} onSubmit={handleSubmit} className="bg-white dark:bg-gray-800 p-4 rounded shadow space-y-3 focus:outline-none">
+        <div>
+          <label htmlFor="note-input" className="block text-sm font-medium">Note</label>
+          <textarea id="note-input" className="border rounded p-1 w-full" rows="3" value={note} onChange={e => setNote(e.target.value)} />
+        </div>
+        <div className="flex justify-end gap-2">
+          <button type="button" onClick={onClose} className="px-3 py-1 rounded bg-gray-200 dark:bg-gray-700">Cancel</button>
+          <button type="submit" className="px-3 py-1 rounded bg-green-600 text-white">Save</button>
+        </div>
+      </form>
+    </div>
+  )
+}

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -3,6 +3,7 @@ import { useRef, useState } from 'react'
 import useRipple from '../utils/useRipple.js'
 import { usePlants } from '../PlantContext.jsx'
 import FadeInImage from './FadeInImage.jsx'
+import NoteModal from './NoteModal.jsx'
 
 export default function PlantCard({ plant }) {
   const navigate = useNavigate()
@@ -10,11 +11,23 @@ export default function PlantCard({ plant }) {
   const startX = useRef(0)
   const [deltaX, setDeltaX] = useState(0)
   const [showActions, setShowActions] = useState(false)
+  const [showNoteModal, setShowNoteModal] = useState(false)
   const [, createRipple] = useRipple()
 
   const handleWatered = () => {
-    const note = window.prompt('Optional note') || ''
+    if (typeof document !== 'undefined') {
+      setShowNoteModal(true)
+    } else if (typeof window !== 'undefined' && typeof window.prompt === 'function') {
+      const note = window.prompt('Optional note') || ''
+      markWatered(plant.id, note)
+    } else {
+      markWatered(plant.id, '')
+    }
+  }
+
+  const handleNoteSave = note => {
     markWatered(plant.id, note)
+    setShowNoteModal(false)
   }
 
   const handleDelete = () => {
@@ -121,6 +134,9 @@ export default function PlantCard({ plant }) {
           Watered
         </button>
       </div>
+      {showNoteModal && (
+        <NoteModal onSave={handleNoteSave} onClose={() => setShowNoteModal(false)} />
+      )}
     </div>
   )
 }

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -6,11 +6,13 @@ import actionIcons from './ActionIcons.jsx'
 import useRipple from '../utils/useRipple.js'
 import { relativeDate } from '../utils/relativeDate.js'
 import { useWeather } from '../WeatherContext.jsx'
+import NoteModal from './NoteModal.jsx'
 
 export default function TaskCard({ task, onComplete }) {
   const { markWatered } = usePlants()
   const Icon = actionIcons[task.type]
   const [checked, setChecked] = useState(false)
+  const [showNoteModal, setShowNoteModal] = useState(false)
   const [, createRipple] = useRipple()
   const { timezone } = useWeather() || {}
   const tz = timezone || Intl.DateTimeFormat().resolvedOptions().timeZone
@@ -22,11 +24,22 @@ export default function TaskCard({ task, onComplete }) {
     if (onComplete) {
       onComplete(task)
     } else if (task.type === 'Water') {
-      const note = window.prompt('Optional note') || ''
-      markWatered(task.plantId, note)
+      if (typeof document !== 'undefined') {
+        setShowNoteModal(true)
+      } else if (typeof window !== 'undefined' && typeof window.prompt === 'function') {
+        const note = window.prompt('Optional note') || ''
+        markWatered(task.plantId, note)
+      } else {
+        markWatered(task.plantId, '')
+      }
     }
     setChecked(true)
     setTimeout(() => setChecked(false), 400)
+  }
+
+  const handleNoteSave = note => {
+    markWatered(task.plantId, note)
+    setShowNoteModal(false)
   }
 
   const pillColors = {
@@ -82,6 +95,9 @@ export default function TaskCard({ task, onComplete }) {
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
           <Drop aria-hidden="true" className="w-8 h-8 text-blue-600 water-drop" />
         </div>
+      )}
+      {showNoteModal && (
+        <NoteModal onSave={handleNoteSave} onClose={() => setShowNoteModal(false)} />
       )}
     </div>
   )

--- a/src/components/__tests__/NoteModal.test.jsx
+++ b/src/components/__tests__/NoteModal.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import NoteModal from '../NoteModal.jsx'
+
+test('submits note data', () => {
+  const onSave = jest.fn()
+  const onClose = jest.fn()
+  render(<NoteModal onSave={onSave} onClose={onClose} />)
+
+  fireEvent.change(screen.getByLabelText(/note/i), { target: { value: 'hello' } })
+  fireEvent.click(screen.getByText('Save'))
+
+  expect(onSave).toHaveBeenCalledWith('hello')
+  expect(onClose).toHaveBeenCalled()
+})
+
+test('cancel closes without saving', () => {
+  const onSave = jest.fn()
+  const onClose = jest.fn()
+  render(<NoteModal onSave={onSave} onClose={onClose} />)
+  fireEvent.click(screen.getByText('Cancel'))
+  expect(onClose).toHaveBeenCalled()
+  expect(onSave).not.toHaveBeenCalled()
+})

--- a/src/components/__tests__/PlantCard.test.jsx
+++ b/src/components/__tests__/PlantCard.test.jsx
@@ -58,15 +58,27 @@ test('renders plant name', () => {
   expect(screen.getByText('Aloe Vera')).toBeInTheDocument()
 })
 
-test('water button triggers watering', () => {
-  jest.spyOn(window, 'prompt').mockReturnValue('')
+test('water button submits note via modal', () => {
   render(
     <MemoryRouter>
       <PlantCard plant={plant} />
     </MemoryRouter>
   )
   fireEvent.click(screen.getByText('Water'))
-  expect(markWatered).toHaveBeenCalledWith(1, '')
+  fireEvent.change(screen.getByLabelText(/note/i), { target: { value: 'hi' } })
+  fireEvent.click(screen.getByText('Save'))
+  expect(markWatered).toHaveBeenCalledWith(1, 'hi')
+})
+
+test('cancel note modal does not water', () => {
+  render(
+    <MemoryRouter>
+      <PlantCard plant={plant} />
+    </MemoryRouter>
+  )
+  fireEvent.click(screen.getByText('Water'))
+  fireEvent.click(screen.getByText('Cancel'))
+  expect(markWatered).not.toHaveBeenCalled()
 })
 
 test('edit button navigates to edit page', () => {


### PR DESCRIPTION
## Summary
- implement `NoteModal` for adding notes
- use `NoteModal` in `PlantCard` and `TaskCard`
- update component tests to cover modal note submission and cancel

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687464331b2c8324aad635d98effeb39