### PR TITLE
Add photo captions to gallery

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -13,13 +13,21 @@ export const addBase = url => {
   return `${base}${url.startsWith('/') ? '' : '/'}${url}`
 }
 
+const mapPhoto = photo => {
+  if (!photo) return photo
+  if (typeof photo === 'string') {
+    return { src: addBase(photo) }
+  }
+  return { ...photo, src: addBase(photo.src) }
+}
+
 export function PlantProvider({ children }) {
 
   const [plants, setPlants] = useState(() => {
     const mapPlant = p => ({
       ...p,
       image: addBase(p.image),
-      photos: (p.photos || p.gallery || []).map(addBase),
+      photos: (p.photos || p.gallery || []).map(mapPhoto),
       careLog: p.careLog || [],
     })
 
@@ -119,11 +127,12 @@ export function PlantProvider({ children }) {
     setPlants(prev => prev.filter(p => p.id !== id))
   }
 
-  const addPhoto = (id, url) => {
+  const addPhoto = (id, photo) => {
+    const newPhoto = mapPhoto(photo)
     setPlants(prev =>
       prev.map(p =>
         p.id === id
-          ? { ...p, photos: [...(p.photos || []), url] }
+          ? { ...p, photos: [...(p.photos || []), newPhoto] }
           : p
       )
     )

--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -34,7 +34,8 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
   const name = plant.plantName || plant.name
   const id = plant.plantId || plant.id
   const preview = formatCareSummary(plant.lastWatered, plant.nextWater)
-  const imageSrc = (plant.photos && plant.photos[0]) || plant.image || '/demo-image-01.jpg'
+  const imageSrc =
+    (plant.photos && plant.photos[0]?.src) || plant.image || '/demo-image-01.jpg'
 
   return (
     <Link

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -49,11 +49,24 @@ export default function Lightbox({ images, startIndex = 0, onClose, label = 'Ima
       >
         ‹
       </button>
-      <img
-        src={images[index]}
-        alt="Gallery image"
-        className="max-w-full max-h-full object-contain"
-      />
+      {(() => {
+        const current =
+          typeof images[index] === 'string' ? { src: images[index] } : images[index]
+        return (
+          <>
+            <img
+              src={current.src}
+              alt="Gallery image"
+              className="max-w-full max-h-full object-contain"
+            />
+            {current.caption && (
+              <p className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white bg-black/60 px-2 py-1 rounded text-sm">
+                {current.caption}
+              </p>
+            )}
+          </>
+        )
+      })()}
       <button
         aria-label="Next image"
         className="absolute right-4 text-white text-3xl"

--- a/src/components/__tests__/Lightbox.test.jsx
+++ b/src/components/__tests__/Lightbox.test.jsx
@@ -2,7 +2,10 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import Lightbox from '../Lightbox.jsx'
 
 test('keyboard navigation and close', () => {
-  const images = ['a.jpg', 'b.jpg']
+  const images = [
+    { src: 'a.jpg', caption: 'first' },
+    { src: 'b.jpg', caption: 'second' },
+  ]
   const onClose = jest.fn()
   const label = 'Photo viewer'
   render(
@@ -14,12 +17,15 @@ test('keyboard navigation and close', () => {
 
   const img = screen.getByAltText(/gallery image/i)
   expect(img).toHaveAttribute('src', 'a.jpg')
+  expect(screen.getByText('first')).toBeInTheDocument()
 
   fireEvent.keyDown(window, { key: 'ArrowRight' })
   expect(img).toHaveAttribute('src', 'b.jpg')
+  expect(screen.getByText('second')).toBeInTheDocument()
 
   fireEvent.keyDown(window, { key: 'ArrowLeft' })
   expect(img).toHaveAttribute('src', 'a.jpg')
+  expect(screen.getByText('first')).toBeInTheDocument()
 
   fireEvent.keyDown(window, { key: 'Escape' })
   expect(onClose).toHaveBeenCalled()

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -71,7 +71,8 @@ export default function PlantDetail() {
     const files = Array.from(e.target.files || [])
     files.forEach(file => {
       const reader = new FileReader()
-      reader.onload = ev => addPhoto(plant.id, ev.target.result)
+      reader.onload = ev =>
+        addPhoto(plant.id, { src: ev.target.result, caption: '' })
       reader.readAsDataURL(file)
     })
     e.target.value = ''
@@ -389,9 +390,10 @@ export default function PlantDetail() {
       </div>
       <Accordion title="Gallery" defaultOpen={false}>
         <div className="flex gap-3 overflow-x-auto pb-2">
-          {(plant.photos || []).map((src, i) => (
-            
-            <div key={i} className="relative">
+          {(plant.photos || []).map((photo, i) => {
+            const { src, caption } = photo
+            return (
+            <div key={i} className="relative flex flex-col items-center">
               <button type="button" onClick={() => setLightboxIndex(i)} className="block focus:outline-none">
                 <img
                   src={src}
@@ -399,6 +401,7 @@ export default function PlantDetail() {
                   className="object-cover w-full h-24 rounded"
                 />
               </button>
+              {caption && <p className="text-xs mt-1 w-24 text-center">{caption}</p>}
 
               <button
                 className="absolute top-1 right-1 bg-white bg-opacity-70 rounded px-1 text-xs"
@@ -407,7 +410,8 @@ export default function PlantDetail() {
                 ✕
               </button>
             </div>
-          ))}
+            )
+          })}
         </div>
         <button
           type="button"

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -106,6 +106,14 @@ test('earliest due task appears first', () => {
 
 
 test('tasks container renders with background', () => {
+  render(
+    <MemoryRouter>
+      <Home />
+    </MemoryRouter>
+  )
+
+  expect(screen.getByTestId('tasks-container')).toHaveClass('bg-sage')
+})
 
 test('featured section provides extra spacing', () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
@@ -130,6 +138,5 @@ test('featured section provides extra spacing', () => {
 
   const section = screen.getByTestId('featured-card').closest('section')
   expect(section).toHaveClass('mb-4')
->
 })
 

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -135,10 +135,14 @@ test('opens lightbox from gallery', () => {
   expect(viewerDialog).toBeInTheDocument()
 
   const viewerImg = screen.getByAltText(/gallery image/i)
-  expect(viewerImg).toHaveAttribute('src', plant.photos[0])
+  expect(viewerImg).toHaveAttribute('src', plant.photos[0].src)
+  expect(screen.getAllByText(plant.photos[0].caption).length).toBeGreaterThan(0)
 
   fireEvent.keyDown(window, { key: 'ArrowRight' })
-  expect(viewerImg).toHaveAttribute('src', plant.photos[1])
+  expect(viewerImg).toHaveAttribute('src', plant.photos[1].src)
+  if (plant.photos[1].caption) {
+    expect(screen.getAllByText(plant.photos[1].caption).length).toBeGreaterThan(0)
+  }
 
   fireEvent.keyDown(window, { key: 'Escape' })
   expect(

--- a/src/plants.json
+++ b/src/plants.json
@@ -5,9 +5,9 @@
     "nickname": "Swiss Cheese",
     "image": "/demo-image-01.jpg",
     "photos": [
-      "/demo-image-01.jpg",
-      "/demo-image-02.jpg",
-      "/demo-image-03.jpg"
+      { "src": "/demo-image-01.jpg", "caption": "Leaf close-up" },
+      { "src": "/demo-image-02.jpg", "caption": "Full plant" },
+      { "src": "/demo-image-03.jpg" }
     ],
     "lastWatered": "2025-07-01",
     "nextWater": "2025-07-08",
@@ -37,9 +37,9 @@
     "nickname": "Mother-in-Law's Tongue",
     "image": "/demo-image-02.jpg",
     "photos": [
-      "/demo-image-02.jpg",
-      "/demo-image-03.jpg",
-      "/demo-image-04.jpg"
+      { "src": "/demo-image-02.jpg" },
+      { "src": "/demo-image-03.jpg" },
+      { "src": "/demo-image-04.jpg" }
     ],
     "lastWatered": "2025-07-02",
     "nextWater": "2025-07-09",
@@ -67,9 +67,9 @@
     "nickname": "Fiddle",
     "image": "/demo-image-03.jpg",
     "photos": [
-      "/demo-image-03.jpg",
-      "/demo-image-04.jpg",
-      "/demo-image-05.jpg"
+      { "src": "/demo-image-03.jpg" },
+      { "src": "/demo-image-04.jpg" },
+      { "src": "/demo-image-05.jpg" }
     ],
     "lastWatered": "2025-07-09",
     "nextWater": "2025-07-16",
@@ -94,9 +94,9 @@
     "nickname": "Lily",
     "image": "/demo-image-04.jpg",
     "photos": [
-      "/demo-image-04.jpg",
-      "/demo-image-05.jpg",
-      "/demo-image-06.jpg"
+      { "src": "/demo-image-04.jpg" },
+      { "src": "/demo-image-05.jpg" },
+      { "src": "/demo-image-06.jpg" }
     ],
     "lastWatered": "2025-07-11",
     "nextWater": "2025-07-15",
@@ -124,9 +124,9 @@
     "nickname": "Zenzi",
     "image": "/demo-image-08.jpg",
     "photos": [
-      "/demo-image-05.jpg",
-      "/demo-image-06.jpg",
-      "/demo-image-07.jpg"
+      { "src": "/demo-image-05.jpg" },
+      { "src": "/demo-image-06.jpg" },
+      { "src": "/demo-image-07.jpg" }
     ],
     "lastWatered": "2025-07-01",
     "nextWater": "2025-07-20",
@@ -153,9 +153,9 @@
     "nickname": "Medic",
     "image": "/demo-image-02.jpg",
     "photos": [
-      "/demo-image-06.jpg",
-      "/demo-image-07.jpg",
-      "/demo-image-08.jpg"
+      { "src": "/demo-image-06.jpg" },
+      { "src": "/demo-image-07.jpg" },
+      { "src": "/demo-image-08.jpg" }
     ],
     "lastWatered": "2025-07-04",
     "nextWater": "2025-07-11",
@@ -183,9 +183,9 @@
     "nickname": "Devil's Ivy",
     "image": "/demo-image-07.jpg",
     "photos": [
-      "/demo-image-07.jpg",
-      "/demo-image-08.jpg",
-      "/demo-image-09.jpg"
+      { "src": "/demo-image-07.jpg" },
+      { "src": "/demo-image-08.jpg" },
+      { "src": "/demo-image-09.jpg" }
     ],
     "lastWatered": "2025-07-06",
     "nextWater": "2025-07-13",
@@ -210,9 +210,9 @@
     "nickname": "Prayer Plant",
     "image": "/demo-image-08.jpg",
     "photos": [
-      "/demo-image-08.jpg",
-      "/demo-image-09.jpg",
-      "/demo-image-10.jpg"
+      { "src": "/demo-image-08.jpg" },
+      { "src": "/demo-image-09.jpg" },
+      { "src": "/demo-image-10.jpg" }
     ],
     "lastWatered": "2025-07-08",
     "nextWater": "2025-07-12",
@@ -237,9 +237,9 @@
     "nickname": "Ficus Elastica",
     "image": "/demo-image-05.jpg",
     "photos": [
-      "/demo-image-09.jpg",
-      "/demo-image-10.jpg",
-      "/demo-image-01.jpg"
+      { "src": "/demo-image-09.jpg" },
+      { "src": "/demo-image-10.jpg" },
+      { "src": "/demo-image-01.jpg" }
     ],
     "lastWatered": "2025-07-05",
     "nextWater": "2025-07-12",
@@ -264,9 +264,9 @@
     "nickname": "Aglaonema",
     "image": "/demo-image-09.jpg",
     "photos": [
-      "/demo-image-10.jpg",
-      "/demo-image-01.jpg",
-      "/demo-image-02.jpg"
+      { "src": "/demo-image-10.jpg" },
+      { "src": "/demo-image-01.jpg" },
+      { "src": "/demo-image-02.jpg" }
     ],
     "lastWatered": "2025-07-04",
     "nextWater": "2025-07-11",


### PR DESCRIPTION
## Summary
- allow photo objects with optional `caption`
- show captions in `PlantDetail` gallery thumbnails and lightbox
- handle caption objects in `PlantContext`
- update lightbox and photo logic
- update sample plant data
- adjust relevant tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877da03fc6c832485f3815943111ea1