### PR TITLE
Fix mismatched button closing tag

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -578,7 +578,7 @@ export default function PlantDetail() {
                 <span className="pointer-events-none absolute inset-0 flex items-center justify-center opacity-0 group-hover:opacity-100 group-focus:opacity-100 transition-opacity">
                   <Trash className="w-6 h-6 text-white" aria-hidden="true" />
                 </span>
-              </div>
+              </Button>
             );
           })}
         </div>


### PR DESCRIPTION
## Summary
- fix closing tag in `PlantDetail` photo remove button

## Testing
- `npm run lint` *(fails: no-unused-vars, react/no-unescaped-entities, etc.)*
- `npm test` *(fails: `overlay displays plant name on hover and focus` in AllGallery.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68750635fdd08324a40a4df8d9bf3394