### PR TITLE
Sort timeline events descending

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -60,7 +60,7 @@ export default function PlantDetail() {
         type: 'log',
       })
     })
-    return list.sort((a, b) => new Date(a.date) - new Date(b.date))
+    return list.sort((a, b) => new Date(b.date) - new Date(a.date))
   }, [plant])
 
   const groupedEvents = useMemo(() => {

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -43,8 +43,8 @@ export default function Timeline() {
         })
       })
     })
-    return all.sort((a, b) => new Date(a.date) - new Date(b.date))
-  }, [plants])
+      return all.sort((a, b) => new Date(b.date) - new Date(a.date))
+    }, [plants])
 
   const groupedEvents = useMemo(() => {
     const map = new Map()

--- a/src/pages/__tests__/Timeline.test.jsx
+++ b/src/pages/__tests__/Timeline.test.jsx
@@ -33,10 +33,10 @@ test('ignores activities without valid dates when generating events', () => {
 
   const items = screen.getAllByRole('listitem')
   expect(items).toHaveLength(4)
-  expect(items[0]).toHaveTextContent('Fertilized Plant A')
-  expect(items[1]).toHaveTextContent('Plant B: Watered on 2025-07-09')
-  expect(items[2]).toHaveTextContent('Watered Plant B')
-  expect(items[3]).toHaveTextContent('Watered Plant A')
+  expect(items[0]).toHaveTextContent('Watered Plant A')
+  expect(items[1]).toHaveTextContent('Watered Plant B')
+  expect(items[2]).toHaveTextContent('Plant B: Watered on 2025-07-09')
+  expect(items[3]).toHaveTextContent('Fertilized Plant A')
 })
 
 test('renders care log notes', () => {
@@ -71,6 +71,6 @@ test('displays month headers when events span months', () => {
 
   const headings = screen.getAllByRole('heading', { level: 3 })
   expect(headings).toHaveLength(2)
-  expect(headings[0]).toHaveTextContent('July 2025')
-  expect(headings[1]).toHaveTextContent('August 2025')
+  expect(headings[0]).toHaveTextContent('August 2025')
+  expect(headings[1]).toHaveTextContent('July 2025')
 })


### PR DESCRIPTION
## Summary
- sort events in `PlantDetail` and `Timeline` pages in descending order
- update `Timeline` tests for new ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68747ca28f1c8324a1e5508240b69d61