### PR TITLE
Add safe area padding to bottom nav

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -27,7 +27,7 @@ export default function BottomNav() {
   ]
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 border-t dark:border-gray-600 bg-white dark:bg-gray-700 flex justify-around py-2">
+    <nav className="fixed bottom-0 left-0 right-0 border-t dark:border-gray-600 bg-white dark:bg-gray-700 flex justify-around pt-2 pb-safe">
       {items.map(({ to, label, icon: Icon }) => (
         <NavLink
           key={to}


### PR DESCRIPTION
## Summary
- keep bottom navigation away from screen edges using Tailwind's `pb-safe`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6876ee2e09b88324b6840755f9ce5fc8