### PR TITLE
Improve dark mode for PlantDetail sections

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -110,11 +110,11 @@ export default function PlantDetail() {
   }
 
   if (!plant) {
-    return <div className="text-gray-700">Plant not found</div>
+    return <div className="text-gray-700 dark:text-gray-200">Plant not found</div>
   }
 
   return (
-    <div className="space-y-4 pt-4 pb-safe px-4 relative text-left">
+    <div className="space-y-4 pt-4 pb-safe px-4 relative text-left text-gray-700 dark:text-gray-200">
       <Toast />
       <div className="space-y-4">
         <div className="rounded-xl shadow-md overflow-hidden relative">
@@ -163,9 +163,9 @@ export default function PlantDetail() {
             )}
           </div>
         </div>
-        <section className="bg-white rounded-xl shadow-sm p-4 space-y-3">
+        <section className="bg-white dark:bg-gray-700 rounded-xl shadow-sm p-4 space-y-3">
           <h3 className="flex items-center gap-2 font-semibold font-headline">
-            <Clock className="w-5 h-5 text-gray-600" aria-hidden="true" />
+            <Clock className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
             Quick Stats
           </h3>
           <div className="flex justify-between items-center text-sm">
@@ -173,7 +173,7 @@ export default function PlantDetail() {
               <Drop className="w-4 h-4" aria-hidden="true" />
               Last watered:
             </span>
-            <span className="text-gray-700">{plant.lastWatered}</span>
+            <span className="text-gray-700 dark:text-gray-200">{plant.lastWatered}</span>
           </div>
           <div className="flex justify-between items-center text-sm">
             <span className="flex items-center gap-1 text-green-600">
@@ -181,7 +181,7 @@ export default function PlantDetail() {
               Next watering:
             </span>
             <div className="flex items-center gap-2">
-              <span className="text-gray-700">{plant.nextWater}</span>
+              <span className="text-gray-700 dark:text-gray-200">{plant.nextWater}</span>
               <button
                 type="button"
                 onClick={handleWatered}
@@ -199,7 +199,7 @@ export default function PlantDetail() {
                 Next fertilizing:
               </span>
               <div className="flex items-center gap-2">
-                <span className="text-gray-700">{plant.nextFertilize}</span>
+                <span className="text-gray-700 dark:text-gray-200">{plant.nextFertilize}</span>
                 <button
                   type="button"
                   onClick={handleFertilized}
@@ -217,19 +217,19 @@ export default function PlantDetail() {
                 <Flower className="w-4 h-4" aria-hidden="true" />
                 Last fertilized:
               </span>
-              <span className="text-gray-700">{plant.lastFertilized}</span>
+              <span className="text-gray-700 dark:text-gray-200">{plant.lastFertilized}</span>
             </div>
           )}
         </section>
 
-        <section className="bg-white rounded-xl shadow-sm p-4 space-y-3">
+        <section className="bg-white dark:bg-gray-700 rounded-xl shadow-sm p-4 space-y-3">
           <h3 className="flex items-center gap-2 font-semibold font-headline">
-            <Sun className="w-5 h-5 text-yellow-600" aria-hidden="true" />
+            <Sun className="w-5 h-5 text-yellow-600 dark:text-yellow-400" aria-hidden="true" />
             Care Profile
           </h3>
           {plant.light && (
             <>
-              <h4 className="text-xs font-semibold text-gray-500 mb-1">Light Needs</h4>
+              <h4 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1">Light Needs</h4>
               <div className="flex gap-2 mb-3">
                 <Badge Icon={Sun} colorClass="bg-yellow-50 text-yellow-800 text-xs">
                   {plant.light}
@@ -237,7 +237,7 @@ export default function PlantDetail() {
               </div>
             </>
           )}
-          <h4 className="text-xs font-semibold text-gray-500 mb-1 mt-1">Care Tags</h4>
+          <h4 className="text-xs font-semibold text-gray-500 dark:text-gray-400 mb-1 mt-1">Care Tags</h4>
           <div className="flex flex-wrap gap-2">
             {plant.humidity && (
               <Badge Icon={Drop} colorClass="bg-blue-50 text-blue-800 text-xs">
@@ -252,21 +252,21 @@ export default function PlantDetail() {
           </div>
         </section>
 
-        <section className="bg-white rounded-xl shadow-sm p-4 space-y-4">
+        <section className="bg-white dark:bg-gray-700 rounded-xl shadow-sm p-4 space-y-4">
           <h3 className="flex items-center gap-2 font-semibold font-headline mb-1">
-            <Note className="w-5 h-5 text-gray-600" aria-hidden="true" />
+            <Note className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
             Activity & Notes
           </h3>
           {groupedEvents.map(([monthKey, list]) => (
             <div key={monthKey} className="mt-2 first:mt-0">
-              <div className="text-sm font-semibold text-gray-500">{formatMonth(monthKey)}</div>
+              <div className="text-sm font-semibold text-gray-500 dark:text-gray-400">{formatMonth(monthKey)}</div>
               <div className="ml-3 border-l-2 border-gray-200 space-y-4 mt-2 pl-5">
                 {list.map((e, i) => {
                   const Icon = actionIcons[e.type]
                   return (
                     <div key={`${e.date}-${i}`} className="relative text-sm">
                       <div className={`absolute -left-5 top-1 w-3 h-3 rounded-full ${bulletColors[e.type]}`}></div>
-                      <p className="flex items-start gap-2 text-gray-700 ml-1">
+                      <p className="flex items-start gap-2 text-gray-700 dark:text-gray-200 ml-1">
                         {Icon && <Icon className={`w-4 h-4 ${iconColors[e.type]}`} aria-hidden="true" />}
                         <span>
                           <span className="font-medium">{formatDate(e.date)}</span> — {e.label}
@@ -284,16 +284,16 @@ export default function PlantDetail() {
           <button
             type="button"
             onClick={handleLogEvent}
-            className="mt-2 inline-flex items-center gap-1 px-2 py-1 bg-gray-100 rounded text-sm"
+            className="mt-2 inline-flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-600 rounded text-sm"
           >
             + Add Note
           </button>
         </section>
       </div>
 
-      <section className="bg-white rounded-xl shadow-sm p-4 space-y-2">
+      <section className="bg-white dark:bg-gray-700 rounded-xl shadow-sm p-4 space-y-2">
         <h3 className="flex items-center gap-2 font-semibold font-headline mb-1">
-          <Image className="w-5 h-5 text-gray-600" aria-hidden="true" />
+          <Image className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
           Gallery
         </h3>
         <div className="flex gap-3 overflow-x-auto pb-2">


### PR DESCRIPTION
## Summary
- tweak `<section>` elements in PlantDetail for dark theme
- adjust text/icon colors for better contrast

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6877f85866bc83249abc864673d9f322