### PR TITLE
Add Water Now button overlay to FeaturedCard

### DIFF
--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -71,6 +71,13 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
         {preview && (
           <p className="text-sm opacity-90">{preview}</p>
         )}
+        <button
+          type="button"
+          aria-label={`Mark ${name} as watered`}
+          className="mt-2 px-3 py-1 bg-blue-600 text-white rounded text-sm animate-bounce-once"
+        >
+          Water Now
+        </button>
 
       </div>
     </Link>

--- a/src/index.css
+++ b/src/index.css
@@ -39,6 +39,10 @@ body {
   animation: bounce-once 0.3s ease;
 }
 
+.animate-bounce-once {
+  animation: bounce-once 0.3s ease;
+}
+
 .fade-enter {
   opacity: 0;
   transform: translateX(10px);


### PR DESCRIPTION
## Summary
- add `animate-bounce-once` helper class
- overlay a new **Water Now** button in `FeaturedCard`
- keep accessibility with aria-labels

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877c058744c8324bfd66f5cdea2b084