### PR TITLE
Replace PlusIcon with PlusCircle

### DIFF
--- a/src/components/AddActionsMenu.jsx
+++ b/src/components/AddActionsMenu.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, useEffect } from 'react'
-import { PlusIcon } from '@radix-ui/react-icons'
+import { PlusCircle } from 'phosphor-react'
 
 export default function AddActionsMenu({
   onAddPlant,
@@ -35,7 +35,7 @@ export default function AddActionsMenu({
         onClick={() => setOpen(o => !o)}
         className="w-12 h-12 bg-primary-green rounded-full flex items-center justify-center text-white"
       >
-        <PlusIcon aria-hidden="true" />
+        <PlusCircle weight="duotone" aria-hidden="true" />
       </button>
       {open && (
         <div


### PR DESCRIPTION
## Summary
- swap AddActionsMenu icon from Radix to Phosphor
- render PlusCircle with duotone weight

## Testing
- `npm test --silent --unsafe-perm`

------
https://chatgpt.com/codex/tasks/task_e_6874f78b5d6883248cf6f181be8c6128