### PR TITLE
Add quick action buttons in Plant Detail

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -185,8 +185,37 @@ export default function PlantDetail() {
               <CalendarCheck className="w-4 h-4" aria-hidden="true" />
               Next watering:
             </span>
-            <span className="text-gray-700">{plant.nextWater}</span>
+            <div className="flex items-center gap-2">
+              <span className="text-gray-700">{plant.nextWater}</span>
+              <button
+                type="button"
+                onClick={handleWatered}
+                aria-label={`Mark ${plant.name} as watered`}
+                className="px-2 py-0.5 bg-blue-600 text-white rounded text-xs"
+              >
+                Water Now
+              </button>
+            </div>
           </div>
+          {plant.nextFertilize && (
+            <div className="flex justify-between items-center text-sm">
+              <span className="flex items-center gap-1 text-yellow-600">
+                <Flower className="w-4 h-4" aria-hidden="true" />
+                Next fertilizing:
+              </span>
+              <div className="flex items-center gap-2">
+                <span className="text-gray-700">{plant.nextFertilize}</span>
+                <button
+                  type="button"
+                  onClick={handleFertilized}
+                  aria-label={`Mark ${plant.name} as fertilized`}
+                  className="px-2 py-0.5 bg-yellow-600 text-white rounded text-xs"
+                >
+                  Fertilize Now
+                </button>
+              </div>
+            </div>
+          )}
           {plant.lastFertilized && (
             <div className="flex justify-between items-center text-sm">
               <span className="flex items-center gap-1 text-yellow-600">

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -105,8 +105,6 @@ test('earliest due task appears first', () => {
 })
 
 
-test('tasks container renders with background', () => {
-
 test('featured section provides extra spacing', () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
   mockPlants.splice(0, mockPlants.length, {
@@ -130,6 +128,5 @@ test('featured section provides extra spacing', () => {
 
   const section = screen.getByTestId('featured-card').closest('section')
   expect(section).toHaveClass('mb-4')
->
 })
 

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -30,7 +30,22 @@ test('renders plant details without duplicates', () => {
   expect(within(wateredLabel.parentElement).getByText(plant.lastWatered)).toBeInTheDocument()
 
   const nextLabel = screen.getByText('Next watering:')
-  expect(within(nextLabel.parentElement).getByText(plant.nextWater)).toBeInTheDocument()
+  const nextWrapper = nextLabel.parentElement
+  expect(within(nextWrapper).getByText(plant.nextWater)).toBeInTheDocument()
+  expect(
+    within(nextWrapper).getByRole('button', {
+      name: `Mark ${plant.name} as watered`,
+    })
+  ).toBeInTheDocument()
+
+  const nextFertLabel = screen.getByText('Next fertilizing:')
+  const nextFertWrapper = nextFertLabel.parentElement
+  expect(within(nextFertWrapper).getByText(plant.nextFertilize)).toBeInTheDocument()
+  expect(
+    within(nextFertWrapper).getByRole('button', {
+      name: `Mark ${plant.name} as fertilized`,
+    })
+  ).toBeInTheDocument()
 
   const fertLabel = screen.getByText('Last fertilized:')
   expect(within(fertLabel.parentElement).getByText(plant.lastFertilized)).toBeInTheDocument()

--- a/src/pages/__tests__/PlantDetailActions.test.jsx
+++ b/src/pages/__tests__/PlantDetailActions.test.jsx
@@ -1,0 +1,59 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import PlantDetail from '../PlantDetail.jsx'
+import { usePlants } from '../../PlantContext.jsx'
+
+const markWatered = jest.fn()
+const markFertilized = jest.fn()
+let mockPlants = []
+
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: jest.fn(),
+}))
+
+const usePlantsMock = usePlants
+
+beforeEach(() => {
+  markWatered.mockClear()
+  markFertilized.mockClear()
+  mockPlants = [
+    {
+      id: 1,
+      name: 'Plant A',
+      image: 'a.jpg',
+      lastWatered: '2025-07-01',
+      nextWater: '2025-07-08',
+      lastFertilized: '2025-06-01',
+      nextFertilize: '2025-07-01',
+      photos: [],
+    },
+  ]
+  usePlantsMock.mockReturnValue({
+    plants: mockPlants,
+    markWatered,
+    markFertilized,
+    addPhoto: jest.fn(),
+    removePhoto: jest.fn(),
+    logEvent: jest.fn(),
+  })
+})
+
+test('quick stats action buttons trigger handlers', () => {
+  render(
+    <MemoryRouter initialEntries={['/plant/1']}>
+      <Routes>
+        <Route path="/plant/:id" element={<PlantDetail />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+  fireEvent.click(
+    screen.getByRole('button', { name: /mark plant a as watered/i })
+  )
+  expect(markWatered).toHaveBeenCalledWith(1, '')
+
+  fireEvent.click(
+    screen.getByRole('button', { name: /mark plant a as fertilized/i })
+  )
+  expect(markFertilized).toHaveBeenCalledWith(1, '')
+})


### PR DESCRIPTION
## Summary
- add Water Now and Fertilize Now buttons in Quick Stats section
- display next fertilizing info
- update PlantDetail tests
- cover quick stats actions with new tests
- fix stray character in Home tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877d9c23720832488456acb580588d1