### PR TITLE
Add swipeable task cards

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,6 +1,12 @@
-import { CheckCircle } from 'phosphor-react'
+import { useState, useRef } from 'react'
+import { useNavigate } from 'react-router-dom'
+import { CheckCircle, Drop, Sun } from 'phosphor-react'
 import actionIcons from './ActionIcons.jsx'
 import { getWateringInfo } from '../utils/watering.js'
+import useSwipe from '../hooks/useSwipe.js'
+import { createRipple } from '../utils/interactions.js'
+import { usePlants } from '../PlantContext.jsx'
+import NoteModal from './NoteModal.jsx'
 import Badge from './Badge.jsx'
 
 export default function TaskCard({
@@ -13,100 +19,230 @@ export default function TaskCard({
   const Icon = actionIcons[task.type]
   const { daysSince, eto } = getWateringInfo(task.lastWatered, { eto: task.eto })
 
+  const navigate = useNavigate()
+  const { markWatered, markFertilized, logEvent, updatePlant } = usePlants()
+
+  const [showMenu, setShowMenu] = useState(false)
+  const [showNote, setShowNote] = useState(false)
+  const [animateComplete, setAnimateComplete] = useState(false)
+  const LONG_PRESS_MS = 600
+  const COMPLETE_THRESHOLD = 80
+  const MENU_THRESHOLD = 60
+  const longPressTimer = useRef(null)
+
+  const handleComplete = () => {
+    if (task.type === 'Water') {
+      markWatered(task.plantId, '')
+    } else if (task.type === 'Fertilize') {
+      markFertilized(task.plantId, '')
+    }
+    setAnimateComplete(true)
+    navigator.vibrate?.(10)
+    setTimeout(() => setAnimateComplete(false), 600)
+  }
+
+  const handleAddNote = () => {
+    setShowMenu(false)
+    setShowNote(true)
+  }
+
+  const handleSaveNote = note => {
+    if (note) {
+      logEvent(task.plantId, 'Note', note)
+    }
+    setShowNote(false)
+  }
+
+  const handleSnooze = () => {
+    const tomorrow = new Date()
+    tomorrow.setDate(tomorrow.getDate() + 1)
+    if (task.type === 'Water') {
+      updatePlant(task.plantId, {
+        nextWater: tomorrow.toISOString().slice(0, 10),
+      })
+    } else if (task.type === 'Fertilize') {
+      updatePlant(task.plantId, {
+        nextFertilize: tomorrow.toISOString().slice(0, 10),
+      })
+    }
+    setShowMenu(false)
+  }
+
+  const handleEdit = () => {
+    navigate(`/plant/${task.plantId}/edit`)
+    setShowMenu(false)
+  }
+
+  const { dx: deltaX, start, move, end } = useSwipe(diff => {
+    if (diff > COMPLETE_THRESHOLD) {
+      handleComplete()
+    } else if (diff < -MENU_THRESHOLD) {
+      setShowMenu(true)
+      navigator.vibrate?.(10)
+    }
+  })
+
+  const handlePointerDown = e => {
+    createRipple(e)
+    start(e)
+    longPressTimer.current = setTimeout(() => setShowMenu(true), LONG_PRESS_MS)
+  }
+
+  const handlePointerMove = e => {
+    move(e)
+    if (Math.abs(deltaX) > 5 && longPressTimer.current) {
+      clearTimeout(longPressTimer.current)
+      longPressTimer.current = null
+    }
+  }
+
+  const handlePointerUp = e => {
+    clearTimeout(longPressTimer.current)
+    longPressTimer.current = null
+    end(e)
+  }
+
   return (
-    <div
-      data-testid="task-card"
-      tabIndex="0"
-      aria-label={`Task card for ${task.plantName}`}
-      className={`relative flex items-center gap-3 px-4 py-3 rounded-xl overflow-hidden shadow-sm ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
-    >
-      <div className="flex items-center flex-1 gap-3">
-        <img src={task.image} alt={task.plantName} className="w-12 h-12 rounded-lg object-cover" />
-        <div className="flex-1 min-w-0">
-          <div className="flex items-center justify-between gap-2">
-            <p className="font-medium text-gray-900 dark:text-gray-100 truncate">
-              {task.plantName}
-            </p>
-            {Icon && (
-              <Icon aria-hidden="true" className="w-5 h-5 text-gray-500 dark:text-gray-400 shrink-0" />
-            )}
-          </div>
-          <p className="text-sm flex flex-wrap items-center gap-1 text-gray-500">
-            <Badge
-              colorClass={`text-sm font-medium ${
-                task.type === 'Water'
-                  ? 'bg-water-100 text-water-800'
-                  : task.type === 'Fertilize'
-                  ? 'bg-fertilize-100 text-fertilize-800'
-                  : 'bg-healthy-100 text-healthy-800'
-              }`}
+    <>
+      {showNote && (
+        <NoteModal label="Add Note" onSave={handleSaveNote} onCancel={() => setShowNote(false)} />
+      )}
+      <div
+        data-testid="task-card"
+        tabIndex="0"
+        aria-label={`Task card for ${task.plantName}`}
+        onPointerDown={handlePointerDown}
+        onPointerMove={handlePointerMove}
+        onPointerUp={handlePointerUp}
+        onPointerCancel={handlePointerUp}
+        onMouseDown={handlePointerDown}
+        onMouseMove={handlePointerMove}
+        onMouseUp={handlePointerUp}
+        onTouchStart={handlePointerDown}
+        onTouchMove={handlePointerMove}
+        onTouchEnd={handlePointerUp}
+        className="relative overflow-hidden rounded-xl"
+      >
+        {showMenu && (
+          <div className="absolute inset-0 flex justify-end items-center gap-2 pr-4 bg-gray-100 dark:bg-gray-600">
+            <button
+              type="button"
+              onClick={handleAddNote}
+              className="bg-white dark:bg-gray-700 px-3 py-1 rounded text-sm"
             >
-              {completed
-                ? task.type === 'Water'
-                  ? 'Watered'
-                  : task.type === 'Fertilize'
-                  ? 'Fertilized'
-                  : task.type
-                : task.type === 'Water'
-                ? 'To Water'
-                : task.type === 'Fertilize'
-                ? 'To Fertilize'
-                : task.type}
-            </Badge>
-            {daysSince != null && (
-              <span className="text-sm text-gray-500">
-                · {daysSince} {daysSince === 1 ? 'day' : 'days'} since care
+              Add Note
+            </button>
+            <button
+              type="button"
+              onClick={handleSnooze}
+              className="bg-white dark:bg-gray-700 px-3 py-1 rounded text-sm"
+            >
+              Snooze
+            </button>
+            <button
+              type="button"
+              onClick={handleEdit}
+              className="bg-white dark:bg-gray-700 px-3 py-1 rounded text-sm"
+            >
+              Edit Plant
+            </button>
+          </div>
+        )}
+        <div
+          className={`relative flex items-center gap-3 px-4 py-3 shadow-sm ${completed || animateComplete ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
+          style={{ transform: `translateX(${showMenu ? -100 : deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
+        >
+          <div className="flex items-center flex-1 gap-3">
+            <img src={task.image} alt={task.plantName} className="w-12 h-12 rounded-lg object-cover" />
+            <div className="flex-1 min-w-0">
+              <div className="flex items-center justify-between gap-2">
+                <p className="font-semibold text-gray-900 dark:text-gray-100 truncate">
+                  {task.plantName}
+                </p>
+                {Icon && (
+                  <Icon aria-hidden="true" className="w-5 h-5 text-gray-500 dark:text-gray-400 shrink-0" />
+                )}
+              </div>
+              <div className="text-sm flex flex-wrap items-center gap-1 text-gray-500 mt-0.5">
+                <Badge
+                  Icon={task.type === 'Water' ? Drop : task.type === 'Fertilize' ? Sun : undefined}
+                  colorClass={`text-sm font-medium ${
+                    task.type === 'Water'
+                      ? 'bg-water-100 text-water-800'
+                      : task.type === 'Fertilize'
+                      ? 'bg-fertilize-100 text-fertilize-800'
+                      : 'bg-healthy-100 text-healthy-800'
+                  }`}
+                >
+                  {completed || animateComplete
+                    ? task.type === 'Water'
+                      ? 'Watered!'
+                      : task.type === 'Fertilize'
+                      ? 'Fertilized!'
+                      : task.type
+                    : task.type === 'Water'
+                    ? 'To Water'
+                    : task.type === 'Fertilize'
+                    ? 'To Fertilize'
+                    : task.type}
+                </Badge>
+                {daysSince != null && (
+                  <span className="text-xs text-gray-500">
+                    {daysSince} {daysSince === 1 ? 'day' : 'days'} since care
+                  </span>
+                )}
+              </div>
+              {!compact && task.reason && (
+                <p className="text-xs text-gray-500 font-body mt-0.5">{task.reason}</p>
+              )}
+            </div>
+          </div>
+          <button
+            type="button"
+            disabled
+            className="ml-auto relative focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-healthy-500"
+            aria-label="Mark complete"
+          >
+            <input type="checkbox" checked={completed || animateComplete} readOnly className="sr-only task-checkbox" />
+            <CheckCircle aria-hidden="true" className={`w-6 h-6 ${completed || animateComplete ? 'text-healthy-500' : 'text-gray-400'}`} />
+            {overdue && (
+              <span
+                className="absolute -top-1 -right-1 bg-fertilize-500 text-white rounded-full w-4 h-4 flex items-center justify-center text-xs overdue-ping"
+                data-testid="overdue-badge"
+              >
+                !
               </span>
             )}
-          </p>
-          {!compact && task.reason && (
-            <p className="text-xs text-gray-500 font-body">{task.reason}</p>
+          </button>
+          {(completed || animateComplete) && (
+            <div className="absolute inset-0 flex items-center justify-center pointer-events-none task-complete-fade">
+              <svg
+                className="w-8 h-8 text-healthy-600 check-pop"
+                xmlns="http://www.w3.org/2000/svg"
+                fill="none"
+                viewBox="0 0 24 24"
+                strokeWidth="1.5"
+                stroke="currentColor"
+                aria-hidden="true"
+              >
+                <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+              </svg>
+            </div>
+          )}
+          {!compact && (
+            <div className="mt-2">
+              <span
+                className="px-2 py-0.5 text-sm rounded-full bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-gray-100 opacity-70"
+                aria-label={`Evapotranspiration (ET₀): ${eto ?? 'N/A'} mm | Last watered ${daysSince ?? '?'} days ago`}
+                title="Evapotranspiration (ET₀) is water lost from soil and plants"
+              >
+                Evapotranspiration (ET₀): {eto ?? '—'} mm | Last watered {daysSince ?? '?'} days ago
+              </span>
+            </div>
           )}
         </div>
       </div>
-      <button
-        type="button"
-        disabled
-        className="ml-auto relative focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-healthy-500"
-        aria-label="Mark complete"
-      >
-        <input type="checkbox" checked={completed} readOnly className="sr-only task-checkbox" />
-        <CheckCircle aria-hidden="true" className={`w-6 h-6 ${completed ? 'text-healthy-500' : 'text-gray-400'}`} />
-        {overdue && (
-          <span
-            className="absolute -top-1 -right-1 bg-fertilize-500 text-white rounded-full w-4 h-4 flex items-center justify-center text-xs overdue-ping"
-            data-testid="overdue-badge"
-          >
-            !
-          </span>
-        )}
-      </button>
-      {completed && (
-        <div className="absolute inset-0 flex items-center justify-center pointer-events-none task-complete-fade">
-          <svg
-            className="w-8 h-8 text-healthy-600 check-pop"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth="1.5"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-          </svg>
-        </div>
-      )}
-      {!compact && (
-        <div className="mt-2">
-          <span
-            className="px-2 py-0.5 text-sm rounded-full bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-gray-100 opacity-70"
-            aria-label={`Evapotranspiration (ET₀): ${eto ?? 'N/A'} mm | Last watered ${daysSince ?? '?'} days ago`}
-            title="Evapotranspiration (ET₀) is water lost from soil and plants"
-          >
-            Evapotranspiration (ET₀): {eto ?? '—'} mm | Last watered {daysSince ?? '?'} days ago
-          </span>
-        </div>
-      )}
-    </div>
+    </>
   )
 }
+

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -6,140 +6,175 @@ exports[`matches snapshot in dark mode 1`] = `
 >
   <div
     aria-label="Task card for Monstera"
-    class="relative flex items-center gap-3 px-4 py-3 rounded-xl overflow-hidden shadow-sm bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
+    class="relative overflow-hidden rounded-xl"
     data-testid="task-card"
     tabindex="0"
   >
     <div
-      class="flex items-center flex-1 gap-3"
+      class="relative flex items-center gap-3 px-4 py-3 shadow-sm bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
+      style="transform: translateX(0px); transition: transform 0.2s;"
     >
-      <img
-        alt="Monstera"
-        class="w-12 h-12 rounded-lg object-cover"
-        src="https://images.pexels.com/photos/5699660/pexels-photo-5699660.jpeg"
-      />
       <div
-        class="flex-1 min-w-0"
+        class="flex items-center flex-1 gap-3"
       >
+        <img
+          alt="Monstera"
+          class="w-12 h-12 rounded-lg object-cover"
+          src="https://images.pexels.com/photos/5699660/pexels-photo-5699660.jpeg"
+        />
         <div
-          class="flex items-center justify-between gap-2"
+          class="flex-1 min-w-0"
         >
-          <p
-            class="font-medium text-gray-900 dark:text-gray-100 truncate"
+          <div
+            class="flex items-center justify-between gap-2"
           >
-            Monstera
-          </p>
-          <svg
-            aria-hidden="true"
-            class="w-5 h-5 text-gray-500 dark:text-gray-400 shrink-0"
-            fill="currentColor"
-            height="1em"
-            viewBox="0 0 256 256"
-            width="1em"
-            xmlns="http://www.w3.org/2000/svg"
+            <p
+              class="font-semibold text-gray-900 dark:text-gray-100 truncate"
+            >
+              Monstera
+            </p>
+            <svg
+              aria-hidden="true"
+              class="w-5 h-5 text-gray-500 dark:text-gray-400 shrink-0"
+              fill="currentColor"
+              height="1em"
+              viewBox="0 0 256 256"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                fill="none"
+                height="256"
+                width="256"
+              />
+              <path
+                d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <path
+                d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+            </svg>
+          </div>
+          <div
+            class="text-sm flex flex-wrap items-center gap-1 text-gray-500 mt-0.5"
           >
-            <rect
-              fill="none"
-              height="256"
-              width="256"
-            />
-            <path
-              d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="16"
-            />
-            <path
-              d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
-              fill="none"
-              stroke="currentColor"
-              stroke-linecap="round"
-              stroke-linejoin="round"
-              stroke-width="16"
-            />
-          </svg>
+            <span
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-sm font-medium bg-water-100 text-water-800"
+            >
+              <svg
+                aria-hidden="true"
+                class="w-3 h-3"
+                fill="currentColor"
+                height="1em"
+                viewBox="0 0 256 256"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  fill="none"
+                  height="256"
+                  width="256"
+                />
+                <path
+                  d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="16"
+                />
+                <path
+                  d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="16"
+                />
+              </svg>
+              To Water
+            </span>
+            <span
+              class="text-xs text-gray-500"
+            >
+              9
+               
+              days
+               since care
+            </span>
+          </div>
         </div>
-        <p
-          class="text-sm flex flex-wrap items-center gap-1 text-gray-500"
-        >
-          <span
-            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-sm font-medium bg-water-100 text-water-800"
-          >
-            To Water
-          </span>
-          <span
-            class="text-sm text-gray-500"
-          >
-            · 
-            9
-             
-            days
-             since care
-          </span>
-        </p>
       </div>
-    </div>
-    <button
-      aria-label="Mark complete"
-      class="ml-auto relative focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-healthy-500"
-      disabled=""
-      type="button"
-    >
-      <input
-        class="sr-only task-checkbox"
-        readonly=""
-        type="checkbox"
-      />
-      <svg
-        aria-hidden="true"
-        class="w-6 h-6 text-gray-400"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 256 256"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
+      <button
+        aria-label="Mark complete"
+        class="ml-auto relative focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-healthy-500"
+        disabled=""
+        type="button"
       >
-        <rect
-          fill="none"
-          height="256"
-          width="256"
+        <input
+          class="sr-only task-checkbox"
+          readonly=""
+          type="checkbox"
         />
-        <polyline
-          fill="none"
-          points="172 104 113.3 160 84 132"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-        <circle
-          cx="128"
-          cy="128"
-          fill="none"
-          r="96"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-      </svg>
-    </button>
-    <div
-      class="mt-2"
-    >
-      <span
-        aria-label="Evapotranspiration (ET₀): N/A mm | Last watered 9 days ago"
-        class="px-2 py-0.5 text-sm rounded-full bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-gray-100 opacity-70"
-        title="Evapotranspiration (ET₀) is water lost from soil and plants"
+        <svg
+          aria-hidden="true"
+          class="w-6 h-6 text-gray-400"
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 256 256"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            fill="none"
+            height="256"
+            width="256"
+          />
+          <polyline
+            fill="none"
+            points="172 104 113.3 160 84 132"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+          <circle
+            cx="128"
+            cy="128"
+            fill="none"
+            r="96"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+        </svg>
+      </button>
+      <div
+        class="mt-2"
       >
-        Evapotranspiration (ET₀): 
-        —
-         mm | Last watered 
-        9
-         days ago
-      </span>
+        <span
+          aria-label="Evapotranspiration (ET₀): N/A mm | Last watered 9 days ago"
+          class="px-2 py-0.5 text-sm rounded-full bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-gray-100 opacity-70"
+          title="Evapotranspiration (ET₀) is water lost from soil and plants"
+        >
+          Evapotranspiration (ET₀): 
+          —
+           mm | Last watered 
+          9
+           days ago
+        </span>
+      </div>
     </div>
   </div>
 </div>

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -142,6 +142,9 @@ test('completed tasks are styled', () => {
     </MemoryRouter>
   )
   const cards = screen.getAllByTestId('task-card')
-  expect(cards[0]).toHaveClass('opacity-50')
-  expect(cards.some(c => c.textContent.includes('Watered'))).toBe(true)
+  const inner = cards[0].querySelector('.shadow-sm')
+  expect(inner).toHaveClass('opacity-50')
+  expect(Array.from(cards).some(c => c.textContent.includes('Watered'))).toBe(
+    true
+  )
 })


### PR DESCRIPTION
## Summary
- enable swipe gestures for TaskCard
- show context menu on left swipe and completion on right swipe
- update tests and snapshots for new TaskCard UI

## Testing
- `npm test --silent -- -u`

------
https://chatgpt.com/codex/tasks/task_e_687802e8f2ec8324a144dd2db1f275d9