### PR TITLE
Update task card styling

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -89,7 +89,7 @@ export default function TaskCard({
       }}
 
 
-      className={`relative flex items-center gap-3 p-4 rounded-2xl overflow-hidden transition-transform duration-150 active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500${completed ? ' bg-gray-100 dark:bg-gray-800 opacity-50' : ' bg-sage dark:bg-gray-700 ring-2 ring-accent hover:bg-sage/80'}${urgent ? ' ring-green-300 dark:ring-green-400' : ''}${overdue ? ' ring-orange-300' : ''}`}
+      className={`relative flex items-center gap-3 px-4 py-3 rounded-2xl overflow-hidden shadow-sm transition-transform duration-150 active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500${completed ? ' bg-gray-100 dark:bg-gray-800 opacity-50 ring-1 ring-neutral-200' : ' bg-white dark:bg-gray-700 ring-1 ring-neutral-200 hover:bg-gray-50 dark:hover:bg-gray-600'}${urgent ? ' ring-green-300 dark:ring-green-400' : ''}${overdue ? ' ring-orange-300' : ''}`}
 
 
       onTouchMove={move}

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -75,8 +75,8 @@ test('incomplete tasks show alert style', () => {
     </PlantProvider>
   )
   const wrapper = container.querySelector('[data-testid="task-card"]')
-  expect(wrapper).toHaveClass('bg-sage')
-  expect(wrapper).toHaveClass('ring-accent')
+  expect(wrapper).toHaveClass('bg-white')
+  expect(wrapper).toHaveClass('ring-neutral-200')
 })
 
 test('applies highlight when urgent', () => {
@@ -88,7 +88,6 @@ test('applies highlight when urgent', () => {
     </MemoryRouter>
   )
   const wrapper = container.querySelector('[data-testid="task-card"]')
-  expect(wrapper).toHaveClass('ring-2')
   expect(wrapper).toHaveClass('ring-green-300')
   expect(wrapper).toHaveClass('dark:ring-green-400')
 })
@@ -102,7 +101,6 @@ test('applies overdue styling', () => {
     </MemoryRouter>
   )
   const wrapper = container.querySelector('[data-testid="task-card"]')
-  expect(wrapper).toHaveClass('ring-2')
   expect(wrapper).toHaveClass('ring-orange-300')
   const badge = screen.getByTestId('overdue-badge')
   expect(badge).toBeInTheDocument()

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`matches snapshot in dark mode 1`] = `
 >
   <div
     aria-label="Task card for Monstera"
-    class="relative flex items-center gap-3 p-4 rounded-2xl overflow-hidden transition-transform duration-150 active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500 bg-sage dark:bg-gray-700 ring-2 ring-accent hover:bg-sage/80 ring-green-300 dark:ring-green-400"
+    class="relative flex items-center gap-3 px-4 py-3 rounded-2xl overflow-hidden shadow-sm transition-transform duration-150 active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500 bg-white dark:bg-gray-700 ring-1 ring-neutral-200 hover:bg-gray-50 dark:hover:bg-gray-600 ring-green-300 dark:ring-green-400"
     data-testid="task-card"
     style="transform: translateX(0px); transition: transform 0.2s;"
     tabindex="0"


### PR DESCRIPTION
## Summary
- adjust TaskCard wrapper styling
- update tests for new classes

## Testing
- `npm test --silent -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6876ee367df88324aae457ba56fbc4c4