### PR TITLE
Unify plant activity timeline

### DIFF
--- a/src/components/ActionIcons.jsx
+++ b/src/components/ActionIcons.jsx
@@ -32,6 +32,8 @@ export const icons = {
   rotate: RotateIcon,
   note: NoteIcon,
   log: LogIcon,
+  advanced: LogIcon,
+  noteText: NoteIcon,
 }
 
 export default icons

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -2,8 +2,6 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useState, useRef, useMemo } from 'react'
 
 import {
-  Activity,
-  Note,
   Clock,
   Sun,
   Drop,
@@ -34,6 +32,8 @@ const iconColors = {
   fertilize: 'text-yellow-500',
   note: 'text-gray-400',
   log: 'text-green-500',
+  advanced: 'text-purple-500',
+  noteText: 'text-gray-400',
 }
 
 const bulletColors = {
@@ -41,6 +41,8 @@ const bulletColors = {
   fertilize: 'bg-yellow-500',
   note: 'bg-gray-400',
   log: 'bg-green-500',
+  advanced: 'bg-purple-500',
+  noteText: 'bg-gray-400',
 }
 
 export default function PlantDetail() {
@@ -49,10 +51,6 @@ export default function PlantDetail() {
   const plant = plants.find(p => p.id === Number(id))
   const navigate = useNavigate()
 
-  const tabNames = ['activity', 'notes', 'care', 'timeline']
-  const tabRefs = useRef([])
-  const [activeTab, setActiveTab] = useState('timeline')
-  const [showMore, setShowMore] = useState(false)
   const fileInputRef = useRef()
   const { Toast, showToast } = useToast()
   const [showNoteModal, setShowNoteModal] = useState(false)
@@ -77,15 +75,6 @@ export default function PlantDetail() {
     e.target.value = ''
   }
 
-  const handleKeyDown = (e, index) => {
-    if (e.key === 'ArrowRight' || e.key === 'ArrowLeft') {
-      e.preventDefault()
-      const dir = e.key === 'ArrowRight' ? 1 : -1
-      const nextIndex = (index + dir + tabNames.length) % tabNames.length
-      setActiveTab(tabNames[nextIndex])
-      tabRefs.current[nextIndex]?.focus()
-    }
-  }
 
   const handleWatered = () => {
     markWatered(plant.id, '')
@@ -237,129 +226,7 @@ export default function PlantDetail() {
 
 
         <Accordion title="Activity & Notes" defaultOpen={false}>
-          <div role="tablist" className="flex gap-2">
-            <button
-              ref={el => (tabRefs.current[0] = el)}
-              role="tab"
-              id="activity-tab"
-              aria-controls="activity-panel"
-              aria-selected={activeTab === 'activity'}
-              onClick={() => setActiveTab('activity')}
-              onKeyDown={e => handleKeyDown(e, 0)}
-              className={`relative px-3 py-1 rounded-full text-sm font-medium focus:outline-none after:absolute after:inset-x-2 after:-bottom-px after:h-0.5 after:bg-white after:transition-transform after:duration-300 ${
-                activeTab === 'activity'
-                  ? 'bg-green-600 text-white after:scale-x-100'
-                  : 'bg-gray-200 text-gray-700 dark:bg-gray-600 dark:text-gray-200 after:scale-x-0'
-              }`}
-            >
-              <Activity className="w-4 h-4 mr-1 inline" aria-hidden="true" />
-              Activity
-            </button>
-            <button
-              ref={el => (tabRefs.current[1] = el)}
-              role="tab"
-              id="notes-tab"
-              aria-controls="notes-panel"
-              aria-selected={activeTab === 'notes'}
-              onClick={() => setActiveTab('notes')}
-              onKeyDown={e => handleKeyDown(e, 1)}
-              className={`relative px-3 py-1 rounded-full text-sm font-medium focus:outline-none after:absolute after:inset-x-2 after:-bottom-px after:h-0.5 after:bg-white after:transition-transform after:duration-300 ${
-                activeTab === 'notes'
-                  ? 'bg-green-600 text-white after:scale-x-100'
-                  : 'bg-gray-200 text-gray-700 dark:bg-gray-600 dark:text-gray-200 after:scale-x-0'
-              }`}
-            >
-              <Note className="w-4 h-4 mr-1 inline" aria-hidden="true" />
-              Notes
-            </button>
-            <button
-              ref={el => (tabRefs.current[2] = el)}
-              role="tab"
-              id="care-tab"
-              aria-controls="care-panel"
-              aria-selected={activeTab === 'care'}
-              onClick={() => setActiveTab('care')}
-              onKeyDown={e => handleKeyDown(e, 2)}
-              className={`relative px-3 py-1 rounded-full text-sm font-medium focus:outline-none after:absolute after:inset-x-2 after:-bottom-px after:h-0.5 after:bg-white after:transition-transform after:duration-300 ${
-                activeTab === 'care'
-                  ? 'bg-green-600 text-white after:scale-x-100'
-                  : 'bg-gray-200 text-gray-700 dark:bg-gray-600 dark:text-gray-200 after:scale-x-0'
-              }`}
-            >
-              Advanced
-            </button>
-            <button
-              ref={el => (tabRefs.current[3] = el)}
-              role="tab"
-              id="timeline-tab"
-              aria-controls="timeline-panel"
-              aria-selected={activeTab === 'timeline'}
-              onClick={() => setActiveTab('timeline')}
-              onKeyDown={e => handleKeyDown(e, 3)}
-              className={`relative px-3 py-1 rounded-full text-sm font-medium focus:outline-none after:absolute after:inset-x-2 after:-bottom-px after:h-0.5 after:bg-white after:transition-transform after:duration-300 ${
-                activeTab === 'timeline'
-                  ? 'bg-green-600 text-white after:scale-x-100'
-                  : 'bg-gray-200 text-gray-700 dark:bg-gray-600 dark:text-gray-200 after:scale-x-0'
-              }`}
-            >
-              <Clock className="w-4 h-4 mr-1 inline" aria-hidden="true" />
-              Timeline
-            </button>
-          </div>
-          <div
-            role="tabpanel"
-            id="activity-panel"
-            aria-labelledby="activity-tab"
-            hidden={activeTab !== 'activity'}
-            className="p-4 border rounded-xl"
-          >
-            <ul className="list-disc pl-4 space-y-1">
-              {(plant.careLog || []).map((ev, i) => (
-                <li key={i}>
-                  {ev.type} on {ev.date}
-                  {ev.note ? ` - ${ev.note}` : ''}
-                </li>
-              ))}
-            </ul>
-          </div>
-          <div
-            role="tabpanel"
-            id="notes-panel"
-            aria-labelledby="notes-tab"
-            hidden={activeTab !== 'notes'}
-            className="p-4 border rounded-xl"
-          >
-            {plant.notes
-              ? showMore
-                ? plant.notes
-                : plant.notes.slice(0, 160)
-              : 'No notes yet.'}
-            {plant.notes && plant.notes.length > 160 && (
-              <button
-                type="button"
-                onClick={() => setShowMore(!showMore)}
-                className="ml-2 text-green-600 underline"
-              >
-                {showMore ? 'Show less' : 'Show more'}
-              </button>
-            )}
-          </div>
-          <div
-            role="tabpanel"
-            id="care-panel"
-            aria-labelledby="care-tab"
-            hidden={activeTab !== 'care'}
-            className="p-4 border rounded-xl"
-          >
-            {plant.advancedCare || 'No advanced care info.'}
-          </div>
-          <div
-            role="tabpanel"
-            id="timeline-panel"
-            aria-labelledby="timeline-tab"
-            hidden={activeTab !== 'timeline'}
-            className="p-4 border border-gray-100 rounded-xl bg-white shadow-sm"
-          >
+          <div className="p-4 border border-gray-100 rounded-xl bg-white shadow-sm">
             {groupedEvents.map(([monthKey, list]) => (
               <div key={monthKey} className="mt-6 first:mt-0">
                 <div className="text-sm font-semibold text-gray-500">{formatMonth(monthKey)}</div>

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -105,8 +105,6 @@ test('earliest due task appears first', () => {
 })
 
 
-test('tasks container renders with background', () => {
-
 test('featured section provides extra spacing', () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
   mockPlants.splice(0, mockPlants.length, {
@@ -130,6 +128,5 @@ test('featured section provides extra spacing', () => {
 
   const section = screen.getByTestId('featured-card').closest('section')
   expect(section).toHaveClass('mb-4')
->
 })
 

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -39,40 +39,6 @@ test('renders plant details without duplicates', () => {
   expect(subHeadings).toHaveLength(2)
 })
 
-test('tab keyboard navigation works', () => {
-  const plant = plants[0]
-  render(
-    <PlantProvider>
-      <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
-        <Routes>
-          <Route path="/plant/:id" element={<PlantDetail />} />
-        </Routes>
-      </MemoryRouter>
-    </PlantProvider>
-  )
-
-  // Expand section first
-  fireEvent.click(
-    screen.getByRole('button', { name: /Activity & Notes Show Details/i })
-  )
-
-  const tabs = [
-    screen.getByRole('tab', { name: /Activity/ }),
-    screen.getByRole('tab', { name: /Notes/ }),
-    screen.getByRole('tab', { name: /Advanced/ }),
-    screen.getByRole('tab', { name: /Timeline/ }),
-  ]
-
-  expect(tabs[3]).toHaveAttribute('aria-selected', 'true')
-  expect(tabs[0]).toHaveAttribute('aria-selected', 'false')
-
-  tabs[0].focus()
-  fireEvent.keyDown(tabs[0], { key: 'ArrowRight' })
-
-  expect(tabs[3]).toHaveAttribute('aria-selected', 'false')
-  expect(tabs[1]).toHaveAttribute('aria-selected', 'true')
-  expect(document.activeElement).toBe(tabs[1])
-})
 
 test('sections collapsed by default', () => {
   const plant = plants[0]

--- a/src/pages/__tests__/PlantDetailCareLog.test.jsx
+++ b/src/pages/__tests__/PlantDetailCareLog.test.jsx
@@ -25,7 +25,7 @@ beforeEach(() => {
   ]
 })
 
-test('shows notes from care log in activity tab', () => {
+test('shows notes from care log in timeline', () => {
   render(
     <MemoryRouter initialEntries={['/plant/1']}>
       <Routes>
@@ -38,11 +38,10 @@ test('shows notes from care log in activity tab', () => {
     screen.getByRole('button', { name: /Activity & Notes Show Details/i })
   )
 
-  const activityTab = screen.getByRole('tab', { name: /Activity/ })
-  fireEvent.click(activityTab)
-
   expect(
-    screen.getByText('Watered on 2025-07-02 - deep soak')
-  ).toBeInTheDocument()
+    screen.getAllByText((content, node) =>
+      node.textContent === 'July 2, 2025 — Watered: deep soak'
+    ).length
+  ).toBeGreaterThan(0)
 
 })

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -66,6 +66,24 @@ export function buildEvents(source, { includePlantName = false } = {}) {
         type: 'fertilize',
       })
     }
+
+    if (p.notes) {
+      addEvent({
+        date: '2100-01-01',
+        label: includePlantName ? `${p.name} note` : 'Note',
+        note: p.notes,
+        type: 'noteText',
+      })
+    }
+
+    if (p.advancedCare) {
+      addEvent({
+        date: '2100-01-01',
+        label: includePlantName ? `${p.name} care tip` : 'Advanced care',
+        note: p.advancedCare,
+        type: 'advanced',
+      })
+    }
   })
 
   return events.sort((a, b) => new Date(a.date) - new Date(b.date))


### PR DESCRIPTION
## Summary
- remove tabs from PlantDetail and show one chronological activity log
- include notes and advanced care tips in `buildEvents`
- update tests for new layout

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6877d979f3a483249e35dc46f6a6e371