### PR TITLE
Improve bottom navigation interaction

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -1,44 +1,40 @@
 import { NavLink } from 'react-router-dom'
 import {
-  HomeIcon,
-  ListBulletIcon,
-  CalendarIcon,
-  PersonIcon,
-} from '@radix-ui/react-icons'
-
-const iconProps = {
-  className: 'w-6 h-6',
-  'aria-hidden': 'true',
-}
-
-const HomeIconComponent = () => <HomeIcon {...iconProps} />
-const ListIcon = () => <ListBulletIcon {...iconProps} />
-const CalendarIconComponent = () => <CalendarIcon {...iconProps} />
-const UserIcon = () => <PersonIcon {...iconProps} />
+  House,
+  ListBullets,
+  CalendarBlank,
+  UserCircle,
+} from 'phosphor-react'
 
 export default function BottomNav() {
   const items = [
-    { to: '/', label: 'Home', icon: HomeIconComponent },
-    { to: '/myplants', label: 'My Plants', icon: ListIcon },
-    { to: '/timeline', label: 'Timeline', icon: CalendarIconComponent },
-    { to: '/profile', label: 'Profile', icon: UserIcon },
+    { to: '/', label: 'Home', Icon: House },
+    { to: '/myplants', label: 'My Plants', Icon: ListBullets },
+    { to: '/timeline', label: 'Timeline', Icon: CalendarBlank },
+    { to: '/profile', label: 'Profile', Icon: UserCircle },
   ]
 
   return (
     <nav
       className="fixed bottom-4 inset-x-4 bg-white/90 dark:bg-gray-700/90 rounded-full backdrop-blur-md shadow-lg px-8 pt-2 pb-3 flex justify-between items-center pb-safe"
     >
-      {items.map(({ to, label, icon: Icon }) => (
+      {items.map(({ to, label, Icon }) => (
         <NavLink
           key={to}
           to={to}
           className={({ isActive }) =>
-            `flex flex-col items-center gap-0.5 px-2 py-1 text-xs font-medium transition-colors duration-150 rounded-full ${isActive ? 'bg-accent/20 text-accent' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}`
+            `flex flex-col items-center gap-0.5 px-2 py-1 text-xs font-medium transition-colors duration-150 rounded-full ${isActive ? 'text-accent' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}`
           }
         >
           {({ isActive }) => (
             <>
-              <Icon className="w-6 h-6" aria-hidden="true" />
+              <span className={`flex items-center justify-center w-10 h-8 rounded-full ${isActive ? 'bg-accent/20' : ''}`}>
+                <Icon
+                  weight={isActive ? 'fill' : 'regular'}
+                  className={`w-6 h-6 ${isActive ? 'animate-bounce-once' : ''}`}
+                  aria-hidden="true"
+                />
+              </span>
               <span className="sr-only">{label}</span>
               {isActive && <span className="text-xs">{label}</span>}
             </>


### PR DESCRIPTION
## Summary
- switch bottom nav to Phosphor icons for consistent stroke weight
- highlight active tab with pill background and bounce animation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878005bf784832490f16983371eabd8