### PR TITLE
Remove pretest hook

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,15 @@ The weather feature uses `VITE_WEATHER_API_KEY`, exposed to the frontend via Vit
 
 ## 🧪 Running Tests
 
-Install dependencies before testing:
+Before running the test suite, make sure dependencies are installed:
 
 ```bash
 npm install
+```
+
+Then run the tests with:
+
+```bash
 npm test
 ```
 

--- a/package.json
+++ b/package.json
@@ -7,7 +7,6 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "pretest": "npm install",
     "test": "jest",
     "lint": "eslint \"src/**/*.{js,jsx}\"",
     "lint:fix": "eslint \"src/**/*.{js,jsx}\" --fix"


### PR DESCRIPTION
## Summary
- remove `pretest` script from package.json
- document manual install step before running tests

## Testing
- `npm test` *(fails: overlay displays plant name on hover and focus, etc.)*

------
https://chatgpt.com/codex/tasks/task_e_6875022a5858832489a57a03d9102a26