### PR TITLE
Add overlay captions for AllGallery images

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -52,14 +52,21 @@ export function AllGallery() {
       </Link>
       <div className="grid grid-cols-2 md:grid-cols-3 gap-1">
         {images.map((src, i) => (
-          <Button key={i} onClick={() => setIndex(i)} className="focus:outline-none">
+          <Button
+            key={i}
+            onClick={() => setIndex(i)}
+            className="relative group focus:outline-none"
+          >
             <FadeInImage
               src={src}
-              alt={`Plant ${i + 1}`}
+              alt={alts[i] || `Plant ${i + 1}`}
               loading="lazy"
               className="w-full h-32 object-cover rounded transition-transform transform hover:scale-105 active:scale-105"
               onError={e => (e.target.src = '/placeholder.svg')}
             />
+            <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">
+              {alts[i]}
+            </span>
           </Button>
         ))}
       </div>

--- a/src/pages/__tests__/AllGallery.test.jsx
+++ b/src/pages/__tests__/AllGallery.test.jsx
@@ -1,6 +1,7 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { PlantProvider } from '../../PlantContext.jsx'
+import plants from '../../plants.json'
 import { AllGallery } from '../Gallery.jsx'
 
 test('clicking add photos button opens file dialog', () => {
@@ -46,4 +47,25 @@ test('newly uploaded image is added to gallery', () => {
   expect(updatedCount).toBe(initialCount + 1)
 
   global.FileReader = original
+})
+
+test('overlay displays plant name on hover and focus', () => {
+  const plant = plants[0]
+  render(
+    <PlantProvider>
+      <MemoryRouter>
+        <AllGallery />
+      </MemoryRouter>
+    </PlantProvider>
+  )
+
+  const img = screen.getAllByAltText(plant.name)[0]
+  const button = img.closest('button')
+  expect(button).not.toBeNull()
+
+  fireEvent.mouseOver(button)
+  expect(within(button).getByText(plant.name)).toBeInTheDocument()
+
+  fireEvent.focus(button)
+  expect(within(button).getByText(plant.name)).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- overlay captions for images in AllGallery
- test overlay visibility on hover/focus

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874ec27a7a083249951eae87cb0975d