### PR TITLE
Fix duplicate hook import

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -1,7 +1,6 @@
 import TaskCard from '../components/TaskCard.jsx'
-import { useState } from 'react'
-import { usePlants } from '../PlantContext.jsx'
 import { useState, useEffect } from 'react'
+import { usePlants } from '../PlantContext.jsx'
 
 import { useWeather } from '../WeatherContext.jsx'
 import { getNextWateringDate } from '../utils/watering.js'


### PR DESCRIPTION
## Summary
- remove duplicate React hook import to fix bundler error

## Testing
- `npm test` *(fails: TaskCard.test.jsx and BottomNav.test.jsx parse errors)*

------
https://chatgpt.com/codex/tasks/task_e_68746fc5e4b08324bde2cc53a7fd8091