### PR TITLE
Update Tasks headings styling

### DIFF
--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -101,7 +101,7 @@ export default function Tasks() {
 
       {overdue.length > 0 && (
         <section>
-          <h2 className="font-semibold mb-2">Needs attention</h2>
+          <h2 className="text-subhead font-bold font-display mb-2">Needs attention</h2>
           <div className="space-y-4">
             {overdue.map(task => (
               <TaskCard key={task.id} task={task} />
@@ -112,7 +112,7 @@ export default function Tasks() {
 
       {today.length > 0 && (
         <section>
-          <h2 className="font-semibold mb-2">Today</h2>
+          <h2 className="text-subhead font-bold font-display mb-2">Today</h2>
           <div className="space-y-4">
             {today.map(task => (
               <TaskCard key={task.id} task={task} />
@@ -123,7 +123,7 @@ export default function Tasks() {
 
       {upcoming.length > 0 && (
         <section>
-          <h2 className="font-semibold mb-2">Upcoming</h2>
+          <h2 className="text-subhead font-bold font-display mb-2">Upcoming</h2>
           <div className="space-y-4">
             {upcoming.map(task => (
               <TaskCard key={task.id} task={task} />


### PR DESCRIPTION
## Summary
- enlarge section heading text in Tasks for better emphasis

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68747cc2ed18832493dbd5cdace8e810