### PR TITLE
Add empty state for Tasks page

### DIFF
--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -99,6 +99,10 @@ export default function Tasks() {
         </select>
       </div>
 
+      {filtered.length === 0 ? (
+        <p className="text-gray-700">No tasks remaining</p>
+      ) : (
+        <>
       {overdue.length > 0 && (
         <section>
           <h2 className="font-semibold mb-2">Needs attention</h2>
@@ -130,6 +134,8 @@ export default function Tasks() {
             ))}
           </div>
         </section>
+      )}
+        </>
       )}
     </div>
   )

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -82,3 +82,15 @@ test('filters tasks by urgency and type', () => {
   expect(screen.getByText('Water Fern')).toBeInTheDocument()
   expect(screen.queryByText('Water Palm')).toBeNull()
 })
+
+test('shows placeholder when no tasks remain after filtering', () => {
+  render(
+    <MemoryRouter>
+      <Tasks />
+    </MemoryRouter>
+  )
+  const selects = screen.getAllByRole('combobox')
+  fireEvent.change(selects[0], { target: { value: 'low' } })
+  fireEvent.change(selects[1], { target: { value: 'succulent' } })
+  expect(screen.getByText(/no tasks remaining/i)).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- render a message when no tasks match current filters
- test Tasks page empty state behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68747cc656408324b46e92cb515dfcf0