### PR TITLE
Improve PlantDetail timeline grouping

### DIFF
--- a/src/pages/__tests__/PlantDetailGrouping.test.jsx
+++ b/src/pages/__tests__/PlantDetailGrouping.test.jsx
@@ -1,0 +1,70 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import PlantDetail from '../PlantDetail.jsx'
+
+let mockPlants = []
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: () => ({
+    plants: mockPlants,
+    addPhoto: jest.fn(),
+    removePhoto: jest.fn(),
+    markWatered: jest.fn(),
+    logEvent: jest.fn(),
+  }),
+}))
+
+beforeEach(() => {
+  mockPlants = [
+    {
+      id: 1,
+      name: 'Plant A',
+      image: 'a.jpg',
+      lastWatered: '2025-07-02',
+      careLog: [{ date: '2025-07-10', type: 'Watered' }],
+      photos: [],
+    },
+  ]
+})
+
+test('groups events by week when within same month', () => {
+  render(
+    <MemoryRouter initialEntries={['/plant/1']}>
+      <Routes>
+        <Route path="/plant/:id" element={<PlantDetail />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /Timeline/ }))
+
+  const headers = screen.getAllByText(/Week of/i)
+  expect(headers.length).toBeGreaterThan(0)
+  expect(headers[0].className).toMatch(/sticky/)
+})
+
+test('groups events by month when spanning multiple months', () => {
+  mockPlants = [
+    {
+      id: 1,
+      name: 'Plant A',
+      image: 'a.jpg',
+      lastWatered: '2025-07-02',
+      careLog: [{ date: '2025-08-05', type: 'Watered' }],
+      photos: [],
+    },
+  ]
+
+  render(
+    <MemoryRouter initialEntries={['/plant/1']}>
+      <Routes>
+        <Route path="/plant/:id" element={<PlantDetail />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /Timeline/ }))
+
+  expect(screen.getByText('July 2025')).toBeInTheDocument()
+  expect(screen.getByText('August 2025')).toBeInTheDocument()
+  expect(screen.queryByText(/Week of/)).toBeNull()
+})

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -16,3 +16,22 @@ export function formatMonth(key) {
   ]
   return `${months[Number(month) - 1]} ${year}`
 }
+
+export function formatWeek(key) {
+  const [year, month, day] = key.split('-').map(Number)
+  const months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ]
+  return `Week of ${months[month - 1]} ${day}, ${year}`
+}


### PR DESCRIPTION
## Summary
- add `formatWeek` helper
- group PlantDetail timeline events by week when all events occur in one month
- make timeline headers sticky and show formatted week
- test weekly and monthly grouping

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68747ca52a008324bdbae6580e22ac88