### PR TITLE
Fix AllGallery button selection

### DIFF
--- a/src/pages/__tests__/AllGallery.test.jsx
+++ b/src/pages/__tests__/AllGallery.test.jsx
@@ -16,7 +16,9 @@ test('clicking add photos button opens file dialog', () => {
   const input = container.querySelector('input[type="file"]')
   const clickSpy = jest.spyOn(input, 'click').mockImplementation(() => {})
 
-  fireEvent.click(screen.getByRole('button', { name: /add photos/i }))
+  fireEvent.click(
+    screen.getAllByRole('button', { name: /add photos/i })[0]
+  )
   expect(clickSpy).toHaveBeenCalled()
 })
 


### PR DESCRIPTION
## Summary
- select the first 'Add Photos' button in AllGallery tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6874fcd5beb0832487555825d2fd8820