### PR TITLE
Add overdue badge animation

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -261,7 +261,7 @@ export default function TaskCard({
         />
         {overdue && (
           <span
-            className="absolute -top-1 -right-1 bg-fertilize-500 text-white rounded-full w-4 h-4 flex items-center justify-center text-xs"
+            className="absolute -top-1 -right-1 bg-fertilize-500 text-white rounded-full w-4 h-4 flex items-center justify-center text-xs overdue-ping"
             data-testid="overdue-badge"
           >
             !

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -105,6 +105,7 @@ test('applies overdue styling', () => {
   const badge = screen.getByTestId('overdue-badge')
   expect(badge).toBeInTheDocument()
   expect(badge).toHaveClass('bg-fertilize-500')
+  expect(badge).toHaveClass('overdue-ping')
 })
 
 test('shows completed state', () => {

--- a/src/index.css
+++ b/src/index.css
@@ -176,6 +176,19 @@ body {
   animation: task-complete-fade 0.4s ease-out forwards;
 }
 
+@keyframes overdue-ping {
+  0%, 100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.2);
+  }
+}
+
+.overdue-ping {
+  animation: overdue-ping 1s ease-in-out infinite;
+}
+
 /* Dropdown select styling */
 .dropdown-select {
   @apply px-2 py-1 pr-8 border border-gray-300 rounded bg-white;


### PR DESCRIPTION
## Summary
- add overdue-ping animation in CSS
- use the animation class for the overdue badge
- test that the overdue badge has the animation class

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877d311537c832494eac4e991a38a57