### PR TITLE
Add View All Photos option

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,10 @@ swipeable gallery carousel of your uploaded photos.
 
 Click or tap a photo to launch the Lightbox viewer. Navigate between
 images with the on-screen arrows or your keyboard’s Left/Right keys, and
-close the viewer with **Esc** or the “×” button. The collapsible **Timeline**
-section on this page lists your watering, fertilizing and note history.
+close the viewer with **Esc** or the “×” button. If your plant has many
+photos, use the **View All Photos** button to open the viewer starting at the
+first image. The collapsible **Timeline** section on this page lists your
+watering, fertilizing and note history.
 
 
 ## Weather Feature

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -305,7 +305,7 @@ export default function PlantDetail() {
                   <img
                     src={src}
                     alt={`${plant.name} ${i}`}
-                    className="object-cover w-full h-24 rounded"
+                    className="object-cover w-full h-24 rounded-lg"
                   />
                 </button>
                 {caption && <p className="text-xs mt-1 w-24 text-center">{caption}</p>}
@@ -320,6 +320,15 @@ export default function PlantDetail() {
             )
           })}
         </div>
+        {(plant.photos || []).length > 3 && (
+          <button
+            type="button"
+            onClick={() => setLightboxIndex(0)}
+            className="mt-2 text-sm text-blue-600 underline"
+          >
+            View All Photos
+          </button>
+        )}
         <button
           type="button"
           onClick={() => fileInputRef.current.click()}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -121,3 +121,22 @@ test('opens lightbox from gallery', () => {
   ).toBeNull()
 
 })
+
+test('view all button opens the viewer from first image', () => {
+  const plant = plants[0]
+  render(
+    <PlantProvider>
+      <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+        <Routes>
+          <Route path="/plant/:id" element={<PlantDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </PlantProvider>
+  )
+
+  const viewAll = screen.getByRole('button', { name: /view all photos/i })
+  fireEvent.click(viewAll)
+
+  const viewerImg = screen.getByAltText(/gallery image/i)
+  expect(viewerImg).toHaveAttribute('src', plant.photos[0].src)
+})

--- a/src/plants.json
+++ b/src/plants.json
@@ -7,7 +7,8 @@
     "photos": [
       { "src": "/demo-image-01.jpg", "caption": "Leaf close-up" },
       { "src": "/demo-image-02.jpg", "caption": "Full plant" },
-      { "src": "/demo-image-03.jpg" }
+      { "src": "/demo-image-03.jpg" },
+      { "src": "/demo-image-04.jpg", "caption": "New growth" }
     ],
     "lastWatered": "2025-07-01",
     "nextWater": "2025-07-08",


### PR DESCRIPTION
## Summary
- show a **View All Photos** button when a plant has more than three pictures
- soften gallery thumbnails with `rounded-lg`
- update sample data with an extra image
- document the new gallery behaviour
- test the View All Photos button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6877f5e7b0f483248692321e921703de