### PR TITLE
Remove Care Tags heading

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -217,12 +217,6 @@ export default function PlantDetail() {
             )}
           </ul>
 
-          <div className="border-t pt-3 space-y-3">
-            <h3 className="flex items-center gap-2 font-semibold font-headline">
-              <Sun className="w-5 h-5 text-yellow-600" aria-hidden="true" />
-              Care Tags
-            </h3>
-          </div>
         </section>
 
 


### PR DESCRIPTION
## Summary
- remove "Care Tags" heading on PlantDetail page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68780bc084e4832496cf4a57ed030db1