### PR TITLE
Hide bottom nav labels until active

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -67,7 +67,7 @@ export default function BottomNav({ dueCount = 0 }) {
               return (
                 <>
                   <Icon active={isActive} className={`mb-1 ${isActive ? 'nav-active' : ''}`} />
-                  <span className="relative">
+                  <span className={`relative ${isActive ? 'block' : 'hidden'}`}>
                     {item.label}
                     {item.to === '/tasks' && dueCount > 0 && (
                       <span className="absolute -top-2 -right-3 bg-red-600 text-white rounded-full text-[10px] px-1">

--- a/src/components/__tests__/BottomNav.test.jsx
+++ b/src/components/__tests__/BottomNav.test.jsx
@@ -75,3 +75,19 @@ test('shows dynamic tasks badge', () => {
   const badge = tasksLink.querySelector('span span')
   expect(badge).toHaveTextContent('3')
 })
+
+test('inactive labels are hidden and active label visible', () => {
+  const { container } = render(
+    <MemoryRouter initialEntries={["/gallery"]}>
+      <BottomNav />
+    </MemoryRouter>
+  )
+  const activeLink = container.querySelector('a[href="/gallery"]')
+  const activeLabel = activeLink.querySelector('span')
+  expect(activeLabel).toHaveClass('block')
+  expect(activeLabel).not.toHaveClass('hidden')
+
+  const homeLink = container.querySelector('a[href="/"]')
+  const homeLabel = homeLink.querySelector('span')
+  expect(homeLabel).toHaveClass('hidden')
+})

--- a/src/pages/__tests__/AllGallery.test.jsx
+++ b/src/pages/__tests__/AllGallery.test.jsx
@@ -16,7 +16,8 @@ test('clicking add photos button opens file dialog', () => {
   const input = container.querySelector('input[type="file"]')
   const clickSpy = jest.spyOn(input, 'click').mockImplementation(() => {})
 
-  fireEvent.click(screen.getByRole('button', { name: /add photos/i }))
+  const buttons = screen.getAllByRole('button', { name: /add photos/i })
+  fireEvent.click(buttons[0])
   expect(clickSpy).toHaveBeenCalled()
 })
 


### PR DESCRIPTION
## Summary
- hide nav labels until active for screen clarity
- check visibility state in BottomNav tests
- resolve AllGallery test query to handle duplicate buttons

## Testing
- `npm test -- -i`

------
https://chatgpt.com/codex/tasks/task_e_6874fc46d75483249eb54e82c35bb6ad