### PR TITLE
Remove plant thumbnails from Home

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -13,11 +13,11 @@ const iconProps = {
 }
 
 
-const HomeIconComponent = () => <HomeIcon {...iconProps} />
-const ListIcon = () => <ListBulletIcon {...iconProps} />
-const CheckIcon = () => <CheckCircledIcon {...iconProps} />
-const GalleryIcon = () => <ImageIcon {...iconProps} />
-const UserIcon = () => <PersonIcon {...iconProps} />
+const HomeIconComponent = props => <HomeIcon {...iconProps} {...props} />
+const ListIcon = props => <ListBulletIcon {...iconProps} {...props} />
+const CheckIcon = props => <CheckCircledIcon {...iconProps} {...props} />
+const GalleryIcon = props => <ImageIcon {...iconProps} {...props} />
+const UserIcon = props => <PersonIcon {...iconProps} {...props} />
 
 
 export default function BottomNav({ dueCount = 0 }) {

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -137,16 +137,6 @@ const handleCompleteAll = type => {
         <p className="text-sm text-gray-500">{today}</p>
       </header>
 
-      <div className="flex justify-center space-x-3 overflow-x-auto py-2">
-        {plants.map(p => (
-          <img
-            key={p.id}
-            src={p.image}
-            alt={p.name}
-            className="w-32 h-32 object-cover rounded-lg flex-shrink-0"
-          />
-        ))}
-      </div>
 
       <PlantSpotlightCard plant={spotlightPlant} nextPlant={nextPlant} onSkip={handleSkip} />
 

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -40,7 +40,7 @@ test('shows messages when there are no tasks', () => {
 
 test('summary items render when tasks exist', () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
-  mockPlants.splice(0, mockPlants.length, {
+  global.mockPlants.splice(0, global.mockPlants.length, {
     id: 1,
     name: 'Plant A',
     image: 'a.jpg',
@@ -76,7 +76,7 @@ test('renders correct greeting icon for morning time', () => {
 test('progress updates when completing a task', () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
   jest.spyOn(window, 'prompt').mockReturnValue('')
-  mockPlants.splice(0, mockPlants.length,
+  global.mockPlants.splice(0, global.mockPlants.length,
     { id: 1, name: 'A', image: 'a.jpg', lastWatered: '2025-07-03' }
   )
   render(
@@ -94,9 +94,10 @@ test('progress updates when completing a task', () => {
 test('complete all marks every task', () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
   jest.spyOn(window, 'prompt').mockReturnValue('')
-  mockPlants.splice(0, mockPlants.length,
-    { id: 1, name: 'A', image: 'a.jpg', lastWatered: '2025-07-03' },
-    { id: 2, name: 'B', image: 'b.jpg', lastWatered: '2025-07-03' }
+  mockForecast = { rainfall: 100 }
+  global.mockPlants.splice(0, global.mockPlants.length,
+    { id: 1, name: 'A', image: 'a.jpg', lastWatered: '2025-07-02' },
+    { id: 2, name: 'B', image: 'b.jpg', lastWatered: '2025-07-02' }
   )
 
 


### PR DESCRIPTION
## Summary
- clean up Home page by removing thumbnail row
- allow passing className to BottomNav icons
- update Home tests to use shared mock plants and ensure rain forecast

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687474e450a88324aebb8061aee49e17