### PR TITLE
Improve timeline UI and refine FAB handling

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -16,8 +16,8 @@ import NotFound from './pages/NotFound'
 export default function App() {
   const location = useLocation()
   const nodeRef = useRef(null)
-  const hideFabRoutes = ['/tasks']
-  const showFab = !hideFabRoutes.includes(location.pathname)
+  const hideFabRoutes = ['/tasks', '/plant']
+  const showFab = !hideFabRoutes.some(r => location.pathname.startsWith(r))
   return (
     <div id="main-content" className="pb-24 px-4 pt-8 font-body overflow-hidden">{/* bottom padding for nav */}
 

--- a/src/__tests__/FabVisibility.test.jsx
+++ b/src/__tests__/FabVisibility.test.jsx
@@ -24,12 +24,10 @@ const routesWithFab = [
   '/add',
   '/profile',
   '/timeline',
-  '/plant/1',
-  '/plant/1/edit',
   '/nonexistent',
 ]
 
-const routesWithoutFab = ['/tasks']
+const routesWithoutFab = ['/tasks', '/plant/1', '/plant/1/edit']
 
 describe('Floating Action Button visibility', () => {
   test.each(routesWithFab)('shows FAB on %s', route => {

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -9,6 +9,7 @@ import {
   Gauge,
   CalendarCheck,
   Flower,
+  DotsThreeVertical,
 } from 'phosphor-react'
 
 import { PlusIcon } from '@radix-ui/react-icons'
@@ -21,7 +22,7 @@ import NoteModal from '../components/NoteModal.jsx'
 import useToast from "../hooks/useToast.jsx"
 import Badge from '../components/Badge.jsx'
 
-import { formatMonth } from '../utils/date.js'
+import { formatMonth, formatDate } from '../utils/date.js'
 
 import { buildEvents, groupEventsByMonth } from '../utils/events.js'
 
@@ -129,37 +130,70 @@ export default function PlantDetail() {
     <div className="space-y-2 relative text-left">
       <Toast />
       <div className="space-y-4">
-        <div className="rounded-xl shadow-md bg-green-50 overflow-hidden">
-          <div className="relative">
-            <img
-              src={plant.image}
-              alt={plant.name}
-              loading="lazy"
-              className="w-full h-64 object-cover"
-            />
-            <div className="absolute inset-x-0 bottom-0 p-3 bg-gradient-to-t from-black/60 via-black/30 to-transparent text-white text-left">
-              <h1 className="text-3xl font-bold font-headline">{plant.name}</h1>
-              {plant.nickname && <p className="text-gray-200">{plant.nickname}</p>}
-            </div>
+        <div className="rounded-xl shadow-md overflow-hidden relative">
+          <img
+            src={plant.image}
+            alt={plant.name}
+            loading="lazy"
+            className="w-full h-64 object-cover"
+          />
+          <button
+            type="button"
+            onClick={() => setShowActionsMenu(v => !v)}
+            className="absolute top-2 right-2 p-1 bg-white rounded-full shadow"
+          >
+            <DotsThreeVertical className="w-5 h-5 text-gray-700" aria-hidden="true" />
+            <span className="sr-only">More options</span>
+          </button>
+          {showActionsMenu && (
+            <ul className="absolute top-10 right-2 bg-white border rounded shadow z-10">
+              <li>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowActionsMenu(false)
+                    handleEdit()
+                  }}
+                  className="block px-3 py-1 text-sm text-left w-full hover:bg-gray-100"
+                >
+                  Edit Plant
+                </button>
+              </li>
+              <li>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setShowActionsMenu(false)
+                    handleAddPhoto()
+                  }}
+                  className="block px-3 py-1 text-sm text-left w-full hover:bg-gray-100"
+                >
+                  Add Photo
+                </button>
+              </li>
+            </ul>
+          )}
+          <div className="absolute inset-x-0 bottom-0 p-3 bg-gradient-to-t from-black/60 via-black/30 to-transparent text-white text-left">
+            <h1 className="text-3xl font-bold font-headline">{plant.name}</h1>
+            {plant.nickname && <p className="text-gray-200">{plant.nickname}</p>}
           </div>
-          <div className="p-3 flex flex-wrap gap-2 text-base">
-            <Badge Icon={Drop} colorClass="bg-blue-100 text-blue-800">
-              <Drop className="w-4 h-4" />
-
-              <span className="font-semibold">Last watered:</span>
-              <span>{plant.lastWatered}</span>
+        </div>
+        <div className="rounded-xl shadow-md bg-green-50 p-3 flex flex-wrap gap-2 text-base">
+          <Badge Icon={Drop} colorClass="bg-blue-100 text-blue-800">
+            <Drop className="w-4 h-4" />
+            <span className="font-semibold">Last watered:</span>
+            <span>{plant.lastWatered}</span>
+          </Badge>
+          <Badge Icon={CalendarCheck} colorClass="bg-green-100 text-green-800">
+            <span className="font-semibold">Next watering:</span>
+            <span>{plant.nextWater}</span>
+          </Badge>
+          {plant.lastFertilized && (
+            <Badge Icon={Flower} colorClass="bg-orange-100 text-orange-800">
+              <span className="font-semibold">Last fertilized:</span>
+              <span>{plant.lastFertilized}</span>
             </Badge>
-            <Badge Icon={CalendarCheck} colorClass="bg-green-100 text-green-800">
-              <span className="font-semibold">Next watering:</span>
-              <span>{plant.nextWater}</span>
-            </Badge>
-            {plant.lastFertilized && (
-              <Badge Icon={Flower} colorClass="bg-orange-100 text-orange-800">
-                <span className="font-semibold">Last fertilized:</span>
-                <span>{plant.lastFertilized}</span>
-              </Badge>
-            )}
-          </div>
+          )}
         </div>
         <div className="flex gap-2 mt-3 items-center">
           <button
@@ -186,43 +220,6 @@ export default function PlantDetail() {
             <Note className="w-4 h-4" aria-hidden="true" />
             Add Note
           </button>
-          <div className="relative">
-            <button
-              type="button"
-              onClick={() => setShowActionsMenu(v => !v)}
-              className="px-3 py-1 rounded-full bg-gray-200 text-gray-700 text-sm font-medium flex items-center gap-1"
-            >
-              More…
-            </button>
-            {showActionsMenu && (
-              <ul className="absolute right-0 mt-1 bg-white border rounded shadow z-10">
-                <li>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setShowActionsMenu(false)
-                      handleEdit()
-                    }}
-                    className="block px-3 py-1 text-sm text-left w-full hover:bg-gray-100"
-                  >
-                    Edit Plant
-                  </button>
-                </li>
-                <li>
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setShowActionsMenu(false)
-                      handleAddPhoto()
-                    }}
-                    className="block px-3 py-1 text-sm text-left w-full hover:bg-gray-100"
-                  >
-                    Add Photo
-                  </button>
-                </li>
-              </ul>
-            )}
-          </div>
         </div>
 
         <div className="space-y-1">
