### PR TITLE
Default to light mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Lisa includes a web app manifest and service worker so you can install it on mob
 
 ## Dark Mode
 
-Lisa ships with built‑in light and dark themes. The app automatically detects your preference using the `prefers-color-scheme` media query. A toggle on the **Settings** page lets you switch modes manually, and the choice is stored locally so it persists across visits.
+Lisa ships with built‑in light and dark themes. The app now defaults to light mode regardless of system settings. A toggle on the **Settings** page lets you switch modes manually, and the choice is stored locally so it persists across visits.
 
 ## useSwipe Hook
 

--- a/src/ThemeContext.jsx
+++ b/src/ThemeContext.jsx
@@ -8,9 +8,6 @@ export function ThemeProvider({ children }) {
       const stored = localStorage.getItem('theme')
       if (stored) return stored
     }
-    if (typeof window !== 'undefined' && window.matchMedia('(prefers-color-scheme: dark)').matches) {
-      return 'dark'
-    }
     return 'light'
   })
 


### PR DESCRIPTION
## Summary
- set the initial theme in `ThemeContext` to always start in light mode
- update documentation regarding default theme

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876e03dd36c8324858ae3c0426cdacc