### PR TITLE
Implement urgency-based styling for Quick Stats

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -41,6 +41,12 @@ const bulletColors = {
   noteText: 'bg-gray-400',
 }
 
+const urgencyColors = {
+  high: 'text-red-600',
+  medium: 'text-yellow-600',
+  low: 'text-green-600',
+}
+
 export default function PlantDetail() {
   const { id } = useParams()
   const { plants, addPhoto, removePhoto, markWatered, markFertilized, logEvent } = usePlants()
@@ -53,6 +59,8 @@ export default function PlantDetail() {
   const [lightboxIndex, setLightboxIndex] = useState(null)
   const [showLegend, setShowLegend] = useState(false)
   const [collapsedMonths, setCollapsedMonths] = useState({})
+
+  const urgencyClass = urgencyColors[plant?.urgency] || ''
 
   const events = useMemo(() => buildEvents(plant), [plant])
   const groupedEvents = useMemo(
@@ -198,7 +206,7 @@ export default function PlantDetail() {
         </div>
         </div>
         <section className="bg-white dark:bg-gray-700 rounded-xl shadow-sm p-4 space-y-3">
-          <h3 className="flex items-center gap-2 font-semibold font-headline">
+          <h3 className={`flex items-center gap-2 font-semibold font-headline ${urgencyClass}`}>
             <Clock className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
             Quick Stats
           </h3>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -77,6 +77,28 @@ test('displays all sections', () => {
   expect(screen.getByRole('heading', { name: /gallery/i })).toBeInTheDocument()
 })
 
+test.each([
+  { index: 0, urgency: 'high', cls: 'text-red-600' },
+  { index: 1, urgency: 'low', cls: 'text-green-600' },
+  { index: 2, urgency: 'medium', cls: 'text-yellow-600' },
+])('applies urgency class for $urgency plants', ({ index, cls }) => {
+  const plant = plants[index]
+  render(
+    <MenuProvider>
+      <PlantProvider>
+        <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+          <Routes>
+            <Route path="/plant/:id" element={<PlantDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </PlantProvider>
+    </MenuProvider>
+  )
+
+  const heading = screen.getByRole('heading', { name: /quick stats/i })
+  expect(heading).toHaveClass(cls)
+})
+
 
 test('opens lightbox from gallery', () => {
 


### PR DESCRIPTION
## Summary
- map plant urgency levels to text color classes
- style Quick Stats header based on urgency
- test Quick Stats header styling for various urgency values

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878274b426083248e2951c17cc9cdbe