### PR TITLE
Enable optional swipe behaviour

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -22,6 +22,7 @@ export default function TaskCard({
   overdue = false,
   completed = false,
   compact = false,
+  swipeable = true,
 }) {
   const navigate = useNavigate()
   const { markWatered, markFertilized, removePlant } = usePlants()
@@ -107,33 +108,36 @@ export default function TaskCard({
       onKeyDown={handleKeyDown}
 
 
-      onPointerDown={e => { createRipple(e); start(e) }}
-      onPointerMove={move}
-      onPointerUp={end}
-      onPointerCancel={end}
-      onMouseMove={move}
-      onMouseUp={end}
+      onPointerDown={e => {
+        createRipple(e)
+        if (swipeable) start(e)
+      }}
+      onPointerMove={swipeable ? move : undefined}
+      onPointerUp={swipeable ? end : undefined}
+      onPointerCancel={swipeable ? end : undefined}
+      onMouseMove={swipeable ? move : undefined}
+      onMouseUp={swipeable ? end : undefined}
       onMouseDown={e => {
         createRipple(e)
-        start(e)
+        if (swipeable) start(e)
       }}
       onTouchStart={e => {
         createRipple(e)
-        start(e)
+        if (swipeable) start(e)
       }}
 
 
       className={`relative flex items-center gap-3 px-4 py-3 rounded-xl overflow-hidden shadow-sm hover:shadow-md transition-shadow transition-transform duration-150 active:scale-95 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-green-500${completed ? ' bg-gray-100 dark:bg-gray-800 opacity-50' : ' bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
 
 
-      onTouchMove={move}
-      onTouchEnd={end}
+      onTouchMove={swipeable ? move : undefined}
+      onTouchEnd={swipeable ? end : undefined}
 
 
 
       style={{
-        transform: `translateX(${deltaX}px)`,
-        transition: deltaX === 0 ? 'transform 0.2s' : 'none',
+        transform: `translateX(${swipeable ? deltaX : 0}px)`,
+        transition: (swipeable ? deltaX : 0) === 0 ? 'transform 0.2s' : 'none',
       }}
     >
       {deltaX > 0 && !isChecked && (

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -270,6 +270,28 @@ test('swipe right marks task complete', async () => {
   expect(onComplete).toHaveBeenCalledWith(task)
 })
 
+test('swipe gestures disabled when swipeable is false', async () => {
+  const onComplete = jest.fn()
+  const { container } = render(
+    <MemoryRouter>
+      <BaseCard variant="task">
+        <TaskCard task={task} onComplete={onComplete} swipeable={false} />
+      </BaseCard>
+    </MemoryRouter>
+  )
+  const wrapper = screen.getByTestId('task-card')
+  fireEvent.pointerDown(wrapper, { clientX: 0, buttons: 1 })
+  fireEvent.pointerMove(wrapper, { clientX: 80, buttons: 1 })
+  fireEvent.pointerUp(wrapper, { clientX: 80 })
+  await act(async () => {
+    fireEvent.touchStart(wrapper, { touches: [{ clientX: 0 }] })
+    fireEvent.touchMove(wrapper, { touches: [{ clientX: 80 }] })
+    fireEvent.touchEnd(wrapper)
+  })
+  expect(onComplete).not.toHaveBeenCalled()
+  expect(container.querySelector('[data-testid="task-card"]').style.transform).toBe('translateX(0px)')
+})
+
 test('matches snapshot in dark mode', () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-16'))
   document.documentElement.classList.add('dark')

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -181,6 +181,7 @@ export default function Home() {
                     urgent={task.urgent}
                     overdue={task.overdue}
                     compact
+                    swipeable={false}
                   />
                 </BaseCard>
               ))


### PR DESCRIPTION
## Summary
- add a `swipeable` prop to `TaskCard`
- guard swipe handlers with `swipeable`
- disable swipe on home page cards
- test swipe disabling

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877e7da504c8324b4464986b7695627