### PR TITLE
Add watering progress ring to detail page

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -24,11 +24,13 @@ import NoteModal from '../components/NoteModal.jsx'
 import { PlusIcon, Pencil1Icon } from '@radix-ui/react-icons'
 import { useMenu, defaultMenu } from '../MenuContext.jsx'
 import LegendModal from '../components/LegendModal.jsx'
+import ProgressRing from '../components/ProgressRing.jsx'
 
 import useToast from "../hooks/useToast.jsx"
 import Badge from '../components/Badge.jsx'
 
 import { formatMonth, formatDate } from '../utils/date.js'
+import { getWateringProgress } from '../utils/watering.js'
 
 import { buildEvents, groupEventsByMonth } from '../utils/events.js'
 
@@ -41,7 +43,7 @@ const bulletColors = {
   noteText: 'bg-gray-400',
 }
 
-const urgencyColors = {
+const ringColors = {
   high: 'text-red-600',
   medium: 'text-yellow-600',
   low: 'text-green-600',
@@ -60,7 +62,8 @@ export default function PlantDetail() {
   const [showLegend, setShowLegend] = useState(false)
   const [collapsedMonths, setCollapsedMonths] = useState({})
 
-  const urgencyClass = urgencyColors[plant?.urgency] || ''
+  const ringClass = ringColors[plant?.urgency] || 'text-green-600'
+  const progressPct = getWateringProgress(plant?.lastWatered, plant?.nextWater)
 
   const events = useMemo(() => buildEvents(plant), [plant])
   const groupedEvents = useMemo(
@@ -203,10 +206,22 @@ export default function PlantDetail() {
               </Badge>
             )}
           </div>
+          <div
+            className="absolute bottom-2 right-2"
+            data-testid="watering-ring"
+            aria-label={`Watering progress ${Math.round(progressPct * 100)}%`}
+          >
+            <div className="relative" style={{ width: 48, height: 48 }}>
+              <ProgressRing percent={progressPct} size={48} colorClass={ringClass} />
+              <div className="absolute inset-1 rounded-full bg-white/80 flex items-center justify-center text-[10px] font-semibold">
+                {Math.round(progressPct * 100)}%
+              </div>
+            </div>
+          </div>
         </div>
         </div>
         <section className="bg-white dark:bg-gray-700 rounded-xl shadow-sm p-4 space-y-3">
-          <h3 className={`flex items-center gap-2 font-semibold font-headline ${urgencyClass}`}>
+          <h3 className="flex items-center gap-2 font-semibold font-headline">
             <Clock className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
             Quick Stats
           </h3>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -77,12 +77,8 @@ test('displays all sections', () => {
   expect(screen.getByRole('heading', { name: /gallery/i })).toBeInTheDocument()
 })
 
-test.each([
-  { index: 0, urgency: 'high', cls: 'text-red-600' },
-  { index: 1, urgency: 'low', cls: 'text-green-600' },
-  { index: 2, urgency: 'medium', cls: 'text-yellow-600' },
-])('applies urgency class for $urgency plants', ({ index, cls }) => {
-  const plant = plants[index]
+test('shows watering progress ring', () => {
+  const plant = plants[0]
   render(
     <MenuProvider>
       <PlantProvider>
@@ -95,8 +91,7 @@ test.each([
     </MenuProvider>
   )
 
-  const heading = screen.getByRole('heading', { name: /quick stats/i })
-  expect(heading).toHaveClass(cls)
+  expect(screen.getByTestId('watering-ring')).toBeInTheDocument()
 })
 
 

--- a/src/utils/__tests__/watering.test.js
+++ b/src/utils/__tests__/watering.test.js
@@ -1,4 +1,8 @@
-import { getNextWateringDate, getWateringInfo } from '../watering.js'
+import {
+  getNextWateringDate,
+  getWateringInfo,
+  getWateringProgress,
+} from '../watering.js'
 
 test('postpones watering when rain expected', () => {
   const { date, reason } = getNextWateringDate('2025-07-10', { rainTomorrow: 5 })
@@ -30,4 +34,11 @@ test('returns days since last watered', () => {
 test('includes eto value when provided', () => {
   const { eto } = getWateringInfo('2025-07-07', { eto: 5 })
   expect(eto).toBe(5)
+})
+
+test('calculates watering progress percentage', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-04'))
+  const pct = getWateringProgress('2025-07-01', '2025-07-08')
+  expect(pct).toBeCloseTo(3 / 7)
+  jest.useRealTimers()
 })

--- a/src/utils/watering.js
+++ b/src/utils/watering.js
@@ -29,3 +29,13 @@ export function getWateringInfo(lastWatered, weather = {}) {
   }
   return { eto, daysSince };
 }
+
+export function getWateringProgress(lastWatered, nextWater, today = new Date()) {
+  const last = new Date(lastWatered);
+  const next = new Date(nextWater);
+  if (isNaN(last) || isNaN(next) || next <= last) return 0;
+  const total = (next - last) / 86400000;
+  if (total <= 0) return 0;
+  const elapsed = Math.min(Math.max((today - last) / 86400000, 0), total);
+  return elapsed / total;
+}


### PR DESCRIPTION
## Summary
- compute watering progress percentage
- render progress ring on plant detail image
- drop old urgency-based heading colors
- update tests for progress ring

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687829b181448324adfc0253152fe635