### PR TITLE
Add tasks container on Home page

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -164,52 +164,54 @@ export default function Home() {
       {showSummary && (
         <CareSummaryModal tasks={tasks} onClose={() => setShowSummary(false)} />
       )}
-      {tasks.length > 0 && (
-        <hr className="my-4 border-t border-neutral-200 dark:border-gray-600" />
-      )}
-      <section className="space-y-4">
-        <div className="flex items-center justify-between">
-          <h2 className="font-semibold font-headline">Today’s Tasks</h2>
-        </div>
-        <div className="space-y-4">
-          {tasks.length > 0 ? (
-            tasks.map(task => (
-              <BaseCard key={task.id} variant="task">
-                <TaskCard
-                  task={task}
-                  urgent={task.urgent}
-                  overdue={task.overdue}
-                  compact
+      <div
+        data-testid="tasks-container"
+        className="mt-4 border-t border-neutral-200 dark:border-gray-600 bg-sage dark:bg-gray-700 rounded-xl p-4"
+      >
+        <section className="space-y-4">
+          <div className="flex items-center justify-between">
+            <h2 className="font-semibold font-headline">Today’s Tasks</h2>
+          </div>
+          <div className="space-y-4">
+            {tasks.length > 0 ? (
+              tasks.map(task => (
+                <BaseCard key={task.id} variant="task">
+                  <TaskCard
+                    task={task}
+                    urgent={task.urgent}
+                    overdue={task.overdue}
+                    compact
+                  />
+                </BaseCard>
+              ))
+            ) : (
+              <div className="text-sm text-gray-500 space-y-1 text-center flex flex-col items-center">
+                <img
+                  src={happyPlant}
+                  alt="Happy plant"
+                  className="w-24 h-24 mb-2"
                 />
-              </BaseCard>
-            ))
-          ) : (
-            <div className="text-sm text-gray-500 space-y-1 text-center flex flex-col items-center">
-              <img
-                src={happyPlant}
-                alt="Happy plant"
-                className="w-24 h-24 mb-2"
-              />
-              <p>All plants are happy today!</p>
-              <p>Want to add a note or photo today?</p>
-              <div className="flex gap-2 mt-2">
-                <Link
-                  to="/timeline"
-                  className="px-3 py-1 bg-green-100 text-green-700 rounded text-xs"
-                >
-                  Add a journal entry
-                </Link>
-                <Link
-                  to="/profile"
-                  className="px-3 py-1 bg-green-100 text-green-700 rounded text-xs"
-                >
-                  Set a reminder
-                </Link>
+                <p>All plants are happy today!</p>
+                <p>Want to add a note or photo today?</p>
+                <div className="flex gap-2 mt-2">
+                  <Link
+                    to="/timeline"
+                    className="px-3 py-1 bg-green-100 text-green-700 rounded text-xs"
+                  >
+                    Add a journal entry
+                  </Link>
+                  <Link
+                    to="/profile"
+                    className="px-3 py-1 bg-green-100 text-green-700 rounded text-xs"
+                  >
+                    Set a reminder
+                  </Link>
+                </div>
               </div>
-            </div>
-          )}
-        </div>
-      </section>
+            )}
+          </div>
+        </section>
+      </div>
     </div>
   )
 }

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -104,3 +104,14 @@ test('earliest due task appears first', () => {
   expect(tasks[1]).toHaveTextContent('Plant B')
 })
 
+test('tasks container renders with background', () => {
+  render(
+    <MemoryRouter>
+      <Home />
+    </MemoryRouter>
+  )
+  const container = screen.getByTestId('tasks-container')
+  expect(container).toBeInTheDocument()
+  expect(container).toHaveClass('bg-sage')
+})
+


### PR DESCRIPTION
## Summary
- style Home tasks in a container with a light background
- test for new tasks container styling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877d31a41a8832484ca9cfecd7880e1