### PR TITLE
Handle empty image when adding plant

### DIFF
--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -14,7 +14,13 @@ export default function Add() {
   const handleSubmit = e => {
     e.preventDefault()
     if (!name) return
-    addPlant({ name, image, lastWatered, nextWater })
+    const plant = { name, lastWatered, nextWater }
+    if (image) {
+      plant.image = image
+    } else {
+      plant.image = null
+    }
+    addPlant(plant)
     navigate('/myplants')
   }
 

--- a/src/pages/__tests__/Add.test.jsx
+++ b/src/pages/__tests__/Add.test.jsx
@@ -7,6 +7,8 @@ import { PlantProvider } from '../../PlantContext.jsx'
 // test adding a plant
 
 test('addPlant updates context and redirects to MyPlants', () => {
+  const consoleSpy = jest.spyOn(console, 'error').mockImplementation(() => {})
+
   const { container } = render(
     <PlantProvider>
       <MemoryRouter initialEntries={['/add']}>
@@ -25,4 +27,6 @@ test('addPlant updates context and redirects to MyPlants', () => {
 
   expect(screen.getByRole('heading', { name: /my plants/i })).toBeInTheDocument()
   expect(screen.getByText('Test Plant')).toBeInTheDocument()
+  expect(consoleSpy).not.toHaveBeenCalled()
+  consoleSpy.mockRestore()
 })


### PR DESCRIPTION
## Summary
- avoid passing an empty string image to `addPlant`
- test that no console errors are emitted when adding a plant with no image

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687464578c088324bd36e42a31f0cbd5