### PR TITLE
Add modal-style FAB menu

### DIFF
--- a/src/MenuContext.jsx
+++ b/src/MenuContext.jsx
@@ -19,6 +19,7 @@ export const defaultMenu = {
     { to: '/profile', label: 'Profile', Icon: UserCircle },
   ],
   Icon: Hamburger,
+  modal: false,
 }
 
 export function MenuProvider({ children }) {

--- a/src/__tests__/FabVisibility.test.jsx
+++ b/src/__tests__/FabVisibility.test.jsx
@@ -44,7 +44,7 @@ describe('Menu contents based on route', () => {
     expect(links.length).toBeGreaterThan(0)
   })
 
-  test.each(plantRoutes)('does not show Add Plant link on %s', route => {
+  test.each(plantRoutes)('shows Add Plant link on %s', route => {
     render(
       <MemoryRouter initialEntries={[route]}>
         <App />
@@ -53,6 +53,7 @@ describe('Menu contents based on route', () => {
 
     const button = screen.getByRole('button', { name: /open navigation menu/i })
     fireEvent.click(button)
-    expect(screen.queryByRole('link', { name: /add plant/i })).toBeNull()
+    const link = screen.getByRole('link', { name: /add plant/i })
+    expect(link).toBeInTheDocument()
   })
 })

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -6,11 +6,49 @@ import { useMenu } from '../MenuContext.jsx'
 export default function BottomNav() {
   const [open, setOpen] = useState(false)
   const { menu } = useMenu()
-  const { items, Icon } = menu
+  const { items, Icon, modal } = menu
 
   return (
     <div className="fixed bottom-4 right-4 flex flex-col items-end z-20">
-      {open && (
+      {open && modal && (
+        <div
+          className="fixed inset-0 bg-black/60 flex items-center justify-center z-20"
+          onClick={() => setOpen(false)}
+        >
+          <ul
+            className="bg-white dark:bg-gray-700 rounded-lg shadow-lg p-6 grid grid-cols-2 gap-4 text-center bloom-pop"
+            onClick={e => e.stopPropagation()}
+          >
+            {items.map(({ to, onClick, label, Icon }) => (
+              <li key={label}>
+                {to ? (
+                  <NavLink
+                    to={to}
+                    onClick={() => setOpen(false)}
+                    className="flex flex-col items-center w-24"
+                  >
+                    <Icon className="w-6 h-6 mb-1" aria-hidden="true" />
+                    {label}
+                  </NavLink>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setOpen(false)
+                      onClick?.()
+                    }}
+                    className="flex flex-col items-center w-24"
+                  >
+                    <Icon className="w-6 h-6 mb-1" aria-hidden="true" />
+                    {label}
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      {open && !modal && (
         <ul className="mb-2 bg-white dark:bg-gray-700 rounded-lg shadow-lg text-sm overflow-hidden py-2">
           {items.map(({ to, onClick, label, Icon }) => (
             <li key={label}>

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -7,10 +7,12 @@ import {
   Drop,
   Gauge,
   CalendarCheck,
+  CalendarBlank,
   Flower,
   Image,
   Note,
   Info,
+  House,
   ArrowLeft,
   CaretDown,
   CaretRight,
@@ -114,13 +116,14 @@ export default function PlantDetail() {
 
   useEffect(() => {
     const plantItems = [
-      { onClick: handleLogEvent, label: 'Add Note', Icon: Note },
-      { onClick: openFileInput, label: 'Add Photo', Icon: Image },
-      { onClick: handleEdit, label: 'Edit Plant', Icon: Pencil1Icon },
+      { to: '/', label: 'Home', Icon: House },
+      { to: '/timeline', label: 'Timeline', Icon: CalendarBlank },
+      { onClick: () => setLightboxIndex(0), label: 'Gallery', Icon: Image },
+      { to: '/add', label: 'Add Plant', Icon: PlusIcon },
     ]
-    setMenu({ items: plantItems, Icon: PlusIcon })
+    setMenu({ items: plantItems, Icon: PlusIcon, modal: true })
     return () => setMenu(defaultMenu)
-  }, [setMenu, plant?.id])
+  }, [setMenu, plant?.id, setLightboxIndex])
 
   useEffect(() => {
     const defaults = {}


### PR DESCRIPTION
## Summary
- allow menu context to specify modal behaviour
- implement modal view for BottomNav when modal flag is true
- customize PlantDetail FAB menu to show Home/Timeline/Gallery/Add Plant
- update tests for new FAB behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68783150e08c83248fa894b95f1e1179