### PR TITLE
Update gallery image wrappers

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -55,13 +55,13 @@ export function AllGallery() {
           <Button
             key={i}
             onClick={() => setIndex(i)}
-            className="relative group focus:outline-none"
+            className="relative group aspect-square overflow-hidden focus:outline-none"
           >
             <FadeInImage
               src={src}
               alt={alts[i] || `Plant ${i + 1}`}
               loading="lazy"
-              className="w-full h-32 object-cover rounded transition-transform transform hover:scale-105 active:scale-105"
+              className="w-full h-full object-cover rounded transition-transform transform hover:scale-105 active:scale-105"
               onError={e => (e.target.src = '/placeholder.svg')}
             />
             <span className="absolute inset-0 flex items-center justify-center bg-black/60 text-white text-sm opacity-0 group-hover:opacity-100 group-focus:opacity-100 group-active:opacity-100 transition-opacity">

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -561,11 +561,11 @@ export default function PlantDetail() {
           {(plant.photos || []).map((ph, i) => {
             const src = typeof ph === "object" ? ph.src : ph;
             return (
-              <div key={i} className="relative">
+              <div key={i} className="relative aspect-square overflow-hidden">
                 <img
                   src={src}
                   alt={`${plant.name} ${i}`}
-                  className="object-cover w-full h-24 rounded"
+                  className="object-cover w-full h-full rounded"
                   onError={(e) => (e.target.src = "/placeholder.svg")}
                 />
                 <Button


### PR DESCRIPTION
## Summary
- use Tailwind aspect utilities for AllGallery images
- ensure PlantDetail thumbnail grid uses aspect utilities
- keep images full within wrappers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6874f7592df88324929925d5133889a7