### PR TITLE
Improve Home header styles

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -116,9 +116,9 @@ const handleCompleteAll = type => {
 
   return (
     <div className="space-y-4">
-      <header className="flex flex-col items-start space-y-1">
+      <header className="flex flex-col items-start space-y-3 py-4 px-4 bg-white rounded-xl">
 
-        <h1 className="text-2xl font-bold font-display flex items-center">
+        <h1 className="text-headline font-bold font-display flex items-center">
           {greeting}
           <GreetingIcon
             data-testid="greeting-icon"
@@ -135,7 +135,7 @@ const handleCompleteAll = type => {
             </span>
           )}
         </p>
-        <p className="text-sm text-gray-500">{today}</p>
+        <p className="text-subhead text-gray-500">{today}</p>
       </header>
 
 


### PR DESCRIPTION
## Summary
- increase padding and spacing for the Home page header
- use larger `text-headline` style for greeting
- bump date text to `text-subhead`
- add subtle background and rounded corners

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874eaa41f2c832491a09daf4f568157