### PR TITLE
Refine CareGraph colors

### DIFF
--- a/src/components/CareGraph.jsx
+++ b/src/components/CareGraph.jsx
@@ -18,18 +18,22 @@ export default function CareGraph({ events = [] }) {
   for (let d = 1; d <= daysInMonth; d++) cells.push(d)
 
   return (
-    <div role="grid" className="grid grid-cols-7 gap-1 text-center text-xs">
-      {cells.map((day, i) => (
-        <div
-          key={i}
-          role="gridcell"
-          className={`w-6 h-6 flex items-center justify-center rounded ${
-            day && eventDays.has(day) ? 'bg-blue-400 text-white' : 'bg-gray-100'
-          }`}
-        >
-          {day || ''}
-        </div>
-      ))}
+    <div className="bg-white rounded-xl p-2 shadow-sm inline-block">
+      <div role="grid" className="grid grid-cols-7 gap-1 text-center text-xs">
+        {cells.map((day, i) => (
+          <div
+            key={i}
+            role="gridcell"
+            className={`w-6 h-6 flex items-center justify-center rounded hover:bg-accent/80 ${
+              day && eventDays.has(day)
+                ? 'bg-accent text-white rounded-full'
+                : 'bg-sage'
+            }`}
+          >
+            {day || ''}
+          </div>
+        ))}
+      </div>
     </div>
   )
 }

--- a/src/components/__tests__/CareGraph.test.jsx
+++ b/src/components/__tests__/CareGraph.test.jsx
@@ -9,7 +9,7 @@ test('renders grid with highlighted events', () => {
   const { container } = render(<CareGraph events={events} />)
   const cells = container.querySelectorAll('[role="gridcell"]')
   expect(cells.length).toBeGreaterThan(30)
-  const highlights = container.querySelectorAll('.bg-blue-400')
+  const highlights = container.querySelectorAll('.bg-accent')
   expect(highlights).toHaveLength(2)
 })
 


### PR DESCRIPTION
## Summary
- update CareGraph calendar styles to use accent palette
- wrap calendar grid with a white rounded container
- adjust CareGraph test to match new classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874ec0d5c5883248393ba7b149d31af