### PR TITLE
Add hover overlay icons in gallery views

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,7 +1,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { Link, useParams } from 'react-router-dom'
-import { Calendar } from 'phosphor-react'
+import { Calendar, MagnifyingGlassPlus } from 'phosphor-react'
 import { usePlants } from '../PlantContext.jsx'
 import Lightbox from '../components/Lightbox.jsx'
 import FadeInImage from '../components/FadeInImage.jsx'
@@ -57,16 +57,19 @@ export function AllGallery() {
             onClick={() => setIndex(i)}
             className="relative group focus:outline-none"
           >
-            <FadeInImage
-              src={src}
-              alt={alts[i] || `Plant ${i + 1}`}
-              loading="lazy"
-              className="w-full h-32 object-cover rounded transition-transform transform hover:scale-105 active:scale-105"
-              onError={e => (e.target.src = '/placeholder.svg')}
-            />
-            <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">
-              {alts[i]}
-            </span>
+          <FadeInImage
+            src={src}
+            alt={alts[i] || `Plant ${i + 1}`}
+            loading="lazy"
+            className="w-full h-32 object-cover rounded transition-transform transform hover:scale-105 active:scale-105"
+            onError={e => (e.target.src = '/placeholder.svg')}
+          />
+          <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity">
+            <MagnifyingGlassPlus className="w-6 h-6 text-white" aria-hidden="true" />
+          </span>
+          <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">
+            {alts[i]}
+          </span>
           </Button>
         ))}
       </div>
@@ -201,6 +204,9 @@ export default function Gallery() {
                 className="w-full h-full object-cover transition-transform transform hover:scale-105 active:scale-105"
                 onError={e => (e.target.src = '/placeholder.svg')}
               />
+              <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity">
+                <MagnifyingGlassPlus className="w-6 h-6 text-white" aria-hidden="true" />
+              </span>
 
               <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">
                 {plant.name}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -1,7 +1,7 @@
 import { useParams, Link } from "react-router-dom";
 import { useState, useRef, useMemo, useEffect } from "react";
 import { usePlants } from "../PlantContext.jsx";
-import { Drop } from "phosphor-react";
+import { Drop, Trash } from "phosphor-react";
 import actionIcons from "../components/ActionIcons.jsx";
 import LogModal from "../components/LogModal.jsx";
 import CareGraph from "../components/CareGraph.jsx";
@@ -561,20 +561,21 @@ export default function PlantDetail() {
           {(plant.photos || []).map((ph, i) => {
             const src = typeof ph === "object" ? ph.src : ph;
             return (
-              <div key={i} className="relative">
+              <Button
+                key={i}
+                onClick={() => removePhoto(plant.id, i)}
+                className="relative group w-full"
+              >
                 <img
                   src={src}
                   alt={`${plant.name} ${i}`}
                   className="object-cover w-full h-24 rounded"
                   onError={(e) => (e.target.src = "/placeholder.svg")}
                 />
-                <Button
-                  className="absolute top-1 right-1 bg-white bg-opacity-70 rounded px-1 text-xs"
-                  onClick={() => removePhoto(plant.id, i)}
-                >
-                  ✕
-                </Button>
-              </div>
+                <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity">
+                  <Trash className="w-6 h-6 text-white" aria-hidden="true" />
+                </span>
+              </Button>
             );
           })}
         </div>

--- a/src/pages/__tests__/AllGallery.test.jsx
+++ b/src/pages/__tests__/AllGallery.test.jsx
@@ -64,8 +64,12 @@ test('overlay displays plant name on hover and focus', () => {
   expect(button).not.toBeNull()
 
   fireEvent.mouseOver(button)
+  const svgHover = button.querySelector('svg')
+  expect(svgHover).toBeInTheDocument()
   expect(within(button).getByText(plant.name)).toBeInTheDocument()
 
   fireEvent.focus(button)
+  const svgFocus = button.querySelector('svg')
+  expect(svgFocus).toBeInTheDocument()
   expect(within(button).getByText(plant.name)).toBeInTheDocument()
 })

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -100,3 +100,24 @@ test('view gallery link shows photo count', () => {
   expect(link).toHaveAttribute('href', `/plant/${plant.id}/gallery`)
   expect(link).toHaveTextContent(String(plant.photos.length))
 })
+
+test('gallery preview shows trash icon on hover', () => {
+  const plant = plants[0]
+  render(
+    <PlantProvider>
+      <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+        <Routes>
+          <Route path="/plant/:id" element={<PlantDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </PlantProvider>
+  )
+
+  const img = screen.getByAltText(`${plant.name} 0`)
+  const button = img.closest('button')
+  expect(button).not.toBeNull()
+
+  fireEvent.mouseOver(button)
+  const svg = button.querySelector('svg')
+  expect(svg).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- show a magnifying glass overlay icon on gallery photos
- show a trash icon when removing plant photos
- update gallery overlay tests for icon visibility
- test trash icon overlay in `PlantDetail`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f75a8fd4832493980365bfa3e74f