### PR TITLE
Add thumbnail overlay interaction

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -137,7 +137,7 @@ export default function Gallery() {
             <button
               key={i}
               onClick={() => setIndex(i)}
-              className="aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900 focus:outline-none"
+              className="relative group aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900 focus:outline-none"
             >
               <FadeInImage
               src={src}
@@ -145,7 +145,10 @@ export default function Gallery() {
               loading="lazy"
               className="w-full h-full object-cover transition-transform transform hover:scale-105 active:scale-105"
             />
-          </button>
+              <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">
+                {plant.name}
+              </span>
+            </button>
           )
         })}
       </div>
@@ -158,7 +161,7 @@ export default function Gallery() {
           <div key={i} className="snap-center shrink-0 w-full">
             <button
               onClick={() => setIndex(i)}
-              className="aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900 w-full h-full focus:outline-none"
+              className="relative group aspect-video overflow-hidden rounded-lg shadow-lg bg-gray-900 w-full h-full focus:outline-none"
             >
               <FadeInImage
                 src={src}
@@ -166,6 +169,9 @@ export default function Gallery() {
                 loading="lazy"
                 className="w-full h-full object-cover transition-transform transform hover:scale-105 active:scale-105"
               />
+              <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">
+                {plant.name}
+              </span>
             </button>
           </div>
           )

--- a/src/pages/PhotoTimeline.jsx
+++ b/src/pages/PhotoTimeline.jsx
@@ -27,13 +27,19 @@ export default function PhotoTimeline() {
           <ul className="grid grid-cols-2 md:grid-cols-3 gap-2">
             {list.map((photo, i) => (
               <li key={i} className="flex flex-col items-start">
-                <FadeInImage
-                  src={photo.src}
-                  alt={`Photo from ${photo.date}`}
-                  loading="lazy"
-                  className="w-full h-32 object-cover rounded"
-                />
-                <span className="text-xs text-gray-500">{photo.date}</span>
+                <div className="relative group w-full" tabIndex="0">
+                  <FadeInImage
+                    src={photo.src}
+                    alt={`Photo from ${photo.date}`}
+                    loading="lazy"
+                    className="w-full h-32 object-cover rounded"
+                  />
+                  <span
+                    className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-xs opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity"
+                  >
+                    {photo.date}
+                  </span>
+                </div>
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- show photo date overlay in the timeline gallery
- show plant name overlay in plant-specific gallery
- fade-in overlay on hover, focus or tap

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68747c47b4788324a9218497e81a0713