### PR TITLE
Refactor PlantDetail action buttons

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -201,28 +201,34 @@ export default function PlantDetail() {
             </p>
           )}
         </div>
-        <div className="flex gap-2 mt-2">
-          <button
-            type="button"
-            onClick={handleWatered}
-            className="px-4 py-1 bg-accent text-white rounded-full"
+        <div className="mt-2">
+          <div
+            role="group"
+            aria-label="log actions"
+            className="flex text-sm rounded-full overflow-hidden bg-accent text-white divide-x divide-white"
           >
-            Watered
-          </button>
-          <button
-            type="button"
-            onClick={handleLogEvent}
-            className="px-4 py-1 bg-accent text-white rounded-full"
-          >
-            Add Note
-          </button>
-          <button
-            type="button"
-            onClick={handleAddCareLog}
-            className="px-4 py-1 bg-accent text-white rounded-full"
-          >
-            + Add care log
-          </button>
+            <button
+              type="button"
+              onClick={handleWatered}
+              className="flex-1 px-3 py-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            >
+              Watered
+            </button>
+            <button
+              type="button"
+              onClick={handleLogEvent}
+              className="flex-1 px-3 py-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            >
+              Add Note
+            </button>
+            <button
+              type="button"
+              onClick={handleAddCareLog}
+              className="flex-1 px-3 py-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
+            >
+              + Add care log
+            </button>
+          </div>
         </div>
 
 

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import PlantDetail from '../PlantDetail.jsx'
 import plants from '../../plants.json'
@@ -77,6 +77,9 @@ test('add note opens log modal', () => {
     </PlantProvider>
   )
 
-  fireEvent.click(screen.getByText('Add Note'))
+  const group = screen.getByRole('group', { name: /log actions/i })
+  expect(within(group).getAllByRole('button')).toHaveLength(3)
+
+  fireEvent.click(screen.getByRole('button', { name: /Add Note/i }))
   expect(screen.getByRole('dialog')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- combine individual action buttons on PlantDetail into a single segmented control
- ensure accessibility with `role="group"` and focus-visible rings
- adjust PlantDetail tests for new grouping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68747c9631388324854fbf29302a6504