### PR TITLE
Replace floating button with AddActionsMenu in nav

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,7 +12,6 @@ import PlantDetail from './pages/PlantDetail'
 import EditPlant from './pages/EditPlant'
 import BottomNav from './components/BottomNav'
 
-import FloatingAddButton from './components/FloatingAddButton'
 
 import useDueTasksCount from './utils/useDueTasksCount.js'
 
@@ -55,7 +54,6 @@ export default function App() {
       </SwitchTransition>
 
 
-      <FloatingAddButton />
       <BottomNav dueCount={dueCount} />
 
     </div>

--- a/src/components/AddActionsMenu.jsx
+++ b/src/components/AddActionsMenu.jsx
@@ -1,0 +1,62 @@
+import { useState, useRef, useEffect } from 'react'
+import { PlusIcon } from '@radix-ui/react-icons'
+
+export default function AddActionsMenu({
+  onAddPlant,
+  onAddNote,
+  onAddPhoto,
+  onAddLog,
+}) {
+  const [open, setOpen] = useState(false)
+  const firstRef = useRef(null)
+
+  useEffect(() => {
+    if (open) {
+      const handler = e => {
+        if (e.key === 'Escape') setOpen(false)
+      }
+      window.addEventListener('keydown', handler)
+      firstRef.current?.focus()
+      return () => window.removeEventListener('keydown', handler)
+    }
+  }, [open])
+
+  const handle = callback => {
+    setOpen(false)
+    callback && callback()
+  }
+
+  return (
+    <div className="relative">
+      <button
+        aria-label="Add"
+        aria-haspopup="true"
+        aria-expanded={open}
+        onClick={() => setOpen(o => !o)}
+        className="w-12 h-12 bg-green-600 rounded-full flex items-center justify-center text-white"
+      >
+        <PlusIcon aria-hidden="true" />
+      </button>
+      {open && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          className="absolute bottom-14 left-1/2 -translate-x-1/2 bg-white dark:bg-gray-800 shadow rounded p-2 flex flex-col z-50"
+        >
+          <button ref={firstRef} onClick={() => handle(onAddPlant)} className="px-4 py-1 text-left rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+            Add Plant
+          </button>
+          <button onClick={() => handle(onAddNote)} className="px-4 py-1 text-left rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+            Add Note
+          </button>
+          <button onClick={() => handle(onAddPhoto)} className="px-4 py-1 text-left rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+            Add Photo
+          </button>
+          <button onClick={() => handle(onAddLog)} className="px-4 py-1 text-left rounded hover:bg-gray-100 dark:hover:bg-gray-700">
+            Add Entry
+          </button>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -6,6 +6,7 @@ import {
   GridFour,
   User,
 } from 'phosphor-react'
+import AddActionsMenu from './AddActionsMenu.jsx'
 
 const iconProps = {
   size: 24,
@@ -35,6 +36,7 @@ export default function BottomNav({ dueCount = 0 }) {
   const items = [
     { to: '/', label: 'Home', icon: HomeIconComponent },
     { to: '/myplants', label: 'Plants', icon: ListIcon },
+    { type: 'add' },
     { to: '/tasks', label: 'Care', icon: CheckIcon },
     { to: '/gallery', label: 'Gallery', icon: GalleryIcon },
     { to: '/settings', label: 'Profile', icon: UserIcon },
@@ -42,29 +44,38 @@ export default function BottomNav({ dueCount = 0 }) {
 
   return (
     <nav className="fixed bottom-0 left-0 right-0 border-t bg-white dark:bg-gray-800 flex justify-around py-2">
-      {items.map(({ to, label, icon: Icon }) => (
-        <NavLink
-          key={to}
-          to={to}
-          className={({ isActive }) =>
-            `w-12 flex flex-col items-center text-xs transition-transform duration-150 ${isActive ? 'text-[#A3C293]' : 'text-gray-500'}`
-          }
-        >
-          {({ isActive }) => (
-            <>
-              <Icon active={isActive} className={`mb-1 ${isActive ? 'nav-active' : ''}`} />
-              <span className="relative">
-                {label}
-                {to === '/tasks' && dueCount > 0 && (
-                  <span className="absolute -top-2 -right-3 bg-red-600 text-white rounded-full text-[10px] px-1">
-                    {dueCount}
+      {items.map(item =>
+        item.type === 'add' ? (
+          <div key="add" className="w-12 flex flex-col items-center">
+            <AddActionsMenu />
+          </div>
+        ) : (
+          <NavLink
+            key={item.to}
+            to={item.to}
+            className={({ isActive }) =>
+              `w-12 flex flex-col items-center text-xs transition-transform duration-150 ${isActive ? 'text-[#A3C293]' : 'text-gray-500'}`
+            }
+          >
+            {({ isActive }) => {
+              const Icon = item.icon
+              return (
+                <>
+                  <Icon active={isActive} className={`mb-1 ${isActive ? 'nav-active' : ''}`} />
+                  <span className="relative">
+                    {item.label}
+                    {item.to === '/tasks' && dueCount > 0 && (
+                      <span className="absolute -top-2 -right-3 bg-red-600 text-white rounded-full text-[10px] px-1">
+                        {dueCount}
+                      </span>
+                    )}
                   </span>
-                )}
-              </span>
-            </>
-          )}
-        </NavLink>
-      ))}
+                </>
+              )
+            }}
+          </NavLink>
+        )
+      )}
     </nav>
   )
 }

--- a/src/components/__tests__/AddActionsMenu.test.jsx
+++ b/src/components/__tests__/AddActionsMenu.test.jsx
@@ -1,0 +1,22 @@
+import { render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import AddActionsMenu from '../AddActionsMenu.jsx'
+
+test('opens menu and focuses first item', async () => {
+  const user = userEvent.setup()
+  render(<AddActionsMenu />)
+  await user.click(screen.getByRole('button', { name: /add/i }))
+  const dialog = screen.getByRole('dialog')
+  expect(dialog).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /add plant/i })).toHaveFocus()
+})
+
+test('calls callback and closes menu', async () => {
+  const user = userEvent.setup()
+  const onAddPlant = jest.fn()
+  render(<AddActionsMenu onAddPlant={onAddPlant} />)
+  await user.click(screen.getByRole('button', { name: /add/i }))
+  await user.click(screen.getByRole('button', { name: /add plant/i }))
+  expect(onAddPlant).toHaveBeenCalled()
+  expect(screen.queryByRole('dialog')).toBeNull()
+})

--- a/src/components/__tests__/BottomNav.test.jsx
+++ b/src/components/__tests__/BottomNav.test.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import BottomNav from '../BottomNav.jsx'
 
@@ -12,6 +12,15 @@ test('all icons are aria-hidden', () => {
   svgs.forEach(svg => {
     expect(svg).toHaveAttribute('aria-hidden', 'true')
   })
+})
+
+test('renders add actions button', () => {
+  render(
+    <MemoryRouter>
+      <BottomNav />
+    </MemoryRouter>
+  )
+  expect(screen.getByRole('button', { name: /add/i })).toBeInTheDocument()
 })
 
 test('renders gallery link', () => {


### PR DESCRIPTION
## Summary
- remove FloatingAddButton from the app shell
- add new AddActionsMenu component
- wire AddActionsMenu into BottomNav as a central button
- keep keyboard focus when menu opens
- test new menu and button behaviours

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68747c1586988324a19b243a6cf0dc05