### PR TITLE
Add component tests

### DIFF
--- a/src/components/__tests__/Button.test.jsx
+++ b/src/components/__tests__/Button.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Button from '../Button.jsx'
+
+test('renders children and applies class name', () => {
+  render(<Button className="px-2">Click</Button>)
+  const btn = screen.getByRole('button', { name: 'Click' })
+  expect(btn).toHaveClass('rounded-lg')
+  expect(btn).toHaveClass('px-2')
+})
+
+test('handles click events', () => {
+  const onClick = jest.fn()
+  render(
+    <Button onClick={onClick}>Press</Button>
+  )
+  fireEvent.click(screen.getByRole('button', { name: 'Press' }))
+  expect(onClick).toHaveBeenCalled()
+})
+

--- a/src/components/__tests__/PlantSpotlightCard.test.jsx
+++ b/src/components/__tests__/PlantSpotlightCard.test.jsx
@@ -1,0 +1,55 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import PlantSpotlightCard from '../PlantSpotlightCard.jsx'
+import { usePlants } from '../../PlantContext.jsx'
+
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: jest.fn(),
+}))
+
+const usePlantsMock = usePlants
+const markWatered = jest.fn()
+const logEvent = jest.fn()
+
+beforeEach(() => {
+  markWatered.mockClear()
+  logEvent.mockClear()
+  usePlantsMock.mockReturnValue({ markWatered, logEvent })
+})
+
+const plant = {
+  id: 1,
+  name: 'Pothos',
+  image: 'a.jpg',
+  light: 'Bright',
+  difficulty: 'Easy',
+}
+const nextPlant = { id: 2, name: 'Monstera' }
+
+test('renders plant info and next plant text', () => {
+  render(<PlantSpotlightCard plant={plant} nextPlant={nextPlant} />)
+  expect(screen.getByText('Pothos')).toBeInTheDocument()
+  expect(screen.getByText(/Next up: Monstera/)).toBeInTheDocument()
+})
+
+test('water button calls markWatered', () => {
+  render(<PlantSpotlightCard plant={plant} />)
+  fireEvent.click(screen.getByText('Water'))
+  expect(markWatered).toHaveBeenCalledWith(1, '')
+})
+
+test('add note button prompts and logs event', () => {
+  const promptMock = jest.spyOn(window, 'prompt').mockReturnValue('hi')
+  render(<PlantSpotlightCard plant={plant} />)
+  fireEvent.click(screen.getByText('Add Note'))
+  expect(logEvent).toHaveBeenCalledWith(1, 'Note', 'hi')
+  promptMock.mockRestore()
+})
+
+test('skip button hides card and calls callback', () => {
+  const onSkip = jest.fn()
+  render(<PlantSpotlightCard plant={plant} onSkip={onSkip} />)
+  fireEvent.click(screen.getByText('Skip'))
+  expect(onSkip).toHaveBeenCalled()
+  expect(screen.queryByText('Pothos')).toBeNull()
+})
+

--- a/src/components/__tests__/ProgressRing.test.jsx
+++ b/src/components/__tests__/ProgressRing.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import ProgressRing from '../ProgressRing.jsx'
+
+function getDashoffset(circle) {
+  return parseFloat(circle.getAttribute('stroke-dashoffset'))
+}
+
+test('renders progress with correct aria attributes and text', () => {
+  const { container } = render(<ProgressRing completed={2} total={4} />)
+  const progress = screen.getByRole('progressbar')
+  expect(progress).toHaveAttribute('aria-valuenow', '2')
+  expect(progress).toHaveAttribute('aria-valuemax', '4')
+  expect(screen.getByText('2/4')).toBeInTheDocument()
+
+  const circles = container.querySelectorAll('circle')
+  const radius = 36
+  const stroke = 4
+  const normalized = radius - stroke * 2
+  const circumference = normalized * 2 * Math.PI
+  const expectedOffset = circumference - (2 / 4) * circumference
+  expect(getDashoffset(circles[1])).toBeCloseTo(expectedOffset)
+})
+

--- a/src/components/__tests__/SummaryStrip.test.jsx
+++ b/src/components/__tests__/SummaryStrip.test.jsx
@@ -1,0 +1,10 @@
+import { render, screen } from '@testing-library/react'
+import SummaryStrip from '../SummaryStrip.jsx'
+
+test('displays summary counts', () => {
+  render(<SummaryStrip total={10} watered={3} fertilized={1} />)
+  expect(screen.getByTestId('summary-total')).toHaveTextContent('10')
+  expect(screen.getByTestId('summary-water')).toHaveTextContent('3')
+  expect(screen.getByTestId('summary-fertilize')).toHaveTextContent('1')
+})
+


### PR DESCRIPTION
## Summary
- add test coverage for `PlantSpotlightCard`, `ProgressRing`, `SummaryStrip`, and `Button`

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874f04d3a208324bd8661751f9d3c25