### PR TITLE
Add aria-label to BottomNav

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -43,7 +43,10 @@ export default function BottomNav({ dueCount = 0 }) {
   ]
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 border-t bg-white dark:bg-gray-800 flex justify-around py-2">
+    <nav
+      aria-label="Bottom navigation"
+      className="fixed bottom-0 left-0 right-0 border-t bg-white dark:bg-gray-800 flex justify-around py-2"
+    >
 
       {items.map(item =>
         item.type === 'add' ? (

--- a/src/components/__tests__/BottomNav.test.jsx
+++ b/src/components/__tests__/BottomNav.test.jsx
@@ -75,3 +75,13 @@ test('shows dynamic tasks badge', () => {
   const badge = tasksLink.querySelector('span span')
   expect(badge).toHaveTextContent('3')
 })
+
+test('nav element has accessible label', () => {
+  const { container } = render(
+    <MemoryRouter>
+      <BottomNav />
+    </MemoryRouter>
+  )
+  const nav = container.querySelector('nav')
+  expect(nav).toHaveAttribute('aria-label', 'Bottom navigation')
+})


### PR DESCRIPTION
## Summary
- improve navigation accessibility with `aria-label`
- test that BottomNav includes the accessible label

## Testing
- `npx jest src/components/__tests__/BottomNav.test.jsx --runInBand`
- `npm test --silent` *(fails: clicking add photos button opens file dialog)*

------
https://chatgpt.com/codex/tasks/task_e_6874fc45134083248bef578b7cf03d8c