### PR TITLE
Add unified plant task card

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ Includes:
 ## Using the UI
 
 Task cards now render as static summaries with no swipe gestures. Plant cards remain interactive and support swiping or keyboard shortcuts through the underlying `PlantCard` component.
+The Tasks page groups care by plant using a `UnifiedTaskCard` that shows a thumbnail, upcoming needs and quick "Water Now" or "Fertilize Now" buttons when due.
 
 ## Plant Detail View
 

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -1,0 +1,59 @@
+import React from 'react'
+import { Drop, Sun } from 'phosphor-react'
+
+export default function UnifiedTaskCard({ plant, urgent = false, overdue = false }) {
+  if (!plant) return null
+  const { name, image, dueWater, dueFertilize, lastCared } = plant
+  const needs = []
+  if (dueWater) needs.push('water \uD83D\uDCA7')
+  if (dueFertilize) needs.push('fertilizer \u2600\uFE0F')
+  const summary = needs.length ? `Needs ${needs.join(' and ')}` : 'No care needed'
+
+  const bgClass = overdue
+    ? 'bg-red-50 dark:bg-red-900'
+    : urgent
+    ? 'bg-yellow-50 dark:bg-yellow-900'
+    : 'bg-gray-50 dark:bg-gray-800'
+
+  const last = lastCared ? (
+    <p className="text-xs text-gray-500">Last cared for {lastCared}</p>
+  ) : null
+
+  return (
+    <div
+      data-testid="unified-task-card"
+      className={`rounded-xl overflow-hidden ${bgClass}`}
+    >
+      <div className="flex items-center gap-3 p-4">
+        <img src={image} alt={name} className="w-12 h-12 rounded-lg object-cover" />
+        <div className="flex-1 min-w-0">
+          <p className="font-semibold font-headline text-gray-900 dark:text-gray-100 truncate">
+            {name}
+          </p>
+          <p className="text-sm text-gray-600 dark:text-gray-300">{summary}</p>
+          {last}
+        </div>
+        <div className="flex flex-col gap-1 items-end">
+          {dueWater && (
+            <button
+              type="button"
+              className="px-3 py-1 border border-blue-600 text-blue-600 rounded-full text-xs flex items-center gap-1"
+            >
+              <Drop className="w-3 h-3" aria-hidden="true" />
+              Water Now
+            </button>
+          )}
+          {dueFertilize && (
+            <button
+              type="button"
+              className="px-3 py-1 border border-yellow-600 text-yellow-600 rounded-full text-xs flex items-center gap-1"
+            >
+              <Sun className="w-3 h-3" aria-hidden="true" />
+              Fertilize Now
+            </button>
+          )}
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -1,0 +1,38 @@
+import { render, screen } from '@testing-library/react'
+import UnifiedTaskCard from '../UnifiedTaskCard.jsx'
+
+const plant = {
+  name: 'Fern',
+  image: 'fern.jpg',
+  lastWatered: '2025-07-10',
+  dueWater: true,
+  dueFertilize: false,
+  lastCared: '2025-07-10',
+}
+
+test('renders plant info and water button', () => {
+  render(<UnifiedTaskCard plant={plant} />)
+  expect(screen.getByText('Fern')).toBeInTheDocument()
+  expect(screen.getByText(/Needs water/)).toBeInTheDocument()
+  expect(screen.getByText('Water Now')).toBeInTheDocument()
+  expect(screen.queryByText('Fertilize Now')).toBeNull()
+})
+
+test('applies urgent style', () => {
+  const { container } = render(<UnifiedTaskCard plant={plant} urgent />)
+  const wrapper = container.querySelector('[data-testid="unified-task-card"]')
+  expect(wrapper).toHaveClass('bg-yellow-50')
+})
+
+test('applies overdue style', () => {
+  const { container } = render(<UnifiedTaskCard plant={plant} overdue />)
+  const wrapper = container.querySelector('[data-testid="unified-task-card"]')
+  expect(wrapper).toHaveClass('bg-red-50')
+})
+
+test('matches snapshot in dark mode', () => {
+  document.documentElement.classList.add('dark')
+  const { container } = render(<UnifiedTaskCard plant={plant} />)
+  expect(container.firstChild).toMatchSnapshot()
+  document.documentElement.classList.remove('dark')
+})

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -1,0 +1,79 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`matches snapshot in dark mode 1`] = `
+<div
+  class="rounded-xl overflow-hidden bg-gray-50 dark:bg-gray-800"
+  data-testid="unified-task-card"
+>
+  <div
+    class="flex items-center gap-3 p-4"
+  >
+    <img
+      alt="Fern"
+      class="w-12 h-12 rounded-lg object-cover"
+      src="fern.jpg"
+    />
+    <div
+      class="flex-1 min-w-0"
+    >
+      <p
+        class="font-semibold font-headline text-gray-900 dark:text-gray-100 truncate"
+      >
+        Fern
+      </p>
+      <p
+        class="text-sm text-gray-600 dark:text-gray-300"
+      >
+        Needs water 💧
+      </p>
+      <p
+        class="text-xs text-gray-500"
+      >
+        Last cared for 
+        2025-07-10
+      </p>
+    </div>
+    <div
+      class="flex flex-col gap-1 items-end"
+    >
+      <button
+        class="px-3 py-1 border border-blue-600 text-blue-600 rounded-full text-xs flex items-center gap-1"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-3 h-3"
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 256 256"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            fill="none"
+            height="256"
+            width="256"
+          />
+          <path
+            d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+          <path
+            d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+        </svg>
+        Water Now
+      </button>
+    </div>
+  </div>
+</div>
+`;

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -4,6 +4,7 @@ import { useWeather } from '../WeatherContext.jsx'
 import { getNextWateringDate } from '../utils/watering.js'
 
 import TaskCard from '../components/TaskCard.jsx'
+import UnifiedTaskCard from '../components/UnifiedTaskCard.jsx'
 import BaseCard from '../components/BaseCard.jsx'
 import TaskTabs from '../components/TaskTabs.jsx'
 import CareRings from '../components/CareRings.jsx'
@@ -277,41 +278,33 @@ export default function Tasks() {
               : 'No tasks coming up.'}
           </p>
         ) : (
-          eventsByPlant.map(({ plant, list }) => (
-            <div key={plant?.id ?? 'none'}>
-              <h3 className="mt-4 text-sm font-semibold text-gray-500">
-                {plant?.name || 'Unknown'}
-              </h3>
-              <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-4'}>
-                {list.map((e, i) => {
-                  const task = {
-                    id: `${e.taskType}-${e.plantId}-${i}`,
-                    plantId: e.plantId,
-                    plantName: e.plantName,
-                    image: e.image,
-                    type:
-                      e.taskType === 'water'
-                        ? 'Water'
-                        : e.taskType === 'fertilize'
-                        ? 'Fertilize'
-                        : 'Note',
-                    reason: e.reason,
-                    completed: e.completed,
-                  }
-                  return (
-                    <BaseCard key={`${e.date}-${i}`} variant="task">
-                      <TaskCard
-                        task={task}
-                        urgent={!!e.urgent}
-                        overdue={!!e.overdue}
-                        completed={e.completed}
-                      />
-                    </BaseCard>
-                  )
-                })}
-              </div>
-            </div>
-          ))
+          <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-4'}>
+          {eventsByPlant.map(({ plant, list }) => {
+            const dueWater = list.some(e => e.taskType === 'water' && !e.completed)
+            const dueFertilize = list.some(
+              e => e.taskType === 'fertilize' && !e.completed
+            )
+            const urgent = list.some(e => e.urgent)
+            const overdue = list.some(e => e.overdue)
+            const lastCared = [plant?.lastWatered, plant?.lastFertilized]
+              .filter(Boolean)
+              .sort((a, b) => new Date(b) - new Date(a))[0]
+            return (
+              <BaseCard key={plant?.id ?? 'none'} variant="task">
+                <UnifiedTaskCard
+                  plant={{
+                    ...plant,
+                    dueWater,
+                    dueFertilize,
+                    lastCared,
+                  }}
+                  urgent={urgent}
+                  overdue={overdue}
+                />
+              </BaseCard>
+            )
+          })}
+          </div>
         )
       ) : groupedEvents.length === 0 ? (
         <p className="text-center text-gray-500">


### PR DESCRIPTION
## Summary
- add UnifiedTaskCard for summarising plant care
- show upcoming needs with optional quick-action buttons
- render UnifiedTaskCard in Tasks page when viewing tasks by plant
- document UnifiedTaskCard in README
- test new component

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68782a32c50c8324b22187d3f1232e7d