### PR TITLE
Remove note/photo buttons from plant detail

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -341,13 +341,6 @@ export default function PlantDetail() {
               </div>
             )
           })}
-          <button
-            type="button"
-            onClick={handleLogEvent}
-            className="mt-2 inline-flex items-center gap-1 px-2 py-1 bg-gray-100 dark:bg-gray-600 rounded text-sm"
-          >
-            + Add Note
-          </button>
         </section>
       </div>
 
@@ -389,14 +382,6 @@ export default function PlantDetail() {
             View All Photos
           </button>
         )}
-        <button
-          type="button"
-          onClick={openFileInput}
-          className="mt-2 inline-flex items-center gap-1 px-3 py-2 bg-gray-200 rounded shadow"
-        >
-          <PlusIcon className="w-4 h-4" aria-hidden="true" />
-          Add Photo
-        </button>
         <input
           type="file"
           accept="image/*"


### PR DESCRIPTION
## Summary
- clean up PlantDetail by removing the inline **Add Note** and **Add Photo** buttons
- these actions are available through the bottom FAB menu

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68782d04c21083248ff398c36a55dbc2