### PR TITLE
Refine bottom nav style

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -26,18 +26,23 @@ export default function BottomNav() {
 
   return (
     <nav
-      className="fixed bottom-4 inset-x-4 bg-white/90 dark:bg-gray-700/90 rounded-full backdrop-blur-md shadow-lg px-8 pt-4 pb-6 flex justify-between items-center pb-safe"
+      className="fixed bottom-4 inset-x-4 bg-white/90 dark:bg-gray-700/90 rounded-full backdrop-blur-md shadow-lg px-8 pt-2 pb-3 flex justify-between items-center pb-safe"
     >
       {items.map(({ to, label, icon: Icon }) => (
         <NavLink
           key={to}
           to={to}
           className={({ isActive }) =>
-            `flex flex-col items-center gap-1 text-base font-medium transition-colors duration-150 ${isActive ? 'text-accent' : 'text-gray-500 hover:text-gray-700'}`
+            `flex flex-col items-center gap-0.5 px-2 py-1 text-xs font-medium transition-colors duration-150 rounded-full ${isActive ? 'bg-accent/20 text-accent' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}`
           }
         >
-          <Icon className="w-6 h-6" aria-hidden="true" />
-          {label}
+          {({ isActive }) => (
+            <>
+              <Icon className="w-6 h-6" aria-hidden="true" />
+              <span className="sr-only">{label}</span>
+              {isActive && <span className="text-xs">{label}</span>}
+            </>
+          )}
         </NavLink>
       ))}
     </nav>


### PR DESCRIPTION
## Summary
- refine BottomNav styles for more compact height
- display nav item labels only on the active page

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877f55384c48324837f335368ce869b