### PR TITLE
Merge quick stats and care profile; adjust timeline

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -180,7 +180,7 @@ export default function PlantDetail() {
               <CalendarCheck className="w-4 h-4" aria-hidden="true" />
               Next watering:
             </span>
-            <div className="flex items-center gap-2">
+            <div className="flex items-center gap-3">
               <span className="text-gray-700">{plant.nextWater}</span>
               <button
                 type="button"
@@ -198,7 +198,7 @@ export default function PlantDetail() {
                 <Flower className="w-4 h-4" aria-hidden="true" />
                 Next fertilizing:
               </span>
-              <div className="flex items-center gap-2">
+              <div className="flex items-center gap-3">
                 <span className="text-gray-700">{plant.nextFertilize}</span>
                 <button
                   type="button"
@@ -220,13 +220,11 @@ export default function PlantDetail() {
               <span className="text-gray-700">{plant.lastFertilized}</span>
             </div>
           )}
-        </section>
-
-        <section className="bg-white rounded-xl shadow-sm p-4 space-y-3">
-          <h3 className="flex items-center gap-2 font-semibold font-headline">
-            <Sun className="w-5 h-5 text-yellow-600" aria-hidden="true" />
-            Care Profile
-          </h3>
+          <div className="border-t pt-3 space-y-3">
+            <h3 className="flex items-center gap-2 font-semibold font-headline">
+              <Sun className="w-5 h-5 text-yellow-600" aria-hidden="true" />
+              Care Profile
+            </h3>
           {plant.light && (
             <>
               <h4 className="text-xs font-semibold text-gray-500 mb-1">Light Needs</h4>
@@ -249,6 +247,7 @@ export default function PlantDetail() {
                 {plant.difficulty}
               </Badge>
             )}
+          </div>
           </div>
         </section>
 

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -37,7 +37,7 @@ export default function Timeline() {
       <div className="rounded-xl bg-white shadow-sm p-4 border border-gray-100">
         {groupedEvents.map(([monthKey, list]) => (
           <div key={monthKey} className="mt-6 first:mt-0">
-            <h3 className="text-xs uppercase tracking-wider text-gray-400 mb-2">
+            <h3 className="text-[0.7rem] uppercase tracking-wider text-gray-300 mb-2">
               {formatMonth(monthKey)}
             </h3>
             <ul className="ml-3 border-l-2 border-gray-200 space-y-6 pl-5">


### PR DESCRIPTION
## Summary
- keep Quick Stats and Care Profile headings in a single section
- increase spacing before "Water Now" and "Fertilize Now" buttons
- lighten and shrink timeline month headers

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6877f5c87f088324ad7c23d6ea215022