### PR TITLE
Fix closing brackets for TaskCard component

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -189,7 +189,11 @@ export default function TaskCard({ task, onComplete }) {
       )}
 
       {showNoteModal && (
-        <NoteModal onSave={handleNoteSave} onClose={() => setShowNoteModal(false)} />
+        <NoteModal
+          onSave={handleNoteSave}
+          onClose={() => setShowNoteModal(false)}
+        />
+      )}
 
       <TaskActions
         visible={showActions}
@@ -198,12 +202,12 @@ export default function TaskCard({ task, onComplete }) {
         onSnooze={handleSnooze}
         onView={handleView}
       />
+
       {showModal && (
         <TaskModal
           onSave={handleSaveModal}
           onClose={() => setShowModal(false)}
         />
-
       )}
     </div>
   )


### PR DESCRIPTION
## Summary
- fix closing parentheses around `NoteModal` and `TaskModal` in `TaskCard.jsx`

## Testing
- `npx esbuild src/components/TaskCard.jsx --bundle --outfile=/tmp/out.js`

------
https://chatgpt.com/codex/tasks/task_e_68746db966908324a8c0eade4ff31763