### PR TITLE
Add collapsible sections to plant details

### DIFF
--- a/src/components/Accordion.jsx
+++ b/src/components/Accordion.jsx
@@ -1,0 +1,22 @@
+import { useState } from 'react'
+
+export default function Accordion({ title, defaultOpen = false, children }) {
+  const [open, setOpen] = useState(defaultOpen)
+
+  return (
+    <div className="border rounded-xl divide-y">
+      <button
+        type="button"
+        onClick={() => setOpen(o => !o)}
+        aria-expanded={open}
+        className="w-full flex justify-between items-center px-4 py-2 font-semibold text-left"
+      >
+        <span>{title}</span>
+        <span className="text-sm text-green-600">
+          {open ? 'Collapse' : 'Expand'}
+        </span>
+      </button>
+      {open && <div className="p-4">{children}</div>}
+    </div>
+  )
+}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -19,6 +19,7 @@ import Lightbox from '../components/Lightbox.jsx'
 import { usePlants } from '../PlantContext.jsx'
 import actionIcons from '../components/ActionIcons.jsx'
 import NoteModal from '../components/NoteModal.jsx'
+import Accordion from '../components/Accordion.jsx'
 
 import useToast from "../hooks/useToast.jsx"
 import Badge from '../components/Badge.jsx'
@@ -185,7 +186,7 @@ export default function PlantDetail() {
             )}
           </div>
         </div>
-        <div className="bg-gray-50 rounded-xl p-4 space-y-3 shadow-sm">
+        <Accordion title="Quick Stats" defaultOpen>
           <div className="flex justify-between items-center text-sm">
             <span className="flex items-center gap-1 text-blue-600">
               <Drop className="w-4 h-4" aria-hidden="true" />
@@ -209,7 +210,7 @@ export default function PlantDetail() {
               <span className="text-gray-700">{plant.lastFertilized}</span>
             </div>
           )}
-        </div>
+        </Accordion>
 
         {events.length > 0 && (
           <div className="mt-4 border-l-4 border-blue-500 pl-4">
@@ -222,7 +223,7 @@ export default function PlantDetail() {
           </div>
         )}
 
-        <div className="space-y-1 mt-4">
+        <Accordion title="Care Profile" defaultOpen>
           <h3 className="text-base font-semibold font-headline">Care Profile</h3>
           {plant.light && (
             <>
@@ -247,10 +248,10 @@ export default function PlantDetail() {
               </Badge>
             )}
           </div>
-        </div>
+        </Accordion>
 
 
-        <div className="space-y-2 mt-4">
+        <Accordion title="Activity & Notes" defaultOpen={false}>
           <div role="tablist" className="flex gap-2">
             <button
               ref={el => (tabRefs.current[0] = el)}
@@ -399,9 +400,9 @@ export default function PlantDetail() {
               </div>
             ))}
           </div>
-        </div>
+        </Accordion>
       </div>
-      <div className="space-y-2">
+      <Accordion title="Gallery" defaultOpen={false}>
         <h2 className="text-xl font-semibold font-headline">Gallery</h2>
         <div className="flex gap-3 overflow-x-auto pb-2">
           {(plant.photos || []).map((src, i) => (
@@ -455,7 +456,7 @@ export default function PlantDetail() {
             />
           </div>
         )}
-      </div>
+      </Accordion>
       {showNoteModal && (
         <NoteModal label="Note" onSave={saveNote} onCancel={cancelNote} />
       )}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -48,6 +48,9 @@ test('tab keyboard navigation works', () => {
     </PlantProvider>
   )
 
+  // Expand section first
+  fireEvent.click(screen.getByRole('button', { name: /Activity & Notes Expand/i }))
+
   const tabs = [
     screen.getByRole('tab', { name: /Activity/ }),
     screen.getByRole('tab', { name: /Notes/ }),
@@ -66,6 +69,32 @@ test('tab keyboard navigation works', () => {
   expect(document.activeElement).toBe(tabs[1])
 })
 
+test('sections collapsed by default', () => {
+  const plant = plants[0]
+  render(
+    <PlantProvider>
+      <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+        <Routes>
+          <Route path="/plant/:id" element={<PlantDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </PlantProvider>
+  )
+
+  expect(
+    screen.getByRole('button', { name: /Activity & Notes Expand/i })
+  ).toHaveAttribute('aria-expanded', 'false')
+  expect(
+    screen.getByRole('button', { name: /Gallery Expand/i })
+  ).toHaveAttribute('aria-expanded', 'false')
+  expect(
+    screen.getByRole('button', { name: /Quick Stats Collapse/i })
+  ).toHaveAttribute('aria-expanded', 'true')
+  expect(
+    screen.getByRole('button', { name: /Care Profile Collapse/i })
+  ).toHaveAttribute('aria-expanded', 'true')
+})
+
 
 test('opens lightbox from gallery', () => {
 
@@ -79,6 +108,8 @@ test('opens lightbox from gallery', () => {
       </MemoryRouter>
     </PlantProvider>
   )
+
+  fireEvent.click(screen.getByRole('button', { name: /Gallery Expand/i }))
 
   const img = screen.getByAltText(`${plant.name} 0`)
   fireEvent.click(img.closest('button'))

--- a/src/pages/__tests__/PlantDetailCareLog.test.jsx
+++ b/src/pages/__tests__/PlantDetailCareLog.test.jsx
@@ -34,6 +34,8 @@ test('shows notes from care log in activity tab', () => {
     </MemoryRouter>
   )
 
+  fireEvent.click(screen.getByRole('button', { name: /Activity & Notes Expand/i }))
+
   const activityTab = screen.getByRole('tab', { name: /Activity/ })
   fireEvent.click(activityTab)
 


### PR DESCRIPTION
## Summary
- build a simple `Accordion` component with `aria-expanded`
- wrap plant detail sections in Accordions so Quick Stats and Care Profile are open initially
- hide Activity/Notes/Timeline tabs and Gallery until expanded
- update tests for accordion behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877b15f6b6c8324a1091f08a95e6daa