### PR TITLE
Add frequent watering check

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -6,6 +6,7 @@ import actionIcons from '../components/ActionIcons.jsx'
 import LogModal from '../components/LogModal.jsx'
 import { formatMonth } from '../utils/date.js'
 import FadeInImage from '../components/FadeInImage.jsx'
+import { isFrequentWatering } from '../utils/watering.js'
 
 export default function PlantDetail() {
   const { id } = useParams()
@@ -20,6 +21,9 @@ export default function PlantDetail() {
   const [toast, setToast] = useState('')
   const [showModal, setShowModal] = useState(false)
   const [modalType, setModalType] = useState('Note')
+  const overWatering = plant
+    ? isFrequentWatering(plant.careLog, plant.name)
+    : false
 
   const events = useMemo(() => {
     if (!plant) return []
@@ -161,6 +165,11 @@ export default function PlantDetail() {
           <p><strong>Next watering:</strong> {plant.nextWater}</p>
           {plant.lastFertilized && (
             <p><strong>Last fertilized:</strong> {plant.lastFertilized}</p>
+          )}
+          {overWatering && (
+            <p className="text-xs text-red-600">
+              Tip: {plant.name} may not need water so frequently.
+            </p>
           )}
         </div>
         <div className="flex gap-2 mt-2">

--- a/src/utils/__tests__/frequentWatering.test.js
+++ b/src/utils/__tests__/frequentWatering.test.js
@@ -1,0 +1,25 @@
+import { isFrequentWatering } from '../watering.js'
+
+test('flags frequent watering for snake plant', () => {
+  const log = [
+    { date: '2025-07-10', type: 'Watered' },
+    { date: '2025-07-14', type: 'Watered' },
+  ]
+  expect(isFrequentWatering(log, 'Snake Plant')).toBe(true)
+})
+
+test('does not flag watering when spaced out', () => {
+  const log = [
+    { date: '2025-07-01', type: 'Watered' },
+    { date: '2025-07-12', type: 'Watered' },
+  ]
+  expect(isFrequentWatering(log, 'Snake Plant')).toBe(false)
+})
+
+test('flags frequent watering for regular plant', () => {
+  const log = [
+    { date: '2025-07-05', type: 'Watered' },
+    { date: '2025-07-07', type: 'Watered' },
+  ]
+  expect(isFrequentWatering(log, 'Monstera')).toBe(true)
+})

--- a/src/utils/watering.js
+++ b/src/utils/watering.js
@@ -13,3 +13,23 @@ export function getNextWateringDate(fromDate, weather = {}) {
 
   return { date: base.toISOString().slice(0, 10), reason };
 }
+
+export const WATER_INTERVALS = {
+  'Snake Plant': 14,
+  'ZZ Plant': 14,
+  'Aloe Vera': 14,
+  'Jade Plant': 14,
+};
+
+export function isFrequentWatering(careLog = [], plantName = '') {
+  const interval = WATER_INTERVALS[plantName] || 7;
+  const watering = careLog
+    .filter(ev => /water/i.test(ev.type))
+    .sort((a, b) => new Date(a.date) - new Date(b.date));
+  if (watering.length < 2) return false;
+  const last = watering[watering.length - 1];
+  const prev = watering[watering.length - 2];
+  const diff =
+    (new Date(last.date) - new Date(prev.date)) / (1000 * 60 * 60 * 24);
+  return diff < interval / 2;
+}


### PR DESCRIPTION
## Summary
- detect watering events happening too frequently per plant type
- expose warning tip in PlantDetail page
- test helper logic for frequent watering detection

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68746455d84c8324810ce3f107727528