### PR TITLE
Remove extra heading in Care Profile section

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -210,7 +210,6 @@ export default function PlantDetail() {
         )}
 
         <Accordion title="Care Profile" defaultOpen>
-          <h3 className="text-base font-semibold font-headline">Care Profile</h3>
           {plant.light && (
             <>
               <h4 className="text-xs font-semibold text-gray-500 mb-1">Light Needs</h4>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -34,6 +34,9 @@ test('renders plant details without duplicates', () => {
 
   const fertLabel = screen.getByText('Last fertilized:')
   expect(within(fertLabel.parentElement).getByText(plant.lastFertilized)).toBeInTheDocument()
+
+  const subHeadings = screen.getAllByRole('heading', { level: 4 })
+  expect(subHeadings).toHaveLength(2)
 })
 
 test('tab keyboard navigation works', () => {


### PR DESCRIPTION
## Summary
- remove the redundant `<h3>` inside the PlantDetail Care Profile accordion
- assert the number of subheadings in PlantDetail after change

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877cecb0f8883248e8e126cb641cd54