### PR TITLE
Add accessible completion toggle

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -152,7 +152,7 @@ export default function TaskCard({ task, onComplete }) {
       onKeyDown={e => {
         if (e.key === 'Enter' || e.key === ' ') {
           e.preventDefault()
-          setShowActions(true)
+          handleComplete()
         }
       }}
     >
@@ -181,6 +181,7 @@ export default function TaskCard({ task, onComplete }) {
         aria-label="Mark complete"
       >
         <input type="checkbox" checked={checked} readOnly className="task-checkbox" />
+        <span className="ml-1">Done</span>
       </button>
       {checked && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -85,6 +85,30 @@ test('mark as done opens modal and saves note', () => {
   expect(screen.getByRole('dialog')).toBeInTheDocument()
 })
 
+test('pressing Enter on card opens note modal', () => {
+  render(
+    <MemoryRouter>
+      <TaskCard task={task} />
+    </MemoryRouter>
+  )
+  const wrapper = screen.getByTestId('task-wrapper')
+  wrapper.focus()
+  fireEvent.keyDown(wrapper, { key: 'Enter', code: 'Enter' })
+  expect(screen.getByLabelText(/note/i)).toBeInTheDocument()
+})
+
+test('pressing Space on card opens note modal', () => {
+  render(
+    <MemoryRouter>
+      <TaskCard task={task} />
+    </MemoryRouter>
+  )
+  const wrapper = screen.getByTestId('task-wrapper')
+  wrapper.focus()
+  fireEvent.keyDown(wrapper, { key: ' ', code: 'Space' })
+  expect(screen.getByLabelText(/note/i)).toBeInTheDocument()
+})
+
 test('cancel note modal does not mark complete', () => {
   const { container } = render(
     <MemoryRouter initialEntries={['/']}>


### PR DESCRIPTION
## Summary
- show "Done" text in TaskCard and handle Enter/Space to complete
- test keyboard completion behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68747c7bf9a883248e0000d60b7c79a3