### PR TITLE
Move badges to top right in plant detail

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -152,7 +152,7 @@ export default function PlantDetail() {
             )}
           </div>
           <div
-            className="absolute bottom-2 right-2 flex flex-wrap gap-2"
+            className="absolute top-2 right-2 z-10 flex flex-wrap gap-2"
             aria-label="Care tags"
           >
             {plant.light && (


### PR DESCRIPTION
## Summary
- reposition the care badge container to the top right of the PlantDetail image
- ensure badges appear above the image gradient

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68780a3091a8832486e670b0ecf3eb7e