### PR TITLE
Add heading typographic utilities

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -123,7 +123,7 @@ export default function PlantCard({ plant }) {
             className="w-full h-48 object-cover rounded-xl"
             onError={e => (e.target.src = '/placeholder.svg')}
           />
-          <h2 className="font-semibold text-xl font-display mt-2">{plant.name}</h2>
+          <h2 className="font-semibold text-xl font-display leading-heading tracking-heading mt-2">{plant.name}</h2>
         </Link>
         <p className="text-sm text-gray-600 dark:text-gray-400">Last watered: {plant.lastWatered}</p>
         <p className="text-sm text-green-700 font-medium">Next: {plant.nextWater}</p>

--- a/src/components/PlantSpotlightCard.jsx
+++ b/src/components/PlantSpotlightCard.jsx
@@ -32,7 +32,7 @@ export default function PlantSpotlightCard({ plant, nextPlant, onSkip }) {
         className="w-full rounded-lg object-cover"
         onError={e => (e.target.src = '/placeholder.svg')}
       />
-      <h2 className="text-xl font-semibold">{plant.name}</h2>
+      <h2 className="text-xl font-semibold leading-heading tracking-heading">{plant.name}</h2>
       <div className="flex gap-2">
         {plant.light && (
           <span className="px-2 py-0.5 text-xs rounded-full bg-yellow-100 text-yellow-800">

--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -24,9 +24,9 @@ export default function Add() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
-      <h1 className="text-headline font-bold font-display">Add Plant</h1>
+      <h1 className="text-headline leading-heading tracking-heading font-bold font-display">Add Plant</h1>
       <div className="grid gap-1">
-        <label htmlFor="name" className="font-medium text-label">Name</label>
+        <label htmlFor="name" className="font-medium text-label leading-label tracking-label">Name</label>
         <input
           id="name"
           type="text"
@@ -37,7 +37,7 @@ export default function Add() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="image" className="font-medium text-label">Image URL</label>
+        <label htmlFor="image" className="font-medium text-label leading-label tracking-label">Image URL</label>
         <input
           id="image"
           type="text"
@@ -47,7 +47,7 @@ export default function Add() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="lastWatered" className="font-medium text-label">Last Watered</label>
+        <label htmlFor="lastWatered" className="font-medium text-label leading-label tracking-label">Last Watered</label>
         <input
           id="lastWatered"
           type="date"
@@ -57,7 +57,7 @@ export default function Add() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="nextWater" className="font-medium text-label">Next Watering</label>
+        <label htmlFor="nextWater" className="font-medium text-label leading-label tracking-label">Next Watering</label>
         <input
           id="nextWater"
           type="date"

--- a/src/pages/EditPlant.jsx
+++ b/src/pages/EditPlant.jsx
@@ -35,9 +35,9 @@ export default function EditPlant() {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4 max-w-md mx-auto">
-      <h1 className="text-headline font-bold font-display">Edit Plant</h1>
+      <h1 className="text-headline leading-heading tracking-heading font-bold font-display">Edit Plant</h1>
       <div className="grid gap-1">
-        <label htmlFor="name" className="font-medium text-label">Name</label>
+        <label htmlFor="name" className="font-medium text-label leading-label tracking-label">Name</label>
         <input
           id="name"
           type="text"
@@ -48,7 +48,7 @@ export default function EditPlant() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="image" className="font-medium text-label">Image URL</label>
+        <label htmlFor="image" className="font-medium text-label leading-label tracking-label">Image URL</label>
         <input
           id="image"
           type="text"
@@ -58,7 +58,7 @@ export default function EditPlant() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="lastWatered" className="font-medium text-label">Last Watered</label>
+        <label htmlFor="lastWatered" className="font-medium text-label leading-label tracking-label">Last Watered</label>
         <input
           id="lastWatered"
           type="date"
@@ -68,7 +68,7 @@ export default function EditPlant() {
         />
       </div>
       <div className="grid gap-1">
-        <label htmlFor="nextWater" className="font-medium text-label">Next Watering</label>
+        <label htmlFor="nextWater" className="font-medium text-label leading-label tracking-label">Next Watering</label>
         <input
           id="nextWater"
           type="date"

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -42,7 +42,7 @@ export function AllGallery() {
 
   return (
     <div>
-      <h1 className="text-headline font-bold font-display mb-4">Gallery</h1>
+      <h1 className="text-headline leading-heading tracking-heading font-bold font-display mb-4">Gallery</h1>
       <Link
         to="/gallery/timeline"
         className="inline-flex items-center gap-1 px-3 py-1 mb-2 bg-accent text-white rounded"
@@ -154,7 +154,7 @@ export default function Gallery() {
 
   return (
     <div className="space-y-4">
-      <h1 className="text-headline font-bold font-display">{plant.name} Gallery</h1>
+      <h1 className="text-headline leading-heading tracking-heading font-bold font-display">{plant.name} Gallery</h1>
 
       {/* desktop grid */}
       <div className="hidden md:grid grid-cols-2 md:grid-cols-3 gap-4">

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -114,7 +114,7 @@ export default function Home() {
     <div className="space-y-4">
       <header className="flex flex-col items-start space-y-3 py-4 px-4 bg-white rounded-xl">
 
-        <h1 className="text-headline font-bold font-display flex items-center">
+        <h1 className="text-headline leading-heading tracking-heading font-bold font-display flex items-center">
           {greeting}
           <GreetingIcon
             data-testid="greeting-icon"
@@ -142,7 +142,7 @@ export default function Home() {
       </div>
       <section>
         <div className="flex items-center justify-between mb-2">
-          <h2 className="font-semibold font-display text-subhead">Watering</h2>
+          <h2 className="font-semibold font-display text-subhead leading-heading tracking-heading">Watering</h2>
           {waterTasks.length > 1 && (
             <Button
               type="button"
@@ -175,7 +175,7 @@ export default function Home() {
       </section>
       <section>
         <div className="flex items-center justify-between mb-2 mt-4">
-          <h2 className="font-semibold font-display text-subhead">Fertilizing</h2>
+          <h2 className="font-semibold font-display text-subhead leading-heading tracking-heading">Fertilizing</h2>
           {fertilizeTasks.length > 1 && (
             <Button
               type="button"

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -46,7 +46,7 @@ export default function MyPlants() {
 
   return (
     <div>
-      <h1 className="text-headline font-bold font-display mb-4">My Plants</h1>
+      <h1 className="text-headline leading-heading tracking-heading font-bold font-display mb-4">My Plants</h1>
 
       <div className="flex justify-center gap-2 mb-4">
         {['Sites', 'Plants', 'Pictures'].map(v => (
@@ -109,7 +109,7 @@ export default function MyPlants() {
           {roomData.map(r => (
             <div key={r.room} className="border rounded-xl p-3 shadow-sm">
               <div className="flex justify-between items-center mb-2">
-                <h2 className="font-semibold text-subhead">{r.room}</h2>
+                <h2 className="font-semibold text-subhead leading-heading tracking-heading">{r.room}</h2>
                 <span className="px-2 py-0.5 text-xs rounded-full bg-green-100 text-green-800">{r.taskCount} tasks</span>
               </div>
               <div className="grid grid-cols-2 gap-1">

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -3,7 +3,7 @@ import { Link } from 'react-router-dom'
 export default function NotFound() {
   return (
     <div className="text-center space-y-4">
-      <h1 className="text-headline font-bold font-display">Page Not Found</h1>
+      <h1 className="text-headline leading-heading tracking-heading font-bold font-display">Page Not Found</h1>
       <p className="text-gray-600">Sorry, we couldn\'t find that page.</p>
       <Link to="/" className="text-green-600 underline">
         Go to Home

--- a/src/pages/PhotoTimeline.jsx
+++ b/src/pages/PhotoTimeline.jsx
@@ -21,7 +21,7 @@ export default function PhotoTimeline() {
     <div className="p-4 space-y-4 text-gray-700 dark:text-gray-200 overflow-y-auto max-h-full">
       {grouped.map(([monthKey, list]) => (
         <div key={monthKey}>
-          <h3 className="mt-4 text-label font-semibold text-gray-500">
+          <h3 className="mt-4 text-label leading-label tracking-label font-semibold text-gray-500">
             {formatMonth(monthKey)}
           </h3>
           <ul className="grid grid-cols-2 md:grid-cols-3 gap-2">

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -209,7 +209,7 @@ export default function PlantDetail() {
             onError={(e) => (e.target.src = "/placeholder.svg")}
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/50 via-transparent to-transparent flex flex-col justify-end p-4 space-y-1">
-            <h1 className="text-headline font-bold font-display text-white">
+            <h1 className="text-headline leading-heading tracking-heading font-bold font-display text-white">
               {plant.name}
             </h1>
             {plant.nickname && (
@@ -484,7 +484,7 @@ export default function PlantDetail() {
                   groupByWeek ? (
                     groupedEvents.map(([monthKey, list]) => (
                       <div key={monthKey}>
-                        <h3 className="sticky top-0 bg-stone mt-4 text-label font-semibold text-gray-500">
+                        <h3 className="sticky top-0 bg-stone mt-4 text-label leading-label tracking-label font-semibold text-gray-500">
                           {groupByWeek
                             ? formatWeek(monthKey)
                             : formatMonth(monthKey)}
@@ -528,7 +528,7 @@ export default function PlantDetail() {
                       const isOpen = openMonths[monthKey];
                       return (
                         <div key={monthKey}>
-                          <h3 className="sticky top-0 bg-stone z-10 mt-4 text-label font-semibold text-gray-500">
+                          <h3 className="sticky top-0 bg-stone z-10 mt-4 text-label leading-label tracking-label font-semibold text-gray-500">
                             <button
                               type="button"
                               className="w-full flex justify-between items-center py-2"
@@ -592,7 +592,7 @@ export default function PlantDetail() {
       </div>
       <div className="space-y-2 mt-4 p-4 shadow-sm bg-stone rounded-xl">
         <div className="flex items-center justify-between">
-          <h2 className="text-subhead font-semibold font-display">Gallery</h2>
+          <h2 className="text-subhead leading-heading tracking-heading font-semibold font-display">Gallery</h2>
           <Link
             to={`/plant/${plant.id}/gallery`}
             className="text-green-600 underline flex items-center gap-1"

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -22,10 +22,10 @@ export default function Settings() {
 
   return (
     <div className="space-y-6 text-gray-700 dark:text-gray-200">
-      <h1 className="text-headline font-bold font-display">Settings</h1>
+      <h1 className="text-headline leading-heading tracking-heading font-bold font-display">Settings</h1>
 
       <section className="space-y-2 p-4 bg-stone dark:bg-gray-800 rounded-xl shadow-sm">
-        <h2 className="text-subhead font-semibold font-display flex items-center gap-2">
+        <h2 className="text-subhead leading-heading tracking-heading font-semibold font-display flex items-center gap-2">
           {theme === 'dark' ? (
             <Moon className="w-5 h-5" aria-hidden="true" />
           ) : (
@@ -39,12 +39,12 @@ export default function Settings() {
       </section>
 
       <section className="space-y-2 p-4 bg-stone dark:bg-gray-800 rounded-xl shadow-sm">
-        <h2 className="text-subhead font-semibold font-display flex items-center gap-2">
+        <h2 className="text-subhead leading-heading tracking-heading font-semibold font-display flex items-center gap-2">
           <MapPin className="w-5 h-5" aria-hidden="true" />
           Weather Location
         </h2>
         <div className="grid gap-1 max-w-xs">
-          <label htmlFor="location" className="font-medium text-label">Location</label>
+          <label htmlFor="location" className="font-medium text-label leading-label tracking-label">Location</label>
           <input
             id="location"
             type="text"
@@ -56,12 +56,12 @@ export default function Settings() {
       </section>
 
       <section className="space-y-2 p-4 bg-stone dark:bg-gray-800 rounded-xl shadow-sm">
-        <h2 className="text-subhead font-semibold font-display flex items-center gap-2">
+        <h2 className="text-subhead leading-heading tracking-heading font-semibold font-display flex items-center gap-2">
           <Clock className="w-5 h-5" aria-hidden="true" />
           Time Zone
         </h2>
         <div className="grid gap-1 max-w-xs">
-          <label htmlFor="timezone" className="font-medium text-label">Time Zone</label>
+          <label htmlFor="timezone" className="font-medium text-label leading-label tracking-label">Time Zone</label>
           <input
             id="timezone"
             type="text"
@@ -73,12 +73,12 @@ export default function Settings() {
       </section>
 
       <section className="space-y-2 p-4 bg-stone dark:bg-gray-800 rounded-xl shadow-sm">
-        <h2 className="text-subhead font-semibold font-display flex items-center gap-2">
+        <h2 className="text-subhead leading-heading tracking-heading font-semibold font-display flex items-center gap-2">
           <Thermometer className="w-5 h-5" aria-hidden="true" />
           Temperature Units
         </h2>
         <div className="grid gap-1 max-w-xs">
-          <label htmlFor="units" className="font-medium text-label">Units</label>
+          <label htmlFor="units" className="font-medium text-label leading-label tracking-label">Units</label>
           <select
             id="units"
             value={units}

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -106,7 +106,7 @@ export default function Tasks() {
           {overdue.length > 0 && (
             <section>
 
-              <h2 className="text-subhead font-bold font-display mb-2">Needs attention</h2>
+              <h2 className="text-subhead leading-heading tracking-heading font-bold font-display mb-2">Needs attention</h2>
               <div className="space-y-4">
 
                 {overdue.map(task => (
@@ -119,7 +119,7 @@ export default function Tasks() {
           {today.length > 0 && (
             <section>
 
-              <h2 className="text-subhead font-bold font-display mb-2">Today</h2>
+              <h2 className="text-subhead leading-heading tracking-heading font-bold font-display mb-2">Today</h2>
               <div className="space-y-4">
 
                 {today.map(task => (
@@ -132,7 +132,7 @@ export default function Tasks() {
           {upcoming.length > 0 && (
             <section>
 
-              <h2 className="text-subhead font-bold font-display mb-2">Upcoming</h2>
+              <h2 className="text-subhead leading-heading tracking-heading font-bold font-display mb-2">Upcoming</h2>
               <div className="space-y-4">
 
                 {upcoming.map(task => (

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -85,7 +85,7 @@ export default function Timeline() {
         const isOpen = openMonths[monthKey]
         return (
           <div key={monthKey}>
-            <h3 className="sticky top-0 bg-stone z-10 mt-4 text-label font-semibold text-gray-500">
+            <h3 className="sticky top-0 bg-stone z-10 mt-4 text-label leading-label tracking-label font-semibold text-gray-500">
               <button
                 type="button"
                 className="w-full flex justify-between items-center py-2"

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -20,6 +20,14 @@ export default {
         label: ['0.875rem', {}],
         detail: ['0.75rem', {}],
       },
+      letterSpacing: {
+        heading: '-0.01em',
+        label: '0.05em',
+      },
+      lineHeight: {
+        heading: '1.25',
+        label: '1.3',
+      },
     },
   },
   plugins: [],


### PR DESCRIPTION
## Summary
- extend Tailwind config with custom `lineHeight` and `letterSpacing` options
- apply new leading and tracking utilities across headings and labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f04958988324aa8737f3228df0f9