### PR TITLE
Update icon styling

### DIFF
--- a/src/components/ActionIcons.jsx
+++ b/src/components/ActionIcons.jsx
@@ -11,7 +11,9 @@ import {
 } from 'phosphor-react'
 
 const iconProps = {
-  className: 'w-6 h-6 text-gray-500 dark:text-gray-400',
+  size: 20,
+  weight: 'regular',
+  className: 'text-gray-500 dark:text-gray-400',
   'aria-hidden': 'true',
 }
 export const WaterIcon = () => <Drop {...iconProps} />


### PR DESCRIPTION
## Summary
- tweak icon styles to use a smaller default size and regular weight

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874ec34538c8324b35f521c2c5d1f82