### PR TITLE
Fix PlantDetail timeline mapping and collapse logic

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -176,7 +176,7 @@ export default function Gallery() {
               <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">
                 {plant.name}
               </span>
-            </button>
+            </Button>
 
           )
         })}
@@ -203,7 +203,7 @@ export default function Gallery() {
               <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">
                 {plant.name}
               </span>
-            </button>
+              </Button>
 
           </div>
           )

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -95,7 +95,7 @@ export default function PlantDetail() {
 
   useEffect(() => {
     const monthKeys = groupedEvents.map(([k]) => k)
-    const recent = monthKeys.slice(-2)
+    const recent = monthKeys.slice(0, 2)
     setOpenMonths(prev => {
       const updated = { ...prev }
       monthKeys.forEach(k => {
@@ -259,6 +259,7 @@ export default function PlantDetail() {
           >
             + Add care log
           </Button>
+        </div>
 
         <div className="mt-2">
           <div
@@ -276,6 +277,7 @@ export default function PlantDetail() {
             <button
               type="button"
               onClick={handleLogEvent}
+              aria-label="Log note"
               className="flex-1 px-3 py-1 focus:outline-none focus-visible:ring-2 focus-visible:ring-white"
             >
               Add Note
@@ -451,49 +453,21 @@ export default function PlantDetail() {
                 </div>
                 {timelineTab === 'list' ? (
 
-                  groupedEvents.map(([monthKey, list]) => (
-                    <div key={monthKey}>
-                      <h3 className="sticky top-0 bg-stone mt-4 text-label font-semibold text-gray-500">
-                        {groupByWeek ? formatWeek(monthKey) : formatMonth(monthKey)}
-                      </h3>
-                      <ul className="relative border-l border-gray-300 pl-4 space-y-6">
-                        {list.map((e, i) => {
-                          const Icon = actionIcons[e.type]
-                          return (
-                            <li key={`${e.date}-${i}`} className="relative">
-                              <span
-                                className={`absolute -left-2 top-1 w-3 h-3 rounded-full ${colors[e.type]}`}
-                              ></span>
-                              <p className="text-xs text-gray-500">{e.date}</p>
-                              <p className="flex items-center gap-1">
-                                {Icon && <Icon />}
-                                {e.label}
-                              </p>
-                              {e.note && (
-                                <p className="text-xs text-gray-500 italic">{e.note}</p>
-                              )}
-                              {e.mood && <p className="text-xs">{e.mood}</p>}
-                            </li>
-                          )
-                        })}
-                      </ul>
-                    </div>
-                  ))
-
                   groupedEvents.map(([monthKey, list]) => {
                     const isOpen = openMonths[monthKey]
                     return (
                       <div key={monthKey}>
-                        <h3 className="sticky top-0 bg-stone z-10 mt-4 text-label font-semibold text-gray-500">
+                        <h3 className="mt-4">
                           <button
                             type="button"
-                            className="w-full flex justify-between items-center py-2"
+                            className="w-full flex justify-between items-center py-2 sticky top-0 bg-stone z-10 text-label font-semibold text-gray-500"
                             aria-expanded={isOpen}
                             onClick={() =>
                               setOpenMonths(prev => ({ ...prev, [monthKey]: !prev[monthKey] }))
                             }
                           >
-                            {formatMonth(monthKey)} <span>{isOpen ? '-' : '+'}</span>
+                            {groupByWeek ? formatWeek(monthKey) : formatMonth(monthKey)}{' '}
+                            <span>{isOpen ? '-' : '+'}</span>
                           </button>
                         </h3>
                         {isOpen && (

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -60,7 +60,7 @@ export default function Timeline() {
 
   useEffect(() => {
     const monthKeys = groupedEvents.map(([k]) => k)
-    const recent = monthKeys.slice(-2)
+    const recent = monthKeys.slice(0, 2)
     setOpenMonths(prev => {
       const updated = { ...prev }
       monthKeys.forEach(k => {


### PR DESCRIPTION
## Summary
- remove duplicate event mapping in PlantDetail timeline
- keep collapsible month view and make headings sticky on the button
- initialize open months from the first two entries
- close flex button group markup and tweak log actions button label
- match Timeline page logic
- fix Gallery closing tags

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687485f62048832487597c0ded7c0d5c