### PR TITLE
Add Profile page tests and UserContext

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -8,6 +8,7 @@ import Add from './pages/Add'
 import Gallery, { AllGallery } from './pages/Gallery'
 import PhotoTimeline from './pages/PhotoTimeline.jsx'
 import Settings from './pages/Settings'
+import Profile from './pages/Profile.jsx'
 import PlantDetail from './pages/PlantDetail'
 import EditPlant from './pages/EditPlant'
 import BottomNav from './components/BottomNav'
@@ -40,6 +41,7 @@ export default function App() {
             <Route path="/add" element={<Add />} />
             <Route path="/gallery" element={<AllGallery />} />
             <Route path="/gallery/timeline" element={<PhotoTimeline />} />
+            <Route path="/profile" element={<Profile />} />
             <Route path="/settings" element={<Settings />} />
             <Route path="/plant/:id" element={<PlantDetail />} />
             <Route path="/plant/:id/edit" element={<EditPlant />} />

--- a/src/UserContext.jsx
+++ b/src/UserContext.jsx
@@ -1,0 +1,27 @@
+import { createContext, useContext, useState, useEffect } from 'react'
+
+const UserContext = createContext()
+
+export function UserProvider({ children }) {
+  const [name, setName] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('userName')
+      if (stored) return stored
+    }
+    return ''
+  })
+
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('userName', name)
+    }
+  }, [name])
+
+  return (
+    <UserContext.Provider value={{ name, setName }}>
+      {children}
+    </UserContext.Provider>
+  )
+}
+
+export const useUser = () => useContext(UserContext)

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -39,7 +39,7 @@ export default function BottomNav({ dueCount = 0 }) {
     { type: 'add' },
     { to: '/tasks', label: 'Care', icon: CheckIcon },
     { to: '/gallery', label: 'Gallery', icon: GalleryIcon },
-    { to: '/settings', label: 'Profile', icon: UserIcon },
+    { to: '/profile', label: 'Profile', icon: UserIcon },
   ]
 
   return (

--- a/src/pages/Profile.jsx
+++ b/src/pages/Profile.jsx
@@ -1,0 +1,49 @@
+import { useUser } from '../UserContext.jsx'
+import { usePlants } from '../PlantContext.jsx'
+import { useMemo } from 'react'
+
+export default function Profile() {
+  const { name } = useUser()
+  const { plants } = usePlants()
+
+  const careLog = useMemo(() => plants.flatMap(p => p.careLog || []), [plants])
+
+  const wateringDates = useMemo(() =>
+    careLog
+      .filter(ev => /water/i.test(ev.type))
+      .map(ev => ev.date)
+      .sort((a, b) => new Date(b) - new Date(a)),
+  [careLog])
+
+  const streak = useMemo(() => {
+    if (wateringDates.length === 0) return 0
+    let count = 1
+    for (let i = 1; i < wateringDates.length; i++) {
+      const diff =
+        (new Date(wateringDates[i - 1]) - new Date(wateringDates[i])) /
+        (1000 * 60 * 60 * 24)
+      if (diff === 1) count++
+      else break
+    }
+    return count
+  }, [wateringDates])
+
+  const recent = useMemo(
+    () => [...careLog].sort((a, b) => new Date(b.date) - new Date(a.date)),
+    [careLog]
+  )
+
+  return (
+    <div>
+      <h1 data-testid="greeting">Hello, {name}</h1>
+      <p>
+        Watering Streak: <span data-testid="streak-count">{streak}</span>
+      </p>
+      <ul data-testid="recent-list">
+        {recent.map((ev, i) => (
+          <li key={i}>{ev.type}: {ev.note}</li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/pages/__tests__/Profile.test.jsx
+++ b/src/pages/__tests__/Profile.test.jsx
@@ -1,0 +1,61 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Profile from '../Profile.jsx'
+import { UserProvider } from '../../UserContext.jsx'
+
+let mockPlants = []
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: () => ({ plants: mockPlants }),
+}))
+
+describe('Profile page', () => {
+  beforeEach(() => {
+    localStorage.setItem('userName', 'Alice')
+    mockPlants = [
+      {
+        id: 1,
+        careLog: [
+          { date: '2025-07-10', type: 'Watered', note: 'note1' },
+          { date: '2025-07-09', type: 'Watered', note: 'note2' },
+          { date: '2025-07-08', type: 'Fertilized', note: 'note3' },
+        ],
+      },
+    ]
+  })
+
+  test('renders stored name in greeting', () => {
+    render(
+      <MemoryRouter>
+        <UserProvider>
+          <Profile />
+        </UserProvider>
+      </MemoryRouter>
+    )
+    expect(screen.getByTestId('greeting')).toHaveTextContent('Alice')
+  })
+
+  test('computes watering streak correctly', () => {
+    render(
+      <MemoryRouter>
+        <UserProvider>
+          <Profile />
+        </UserProvider>
+      </MemoryRouter>
+    )
+    expect(screen.getByTestId('streak-count').textContent).toBe('2')
+  })
+
+  test('shows notes in reverse chronological order', () => {
+    render(
+      <MemoryRouter>
+        <UserProvider>
+          <Profile />
+        </UserProvider>
+      </MemoryRouter>
+    )
+    const items = screen.getAllByRole('listitem')
+    expect(items[0]).toHaveTextContent('note1')
+    expect(items[1]).toHaveTextContent('note2')
+    expect(items[2]).toHaveTextContent('note3')
+  })
+})


### PR DESCRIPTION
## Summary
- create `UserContext` with localStorage-backed name
- add new `Profile` page showing watering streak and recent notes
- expose `/profile` route and update bottom nav
- add Jest tests covering greeting, watering streak, and log order

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6874f7708c048324808d4924abe92cb5