### PR TITLE
Add spacing around progress rings

### DIFF
--- a/src/components/CareStats.jsx
+++ b/src/components/CareStats.jsx
@@ -72,7 +72,10 @@ export default function CareStats({
     },
   ]
   return (
-    <div className="flex justify-around gap-4 flex-wrap" data-testid="care-stats">
+    <div
+      className="flex justify-around gap-4 flex-wrap my-4"
+      data-testid="care-stats"
+    >
       {stats.map(s => (
         <StatBlock key={s.label} {...s} />
       ))}

--- a/src/components/__tests__/CareStats.test.jsx
+++ b/src/components/__tests__/CareStats.test.jsx
@@ -54,3 +54,8 @@ test('ring colors remain in dark mode', () => {
   expect(getCircle('stat-fertilize')).toHaveClass('text-yellow-700')
   document.documentElement.classList.remove('dark')
 })
+
+test('container has vertical margins for spacing', () => {
+  render(<CareStats />)
+  expect(screen.getByTestId('care-stats')).toHaveClass('my-4')
+})

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -150,7 +150,7 @@ export default function Home() {
         </p>
       </header>
     {plants.length > 0 && (
-      <section>
+      <section className="mb-4">
         <h2 className="sr-only">Featured Plant</h2>
         <FeaturedCard plants={plants} startIndex={featuredIndex} />
       </section>

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -104,3 +104,23 @@ test('earliest due task appears first', () => {
   expect(tasks[1]).toHaveTextContent('Plant B')
 })
 
+test('featured section provides extra spacing', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
+  mockPlants.splice(0, mockPlants.length, {
+    id: 1,
+    name: 'Plant A',
+    image: 'a.jpg',
+    lastWatered: '2025-07-03',
+    nextFertilize: '2025-07-10',
+  })
+
+  render(
+    <MemoryRouter>
+      <Home />
+    </MemoryRouter>
+  )
+
+  const section = screen.getByTestId('featured-card').closest('section')
+  expect(section).toHaveClass('mb-4')
+})
+


### PR DESCRIPTION
## Summary
- pad the CareStats component
- add margin after the FeaturedCard section on the home page
- test for new spacing classes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877d31e6190832492f213d13f9e6c6e