### PR TITLE
Add UX tweaks to BottomNav

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -5,6 +5,7 @@ import {
   CalendarIcon,
   PersonIcon,
 } from '@radix-ui/react-icons'
+import { createRipple } from '../utils/interactions.js'
 
 const iconProps = {
   className: 'w-6 h-6',
@@ -27,17 +28,21 @@ export default function BottomNav() {
   ]
 
   return (
-    <nav className="fixed bottom-0 left-0 right-0 border-t dark:border-gray-600 bg-white dark:bg-gray-700 flex justify-around pt-2 pb-safe">
+    <nav
+      aria-label="Bottom navigation"
+      className="fixed bottom-0 left-0 right-0 border-t dark:border-gray-600 bg-white dark:bg-gray-700 flex justify-around pt-2 pb-safe"
+    >
       {items.map(({ to, label, icon: Icon }) => (
         <NavLink
           key={to}
           to={to}
+          onPointerDown={createRipple}
           className={({ isActive }) =>
-            `flex flex-col items-center text-xs transition-transform duration-150 ${isActive ? 'text-accent scale-110' : 'text-gray-500'}`
+            `relative flex flex-col items-center text-xs transition-transform duration-150 py-3 overflow-hidden border-t-2 ${isActive ? 'text-accent scale-110 border-accent bg-accent/10' : 'text-gray-500 border-transparent'}`
           }
         >
           <Icon className="mb-1 transition-colors duration-150" aria-hidden="true" />
-          {label}
+          <span className="hidden sm:block">{label}</span>
         </NavLink>
       ))}
     </nav>


### PR DESCRIPTION
## Summary
- tweak BottomNav accessibility and feedback
- show visual active state with highlight
- enlarge tap targets and hide labels on mobile
- add ripple effect on nav button presses

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6876f444b7e88324862be424c6e23179