### PR TITLE
Add back button to plant detail

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -11,6 +11,7 @@ import {
   Image,
   Note,
   Info,
+  ArrowLeft,
 } from 'phosphor-react'
 
 import Lightbox from '../components/Lightbox.jsx'
@@ -91,6 +92,10 @@ export default function PlantDetail() {
     navigate(`/plant/${plant.id}/edit`)
   }
 
+  const handleBack = () => {
+    navigate(-1)
+  }
+
   const { setMenu } = useMenu()
 
   useEffect(() => {
@@ -143,6 +148,14 @@ export default function PlantDetail() {
             className="w-full h-64 object-cover"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent" aria-hidden="true"></div>
+          <button
+            type="button"
+            onClick={handleBack}
+            className="absolute top-2 left-2 bg-white bg-opacity-70 rounded px-2 py-1 text-sm flex items-center gap-1"
+          >
+            <ArrowLeft className="w-4 h-4" aria-hidden="true" />
+            Back
+          </button>
           <div className="absolute bottom-3 left-4 text-white drop-shadow">
             <h2 className="text-2xl font-semibold font-headline">{plant.name}</h2>
             {plant.nickname && (

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -148,3 +148,23 @@ test('view all button opens the viewer from first image', () => {
   const viewerImg = screen.getByAltText(/gallery image/i)
   expect(viewerImg).toHaveAttribute('src', plant.photos[0].src)
 })
+
+test('back button navigates to previous page', () => {
+  const plant = plants[0]
+  render(
+    <MenuProvider>
+      <PlantProvider>
+        <MemoryRouter initialEntries={['/myplants', `/plant/${plant.id}`]} initialIndex={1}>
+          <Routes>
+            <Route path="/myplants" element={<div>My Plants View</div>} />
+            <Route path="/plant/:id" element={<PlantDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </PlantProvider>
+    </MenuProvider>
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /back/i }))
+
+  expect(screen.getByText(/my plants view/i)).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- add `ArrowLeft` import and helper function for navigation
- render a back button overlay on the PlantDetail hero image
- test that the button returns to the previous route

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687817afd4c48324b5e3bf4a06a0ee44