### PR TITLE
Add alt text support to lightbox

### DIFF
--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -1,6 +1,12 @@
 import { useEffect, useRef, useState } from 'react'
 
-export default function Lightbox({ images, startIndex = 0, onClose, label = 'Image viewer' }) {
+export default function Lightbox({
+  images,
+  alts = [],
+  startIndex = 0,
+  onClose,
+  label = 'Image viewer',
+}) {
   const [index, setIndex] = useState(startIndex)
   const closeBtnRef = useRef(null)
   const prevFocusRef = useRef(null)
@@ -51,7 +57,7 @@ export default function Lightbox({ images, startIndex = 0, onClose, label = 'Ima
       </button>
       <img
         src={images[index]}
-        alt="Gallery image"
+        alt={alts[index] || 'Gallery image'}
         className="max-w-full max-h-full object-contain"
       />
       <button

--- a/src/components/__tests__/Lightbox.test.jsx
+++ b/src/components/__tests__/Lightbox.test.jsx
@@ -3,16 +3,23 @@ import Lightbox from '../Lightbox.jsx'
 
 test('keyboard navigation and close', () => {
   const images = ['a.jpg', 'b.jpg']
+  const alts = ['First', 'Second']
   const onClose = jest.fn()
   const label = 'Photo viewer'
   render(
-    <Lightbox images={images} startIndex={0} onClose={onClose} label={label} />
+    <Lightbox
+      images={images}
+      alts={alts}
+      startIndex={0}
+      onClose={onClose}
+      label={label}
+    />
   )
   const dialog = screen.getByRole('dialog', { name: label })
   expect(dialog).toHaveAttribute('aria-modal', 'true')
   expect(dialog).toHaveAttribute('aria-label', label)
 
-  const img = screen.getByAltText(/gallery image/i)
+  const img = screen.getByAltText('First')
   expect(img).toHaveAttribute('src', 'a.jpg')
 
   fireEvent.keyDown(window, { key: 'ArrowRight' })

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -7,7 +7,16 @@ import FadeInImage from '../components/FadeInImage.jsx'
 
 export function AllGallery() {
   const { plants, addPhoto } = usePlants()
-  const images = plants.flatMap(p => [p.image, ...(p.photos || []).map(ph => (typeof ph === 'object' ? ph.src : ph))])
+  const images = plants.flatMap(p => [
+    p.image,
+    ...(p.photos || []).map(ph => (typeof ph === 'object' ? ph.src : ph)),
+  ])
+  const alts = plants.flatMap(p => [
+    p.name,
+    ...(p.photos || []).map(ph =>
+      typeof ph === 'object' ? ph.note || p.name : p.name
+    ),
+  ])
   const [index, setIndex] = useState(null)
   const [selected, setSelected] = useState(plants[0]?.id || '')
   const [bouncing, setBouncing] = useState(false)
@@ -50,6 +59,7 @@ export function AllGallery() {
       {index !== null && (
         <Lightbox
           images={images}
+          alts={alts}
           startIndex={index}
           onClose={() => setIndex(null)}
           label="Photo viewer"
@@ -101,6 +111,9 @@ export default function Gallery() {
   }
 
   const photos = plant.photos || []
+  const alts = photos.map(ph =>
+    typeof ph === 'object' ? ph.note || plant.name : plant.name
+  )
   const [index, setIndex] = useState(null)
   const [editIndex, setEditIndex] = useState(null)
   const [note, setNote] = useState('')
@@ -174,6 +187,7 @@ export default function Gallery() {
       {index !== null && (
         <Lightbox
           images={photos.map(ph => (typeof ph === 'object' ? ph.src : ph))}
+          alts={alts}
           startIndex={index}
           onClose={() => setIndex(null)}
           label="Photo viewer"


### PR DESCRIPTION
## Summary
- extend `Lightbox` to accept an `alts` prop for per-image descriptions
- supply alt text arrays when opening the lightbox in gallery pages
- update lightbox unit test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68747c455a508324a5e41a3e08bf21ab