### PR TITLE
Refactor nav into floating menu

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -1,12 +1,15 @@
+import { useState } from 'react'
 import { NavLink } from 'react-router-dom'
 import {
   House,
   ListBullets,
   CalendarBlank,
   UserCircle,
+  Hamburger,
 } from 'phosphor-react'
 
 export default function BottomNav() {
+  const [open, setOpen] = useState(false)
   const items = [
     { to: '/', label: 'Home', Icon: House },
     { to: '/myplants', label: 'My Plants', Icon: ListBullets },
@@ -15,31 +18,37 @@ export default function BottomNav() {
   ]
 
   return (
-    <nav
-      className="fixed bottom-4 inset-x-4 bg-white/90 dark:bg-gray-700/90 rounded-full backdrop-blur-md shadow-lg px-8 pt-2 pb-3 flex justify-between items-center pb-safe"
-    >
-      {items.map(({ to, label, Icon }) => (
-        <NavLink
-          key={to}
-          to={to}
-          className={({ isActive }) =>
-            `flex flex-col items-center gap-0.5 px-2 py-1 text-xs font-medium transition-colors duration-150 rounded-full ${isActive ? 'text-accent' : 'text-gray-500 hover:text-gray-700 dark:hover:text-gray-300'}`
-          }
-        >
-          {({ isActive }) => (
-            <>
-              <span className={`flex items-center justify-center w-10 h-8 rounded-full ${isActive ? 'bg-accent/20' : ''}`}>
-                <Icon
-                  weight={isActive ? 'fill' : 'regular'}
-                  className={`w-6 h-6 ${isActive ? 'animate-bounce-once' : ''}`}
-                  aria-hidden="true"
-                />
-              </span>
-              <span className="sr-only">{label}</span>
-            </>
-          )}
-        </NavLink>
-      ))}
-    </nav>
+    <div className="fixed bottom-4 right-4 flex flex-col items-end z-20">
+      {open && (
+        <ul className="mb-2 bg-white dark:bg-gray-700 rounded-lg shadow-lg text-sm overflow-hidden py-2">
+          {items.map(({ to, label, Icon }) => (
+            <li key={to}>
+              <NavLink
+                to={to}
+                onClick={() => setOpen(false)}
+                className={({ isActive }) =>
+                  `flex items-center gap-2 px-3 py-2 w-full hover:bg-gray-100 dark:hover:bg-gray-600 ${isActive ? 'text-accent' : ''}`
+                }
+              >
+                {({ isActive }) => (
+                  <>
+                    <Icon weight={isActive ? 'fill' : 'regular'} className="w-4 h-4" aria-hidden="true" />
+                    {label}
+                  </>
+                )}
+              </NavLink>
+            </li>
+          ))}
+        </ul>
+      )}
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-label="Open navigation menu"
+        className="bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700"
+      >
+        <Hamburger className="w-6 h-6" aria-hidden="true" />
+      </button>
+    </div>
   )
 }

--- a/src/components/__tests__/BottomNav.test.jsx
+++ b/src/components/__tests__/BottomNav.test.jsx
@@ -1,4 +1,4 @@
-import { render } from '@testing-library/react'
+import { render, fireEvent, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import BottomNav from '../BottomNav.jsx'
 
@@ -20,6 +20,8 @@ test('does not render gallery link', () => {
       <BottomNav />
     </MemoryRouter>
   )
+  // open the menu
+  fireEvent.click(screen.getByRole('button', { name: /open navigation menu/i }))
   const galleryLink = container.querySelector('a[href="/gallery"]')
   expect(galleryLink).toBeNull()
 })
@@ -30,6 +32,7 @@ test('renders timeline navigation link', () => {
       <BottomNav />
     </MemoryRouter>
   )
+  fireEvent.click(screen.getByRole('button', { name: /open navigation menu/i }))
   const timelineLink = container.querySelector('a[href="/timeline"]')
   expect(timelineLink).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- switch `BottomNav` to a floating FAB-style navigation menu
- update nav test for expandable menu behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6878080fd1188324b4445fb9eca018a4