@@ -383,8 +380,9 @@ export default function PlantDetail() {
                         >
                           {Icon && <Icon className={`w-4 h-4 ${iconColors[e.type]}`} />}
                         </div>
-                        <p className="text-xs text-gray-400">{e.date}</p>
-                        <p className="font-medium">{e.label}</p>
+                        <p className="font-medium">
+                          {formatDate(e.date)} — {e.label}
+                        </p>
                         {e.note && (
                           <p className="text-xs text-gray-500 italic">{e.note}</p>
                         )}

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -1,7 +1,7 @@
 import { usePlants } from '../PlantContext.jsx'
 import { useMemo } from 'react'
 import actionIcons from '../components/ActionIcons.jsx'
-import { formatMonth } from '../utils/date.js'
+import { formatMonth, formatDate } from '../utils/date.js'
 import { buildEvents, groupEventsByMonth } from '../utils/events.js'
 
 export default function Timeline() {
@@ -53,8 +53,9 @@ export default function Timeline() {
                   >
                     {Icon && <Icon className={`w-4 h-4 ${iconColors[e.type]}`} />}
                   </div>
-                  <p className="text-xs text-gray-400">{e.date}</p>
-                  <p className="font-medium">{e.label}</p>
+                  <p className="font-medium">
+                    {formatDate(e.date)} — {e.label}
+                  </p>
                   {e.note && (
                     <p className="text-xs text-gray-500 italic">{e.note}</p>
                   )}

--- a/src/pages/__tests__/Timeline.test.jsx
+++ b/src/pages/__tests__/Timeline.test.jsx
@@ -51,7 +51,7 @@ test('renders care log notes', () => {
   ]
 
   render(<Timeline />)
-  expect(screen.getByText('Watered Plant A')).toBeInTheDocument()
+  expect(screen.getByText(/Watered Plant A/)).toBeInTheDocument()
   expect(screen.getByText('deep soak')).toBeInTheDocument()
 })
 

--- a/src/pages/__tests__/TimelineRoute.test.jsx
+++ b/src/pages/__tests__/TimelineRoute.test.jsx
@@ -13,5 +13,5 @@ test('navigating to /timeline renders the Timeline page', () => {
     </MemoryRouter>
   )
 
-  expect(screen.getByText('Watered Plant A')).toBeInTheDocument()
+  expect(screen.getByText(/Watered Plant A/)).toBeInTheDocument()
 })

--- a/src/utils/__tests__/events.test.js
+++ b/src/utils/__tests__/events.test.js
@@ -13,7 +13,7 @@ test('buildEvents returns sorted events for a single plant', () => {
   expect(events).toEqual([
     { date: '2025-07-01', label: 'Fertilized', type: 'fertilize' },
     { date: '2025-07-02', label: 'Watered', note: 'deep soak', type: 'log' },
-    { date: '2025-07-09', label: 'Watered on 2025-07-09', type: 'note' },
+    { date: '2025-07-09', label: 'Watered on 2025-07-09', type: 'water' },
     { date: '2025-07-11', label: 'Watered', type: 'water' },
   ])
 })

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -17,6 +17,26 @@ export function formatMonth(key) {
   return `${months[Number(month) - 1]} ${year}`
 }
 
+export function formatDate(dateStr) {
+  const d = new Date(dateStr)
+  if (isNaN(d)) return dateStr
+  const months = [
+    'January',
+    'February',
+    'March',
+    'April',
+    'May',
+    'June',
+    'July',
+    'August',
+    'September',
+    'October',
+    'November',
+    'December',
+  ]
+  return `${months[d.getMonth()]} ${d.getDate()}, ${d.getFullYear()}`
+}
+
 export function daysAgo(dateStr, today = new Date()) {
   if (!dateStr) return null
   const d = new Date(dateStr)

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -1,41 +1,72 @@
 export function buildEvents(source, { includePlantName = false } = {}) {
   const plants = Array.isArray(source) ? source : [source].filter(Boolean)
   const events = []
+  const added = new Set()
+
+  const addEvent = (e) => {
+    const key = `${e.type}-${e.date}`
+    if (!added.has(key)) {
+      added.add(key)
+      events.push(e)
+    }
+  }
+
   plants.forEach(p => {
     if (!p) return
-    if (p.lastWatered) {
-      events.push({
-        date: p.lastWatered,
-        label: includePlantName ? `Watered ${p.name}` : 'Watered',
-        type: 'water',
-      })
-    }
-    if (p.lastFertilized) {
-      events.push({
-        date: p.lastFertilized,
-        label: includePlantName ? `Fertilized ${p.name}` : 'Fertilized',
-        type: 'fertilize',
-      })
-    }
+
+    const waterDates = new Set()
+    const fertilizeDates = new Set()
+
     ;(p.activity || []).forEach(a => {
       const m = a.match(/(\d{4}-\d{2}-\d{2})/)
-      if (m) {
-        events.push({
-          date: m[1],
-          label: includePlantName ? `${p.name}: ${a}` : a,
-          type: 'note',
-        })
+      if (!m) return
+
+      const lower = a.toLowerCase()
+      let type = 'note'
+      if (lower.includes('watered')) {
+        type = 'water'
+        waterDates.add(m[1])
+      } else if (lower.includes('fertilized')) {
+        type = 'fertilize'
+        fertilizeDates.add(m[1])
       }
+
+      addEvent({
+        date: m[1],
+        label: includePlantName ? `${p.name}: ${a}` : a,
+        type,
+      })
     })
+
     ;(p.careLog || []).forEach(ev => {
-      events.push({
+      const lowerType = (ev.type || '').toLowerCase()
+      if (lowerType.includes('water')) waterDates.add(ev.date)
+      if (lowerType.includes('fertilize')) fertilizeDates.add(ev.date)
+      addEvent({
         date: ev.date,
         label: includePlantName ? `${ev.type} ${p.name}` : ev.type,
         note: ev.note,
         type: 'log',
       })
     })
+
+    if (p.lastWatered && !waterDates.has(p.lastWatered)) {
+      addEvent({
+        date: p.lastWatered,
+        label: includePlantName ? `Watered ${p.name}` : 'Watered',
+        type: 'water',
+      })
+    }
+
+    if (p.lastFertilized && !fertilizeDates.has(p.lastFertilized)) {
+      addEvent({
+        date: p.lastFertilized,
+        label: includePlantName ? `Fertilized ${p.name}` : 'Fertilized',
+        type: 'fertilize',
+      })
+    }
   })
+
   return events.sort((a, b) => new Date(a.date) - new Date(b.date))
 }
 


### PR DESCRIPTION
## Summary
- de-duplicate plant care events
- format dates for readability
- relocate plant detail menu to hero image
- hide global FAB on plant routes
- adjust tests for new layout

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687712a340f48324aa286cebda0155f7