### PR TITLE
Handle weather API errors

### DIFF
--- a/src/WeatherContext.jsx
+++ b/src/WeatherContext.jsx
@@ -4,6 +4,7 @@ const WeatherContext = createContext()
 
 export function WeatherProvider({ children }) {
   const [forecast, setForecast] = useState(null)
+  const [error, setError] = useState(null)
   const [location, setLocation] = useState(() => {
     if (typeof localStorage !== 'undefined') {
       const stored = localStorage.getItem('weatherLocation')
@@ -32,6 +33,7 @@ export function WeatherProvider({ children }) {
   useEffect(() => {
     const key = process.env.VITE_WEATHER_API_KEY
     if (!key) return
+    setError(null)
     const url = `https://api.openweathermap.org/data/2.5/forecast?q=${encodeURIComponent(location)}&units=${units}&appid=${key}`
     fetch(url)
       .then(res => res.json())
@@ -45,9 +47,15 @@ export function WeatherProvider({ children }) {
             condition: next.weather?.[0]?.main,
             rainfall,
           })
+        } else {
+          setForecast(null)
+          setError('No weather data')
         }
       })
-      .catch(err => console.error(err))
+      .catch(err => {
+        console.error(err)
+        setError(err.message || 'Failed to fetch weather')
+      })
   }, [location, units])
 
   useEffect(() => {
@@ -72,6 +80,7 @@ export function WeatherProvider({ children }) {
     <WeatherContext.Provider
       value={{
         forecast,
+        error,
         location,
         setLocation,
         timezone,

--- a/src/__tests__/WeatherContext.test.jsx
+++ b/src/__tests__/WeatherContext.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import { WeatherProvider, useWeather } from '../WeatherContext.jsx'
+
+function ShowWeather() {
+  const { forecast, error } = useWeather()
+  return (
+    <div>
+      <span data-testid="forecast">{forecast ? 'y' : 'n'}</span>
+      <span data-testid="error">{error || ''}</span>
+    </div>
+  )
+}
+
+describe('WeatherProvider', () => {
+  const originalFetch = global.fetch
+  beforeEach(() => {
+    process.env.VITE_WEATHER_API_KEY = 'test'
+    global.fetch = jest.fn().mockRejectedValue(new Error('fail'))
+  })
+
+  afterEach(() => {
+    global.fetch = originalFetch
+    delete process.env.VITE_WEATHER_API_KEY
+  })
+
+  test('sets error when fetch fails', async () => {
+    render(
+      <WeatherProvider>
+        <ShowWeather />
+      </WeatherProvider>
+    )
+
+    await waitFor(() => {
+      expect(screen.getByTestId('error').textContent).toContain('fail')
+    })
+    expect(screen.getByTestId('forecast').textContent).toBe('n')
+  })
+})

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -16,6 +16,7 @@ export default function Home() {
   const { plants, markWatered } = usePlants()
   const weatherCtx = useWeather()
   const forecast = weatherCtx?.forecast
+  const weatherError = weatherCtx?.error
   const timezone = weatherCtx?.timezone || 'UTC'
   const weatherData = { rainTomorrow: forecast?.rainfall || 0 }
 
@@ -124,7 +125,11 @@ export default function Home() {
 
         <p className="flex items-center text-sm text-gray-600">
           <CloudSun className="w-5 h-5 mr-1 text-green-600" />
-          {forecast ? `${forecast.temp} - ${forecast.condition}` : 'Loading...'}
+          {weatherError
+            ? 'Weather unavailable'
+            : forecast
+            ? `${forecast.temp} - ${forecast.condition}`
+            : 'Loading...'}
           {showRainSuggestion && (
             <span className="ml-2" aria-label="rain forecasted">
               💧Skip watering if it rains tomorrow


### PR DESCRIPTION
## Summary
- track API error status in `WeatherContext`
- show fallback text in Home page when weather fails
- test failed fetch handling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f04f241c83249d4e0d723bdf98a1