### PR TITLE
Add care progress rings to PlantDetail

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -24,6 +24,7 @@ import NoteModal from '../components/NoteModal.jsx'
 import { PlusIcon, Pencil1Icon } from '@radix-ui/react-icons'
 import { useMenu, defaultMenu } from '../MenuContext.jsx'
 import LegendModal from '../components/LegendModal.jsx'
+import CareRings from '../components/CareRings.jsx'
 
 import useToast from "../hooks/useToast.jsx"
 import Badge from '../components/Badge.jsx'
@@ -121,6 +122,26 @@ export default function PlantDetail() {
     setCollapsedMonths(defaults)
   }, [groupedEvents])
 
+  const calcPercent = (start, end) => {
+    if (!start || !end) return 0
+    const s = new Date(start)
+    const e = new Date(end)
+    if (isNaN(s) || isNaN(e)) return 0
+    const total = e - s
+    if (total <= 0) return 0
+    const now = new Date()
+    const elapsed = now - s
+    return Math.min(Math.max(elapsed / total, 0), 1)
+  }
+
+  const waterPct = plant
+    ? calcPercent(plant.lastWatered, plant.nextWater)
+    : 0
+  const fertPct = plant
+    ? calcPercent(plant.lastFertilized, plant.nextFertilize)
+    : 0
+
+
 
   const saveNote = note => {
     if (note) {
@@ -195,6 +216,15 @@ export default function PlantDetail() {
               </Badge>
             )}
           </div>
+        </div>
+        </div>
+        <div className="flex justify-center -mt-6">
+          <CareRings
+            waterCompleted={Math.round(waterPct * 100)}
+            waterTotal={plant.lastWatered && plant.nextWater ? 100 : 0}
+            fertCompleted={Math.round(fertPct * 100)}
+            fertTotal={plant.lastFertilized && plant.nextFertilize ? 100 : 0}
+          />
         </div>
         </div>
         <section className="bg-white dark:bg-gray-700 rounded-xl shadow-sm p-4 space-y-3">
@@ -326,7 +356,6 @@ export default function PlantDetail() {
             + Add Note
           </button>
         </section>
-      </div>
 
       <section className="bg-white dark:bg-gray-700 rounded-xl shadow-sm p-4 space-y-2">
         <h3 className="flex items-center gap-2 font-semibold font-headline mb-1">

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -168,3 +168,24 @@ test('back button navigates to previous page', () => {
 
   expect(screen.getByText(/my plants view/i)).toBeInTheDocument()
 })
+
+test('renders care rings with correct percentages', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-04'))
+  const plant = plants[0]
+  render(
+    <MenuProvider>
+      <PlantProvider>
+        <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+          <Routes>
+            <Route path="/plant/:id" element={<PlantDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </PlantProvider>
+    </MenuProvider>
+  )
+
+  expect(
+    screen.getByRole('img', { name: '43% watered, 100% fertilized' })
+  ).toBeInTheDocument()
+  jest.useRealTimers()
+})


### PR DESCRIPTION
## Summary
- add CareRings to the plant detail page
- compute watering/fertilizing progress using plant schedule dates
- guard percent calculations when plant not found
- test care ring display

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878275802e48324a5fe72c7aa0a16ce