### PR TITLE
Enhance task completion swipe

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -64,6 +64,8 @@ export default function TaskCard({
     }
   })
 
+  const swipeProgress = Math.max(0, Math.min(deltaX / 80, 1))
+
   return (
     <>
     <div
@@ -102,6 +104,21 @@ export default function TaskCard({
         transition: deltaX === 0 ? 'transform 0.2s' : 'none',
       }}
     >
+      {deltaX > 0 && !isChecked && (
+        <div
+          className="absolute inset-0 flex items-center rounded-2xl pointer-events-none"
+          style={{
+            backgroundColor: `rgba(74,222,128,${0.2 * swipeProgress})`,
+            opacity: swipeProgress,
+          }}
+        >
+          <CheckCircle
+            aria-hidden="true"
+            className="w-8 h-8 text-healthy-600 swipe-check"
+            style={{ marginLeft: `${8 + Math.min(deltaX, 80) / 2}px` }}
+          />
+        </div>
+      )}
       <Link
         to={`/plant/${task.plantId}`}
         className="flex items-center flex-1 gap-3"
@@ -111,9 +128,23 @@ export default function TaskCard({
           alt={task.plantName}
           className={`${compact ? 'w-12 h-12' : 'w-16 h-16'} object-cover rounded-md`}
         />
-        <div className="flex-1">
-          <p className={`${compact ? '' : 'text-lg'} font-bold font-headline`}>{task.plantName}</p>
-          <p className={`${compact ? 'text-sm' : 'text-base'} font-body`}>
+        <div className="flex-1 min-w-0">
+          <div className="flex items-center justify-between gap-2">
+            <p
+              className={`${compact ? '' : 'text-lg'} font-bold font-headline truncate`}
+            >
+              {task.plantName}
+            </p>
+            {Icon && (
+              <Icon
+                aria-hidden="true"
+                className="w-5 h-5 text-gray-500 dark:text-gray-400 shrink-0"
+              />
+            )}
+          </div>
+          <p
+            className={`${compact ? 'text-sm' : 'text-base'} font-body flex flex-wrap items-center gap-1 text-gray-600 dark:text-gray-300`}
+          >
             <Badge
               colorClass={`text-xs ${
                 task.type === 'Water'
@@ -135,12 +166,16 @@ export default function TaskCard({
                 ? 'To Fertilize'
                 : task.type}
             </Badge>
+            {daysSince != null && (
+              <span className="text-xs text-gray-500">
+                · {daysSince} {daysSince === 1 ? 'day' : 'days'} since care
+              </span>
+            )}
           </p>
           {!compact && task.reason && (
-            <p className="text-sm text-gray-500 font-body">{task.reason}</p>
+            <p className="text-xs text-gray-500 font-body">{task.reason}</p>
           )}
         </div>
-        {Icon && <Icon aria-hidden="true" />}
       </Link>
       <button
         type="button"

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -21,54 +21,67 @@ exports[`matches snapshot in dark mode 1`] = `
         src="https://images.pexels.com/photos/5699660/pexels-photo-5699660.jpeg"
       />
       <div
-        class="flex-1"
+        class="flex-1 min-w-0"
       >
-        <p
-          class="text-lg font-bold font-headline"
+        <div
+          class="flex items-center justify-between gap-2"
         >
-          Monstera
-        </p>
+          <p
+            class="text-lg font-bold font-headline truncate"
+          >
+            Monstera
+          </p>
+          <svg
+            aria-hidden="true"
+            class="w-5 h-5 text-gray-500 dark:text-gray-400 shrink-0"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 256 256"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              fill="none"
+              height="256"
+              width="256"
+            />
+            <path
+              d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="16"
+            />
+            <path
+              d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="16"
+            />
+          </svg>
+        </div>
         <p
-          class="text-base font-body"
+          class="text-base font-body flex flex-wrap items-center gap-1 text-gray-600 dark:text-gray-300"
         >
           <span
             class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs bg-water-200 text-water-800"
           >
             To Water
           </span>
+          <span
+            class="text-xs text-gray-500"
+          >
+            · 
+            9
+             
+            days
+             since care
+          </span>
         </p>
       </div>
-      <svg
-        aria-hidden="true"
-        class="w-6 h-6 text-gray-500 dark:text-gray-400"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 256 256"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <rect
-          fill="none"
-          height="256"
-          width="256"
-        />
-        <path
-          d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-        <path
-          d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-      </svg>
     </a>
     <button
       aria-label="Mark complete"

--- a/src/index.css
+++ b/src/index.css
@@ -81,6 +81,21 @@ body {
   animation: pop 0.3s ease-out;
 }
 
+@keyframes fly-in {
+  from {
+    transform: translateX(-20px) scale(0.8);
+    opacity: 0;
+  }
+  to {
+    transform: translateX(0) scale(1);
+    opacity: 1;
+  }
+}
+
+.swipe-check {
+  animation: fly-in 0.3s ease-out;
+}
+
 @keyframes bloom {
   from {
     transform: scale(0.5);


### PR DESCRIPTION
## Summary
- show green overlay and checkmark when swiping right on a task card
- animate the checkmark with a new `fly-in` effect
- refine task card layout with name truncation and days-since info

## Testing
- `npm test -- -u`


------
https://chatgpt.com/codex/tasks/task_e_6876f1805b048324a6235c19df072a5e