### PR TITLE
Remove note modal when completing tasks

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -11,7 +11,6 @@ import useSwipe from '../hooks/useSwipe.js'
 
 
 import { getWateringInfo } from '../utils/watering.js'
-import NoteModal from './NoteModal.jsx'
 import Badge from './Badge.jsx'
 
 export default function TaskCard({
@@ -27,7 +26,6 @@ export default function TaskCard({
   const { Toast, showToast } = useToast()
   const [checked, setChecked] = useState(false)
   const isChecked = checked || completed
-  const [showNote, setShowNote] = useState(false)
 
   const handleKeyDown = e => {
     if (e.key === 'ArrowRight') {
@@ -48,29 +46,16 @@ export default function TaskCard({
   const handleComplete = () => {
     if (onComplete) {
       onComplete(task)
-      showToast(toastMsg)
-      setChecked(true)
-      setTimeout(() => setChecked(false), 400)
     } else {
-      setShowNote(true)
+      if (task.type === 'Water') {
+        markWatered(task.plantId, '')
+      } else if (task.type === 'Fertilize') {
+        markFertilized(task.plantId, '')
+      }
     }
-  }
-
-  const handleSaveNote = note => {
-    if (task.type === 'Water') {
-      markWatered(task.plantId, note)
-      showToast(toastMsg)
-    } else if (task.type === 'Fertilize') {
-      markFertilized(task.plantId, note)
-      showToast(toastMsg)
-    }
+    showToast(toastMsg)
     setChecked(true)
     setTimeout(() => setChecked(false), 400)
-    setShowNote(false)
-  }
-
-  const handleCancelNote = () => {
-    handleSaveNote('')
   }
 
   const { dx: deltaX, start, move, end } = useSwipe(diff => {
@@ -218,9 +203,6 @@ export default function TaskCard({
         </div>
       )}
     </div>
-    {showNote && (
-      <NoteModal label="Optional note" onSave={handleSaveNote} onCancel={handleCancelNote} />
-    )}
     </>
   )
 }

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -184,13 +184,11 @@ test('mark as done does not navigate', () => {
     </MemoryRouter>
   )
   fireEvent.click(screen.getByRole('checkbox'))
-  const dialog = screen.getByRole('dialog', { name: /optional note/i })
-  fireEvent.change(dialog.querySelector('textarea'), { target: { value: '' } })
-  fireEvent.click(screen.getByText('Save'))
+  expect(markWatered).toHaveBeenCalledWith(1, '')
   expect(screen.queryByText('Plant Page')).not.toBeInTheDocument()
 })
 
-test('completing with note calls log function', () => {
+test('completing task logs watering', () => {
   render(
     <MemoryRouter>
       <BaseCard variant="task">
@@ -199,10 +197,7 @@ test('completing with note calls log function', () => {
     </MemoryRouter>
   )
   fireEvent.click(screen.getByRole('checkbox'))
-  const dialog = screen.getByRole('dialog', { name: /optional note/i })
-  fireEvent.change(dialog.querySelector('textarea'), { target: { value: 'hello' } })
-  fireEvent.click(screen.getByText('Save'))
-  expect(markWatered).toHaveBeenCalledWith(1, 'hello')
+  expect(markWatered).toHaveBeenCalledWith(1, '')
 })
 
 test('clicking card adds ripple effect', () => {
@@ -301,9 +296,6 @@ test('shows toast on completion', () => {
     </MemoryRouter>
   )
   fireEvent.click(screen.getByRole('checkbox'))
-  const dialog = screen.getByRole('dialog', { name: /optional note/i })
-  fireEvent.change(dialog.querySelector('textarea'), { target: { value: '' } })
-  fireEvent.click(screen.getByText('Save'))
   expect(screen.getByText('Watered Monstera 🌿')).toBeInTheDocument()
   act(() => {
     jest.runAllTimers()


### PR DESCRIPTION
## Summary
- remove `NoteModal` from TaskCard
- automatically mark tasks complete without prompting for a note
- update tests for new behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876eb769b008324acf2ab756c8b7760