### PR TITLE
Fix PhotoTimeline image count

### DIFF
--- a/src/pages/PhotoTimeline.jsx
+++ b/src/pages/PhotoTimeline.jsx
@@ -27,22 +27,13 @@ export default function PhotoTimeline() {
           <ul className="grid grid-cols-2 md:grid-cols-3 gap-2">
             {list.map((photo, i) => (
               <li key={i} className="flex flex-col items-start">
-
-                <FadeInImage
-                  src={photo.src}
-                  alt={`Photo from ${photo.date}`}
-                  loading="lazy"
-                  className="w-full h-32 object-cover rounded"
-                  onError={e => (e.target.src = '/placeholder.svg')}
-                />
-                <span className="text-xs text-gray-500">{photo.date}</span>
-
                 <div className="relative group w-full" tabIndex="0">
                   <FadeInImage
                     src={photo.src}
                     alt={`Photo from ${photo.date}`}
                     loading="lazy"
                     className="w-full h-32 object-cover rounded"
+                    onError={e => (e.target.src = '/placeholder.svg')}
                   />
                   <span
                     className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-xs opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity"
@@ -50,7 +41,6 @@ export default function PhotoTimeline() {
                     {photo.date}
                   </span>
                 </div>
-
               </li>
             ))}
           </ul>


### PR DESCRIPTION
## Summary
- remove duplicated `<FadeInImage>` from `PhotoTimeline`
- keep only the overlay image div

## Testing
- `npm test` *(fails: Test Suites: 11 failed, 15 passed, 26 total)*

------
https://chatgpt.com/codex/tasks/task_e_6874814f40b0832489fc1bd8a67d2193