### PR TITLE
Remove label from active nav icons

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -36,7 +36,6 @@ export default function BottomNav() {
                 />
               </span>
               <span className="sr-only">{label}</span>
-              {isActive && <span className="text-xs">{label}</span>}
             </>
           )}
         </NavLink>


### PR DESCRIPTION
## Summary
- show only icons in BottomNav's active state

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6878037ba90c83248c26309077a60814