### PR TITLE
Fix Lightbox component duplicate line

### DIFF
--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -2,7 +2,6 @@ import { useEffect, useRef, useState } from 'react'
 
 
 import Button from "./Button.jsx"
-export default function Lightbox({ images, startIndex = 0, onClose, label = 'Image viewer' }) {
 
 export default function Lightbox({
   images,


### PR DESCRIPTION
## Summary
- remove the stray duplicate export line in `Lightbox.jsx`

## Testing
- `npm test` *(fails: SyntaxError in PlantDetail.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_687481454430832486ecb921ead76b16