### PR TITLE
Fix Gallery button closing tag

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -166,17 +166,10 @@ export default function Gallery() {
                 loading="lazy"
                 className="w-full h-full object-cover transition-transform transform hover:scale-105 active:scale-105"
               />
-
-              src={src}
-              alt={plant.name}
-              loading="lazy"
-              className="w-full h-full object-cover transition-transform transform hover:scale-105 active:scale-105"
-              onError={e => (e.target.src = '/placeholder.svg')}
-            />
               <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">
                 {plant.name}
               </span>
-            </button>
+            </Button>
 
           )
         })}
@@ -203,7 +196,7 @@ export default function Gallery() {
               <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">
                 {plant.name}
               </span>
-            </button>
+            </Button>
 
           </div>
           )


### PR DESCRIPTION
## Summary
- remove duplicated image attribute block in Gallery
- close `<Button>` elements correctly

## Testing
- `npm test --silent` *(fails: BottomNav.test.jsx, Timeline.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_687485f26a0c8324b0a83fd9da0ad185