### PR TITLE
Add padding to Tasks list container

### DIFF
--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -202,7 +202,7 @@ export default function Tasks() {
   const handleFertRingClick = () => setTypeFilter('fertilize')
 
   return (
-    <div className="overflow-y-auto max-h-full p-4">
+    <div className="overflow-y-auto max-h-full p-4 pb-24">
 
       <div className="flex justify-center mb-4">
         <CareRings


### PR DESCRIPTION
## Summary
- add bottom padding in `Tasks` page to avoid overlap with bottom nav
- ensure spacing between task cards in list view remains

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877bfee1a208324aeeec9818278e05e