### PR TITLE
Move gallery link to header

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -226,14 +226,6 @@ export default function PlantDetail() {
         </div>
 
 
-        <div>
-          <Link
-            to={`/plant/${plant.id}/gallery`}
-            className="text-green-600 underline"
-          >
-            View Gallery
-          </Link>
-        </div>
 
         <div className="space-y-2 mt-4 divide-y divide-gray-200 rounded-xl shadow-sm bg-stone">
           <div>
@@ -428,8 +420,21 @@ export default function PlantDetail() {
           </div>
         </div>
       </div>
-      <div className="space-y-2 mt-4 p-4 shadow-sm bg-stone rounded-xl">
-        <h2 className="text-subhead font-semibold font-display">Gallery</h2>
+        <div className="space-y-2 mt-4 p-4 shadow-sm bg-stone rounded-xl">
+          <div className="flex items-center justify-between">
+            <h2 className="text-subhead font-semibold font-display">Gallery</h2>
+            <Link
+              to={`/plant/${plant.id}/gallery`}
+              className="text-green-600 underline flex items-center gap-1"
+            >
+              View Gallery
+              {plant.photos && (
+                <span className="ml-1 bg-gray-200 rounded-full px-1 text-xs">
+                  {plant.photos.length}
+                </span>
+              )}
+            </Link>
+          </div>
         <div className="grid grid-cols-3 gap-2">
           {(plant.photos || []).map((ph, i) => {
             const src = typeof ph === 'object' ? ph.src : ph

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -80,3 +80,20 @@ test('add note opens log modal', () => {
   fireEvent.click(screen.getByText('Add Note'))
   expect(screen.getByRole('dialog')).toBeInTheDocument()
 })
+
+test('view gallery link shows photo count', () => {
+  const plant = plants[0]
+  render(
+    <PlantProvider>
+      <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+        <Routes>
+          <Route path="/plant/:id" element={<PlantDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </PlantProvider>
+  )
+
+  const link = screen.getByRole('link', { name: /view gallery/i })
+  expect(link).toHaveAttribute('href', `/plant/${plant.id}/gallery`)
+  expect(link).toHaveTextContent(String(plant.photos.length))
+})


### PR DESCRIPTION
## Summary
- move 'View Gallery' link next to the Gallery header
- show a badge with image count
- update PlantDetail tests for new gallery link

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68747c9e329883248cc37c1dc97b8b6c