### PR TITLE
Add relative date helper and update UnifiedTaskCard

### DIFF
--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -1,5 +1,6 @@
 import React from 'react'
 import { Drop, Sun } from 'phosphor-react'
+import { formatDaysAgo } from '../utils/dateFormat.js'
 
 export default function UnifiedTaskCard({ plant, urgent = false, overdue = false }) {
   if (!plant) return null
@@ -15,8 +16,9 @@ export default function UnifiedTaskCard({ plant, urgent = false, overdue = false
     ? 'bg-yellow-50 dark:bg-yellow-900'
     : 'bg-gray-50 dark:bg-gray-800'
 
-  const last = lastCared ? (
-    <p className="text-xs text-gray-500">Last cared for {lastCared}</p>
+  const lastText = lastCared ? formatDaysAgo(lastCared) : null
+  const last = lastText ? (
+    <p className="text-xs text-gray-500">Last cared for {lastText}</p>
   ) : null
 
   return (

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -1,13 +1,15 @@
 import { render, screen } from '@testing-library/react'
 import UnifiedTaskCard from '../UnifiedTaskCard.jsx'
 
+jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
+
 const plant = {
   name: 'Fern',
   image: 'fern.jpg',
   lastWatered: '2025-07-10',
   dueWater: true,
   dueFertilize: false,
-  lastCared: '2025-07-10',
+  lastCared: '2025-07-07',
 }
 
 test('renders plant info and water button', () => {
@@ -16,6 +18,7 @@ test('renders plant info and water button', () => {
   expect(screen.getByText(/Needs water/)).toBeInTheDocument()
   expect(screen.getByText('Water Now')).toBeInTheDocument()
   expect(screen.queryByText('Fertilize Now')).toBeNull()
+  expect(screen.getByText('Last cared for 3 days ago')).toBeInTheDocument()
 })
 
 test('applies urgent style', () => {
@@ -35,4 +38,8 @@ test('matches snapshot in dark mode', () => {
   const { container } = render(<UnifiedTaskCard plant={plant} />)
   expect(container.firstChild).toMatchSnapshot()
   document.documentElement.classList.remove('dark')
+})
+
+afterAll(() => {
+  jest.useRealTimers()
 })

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -30,7 +30,7 @@ exports[`matches snapshot in dark mode 1`] = `
         class="text-xs text-gray-500"
       >
         Last cared for 
-        2025-07-10
+        3 days ago
       </p>
     </div>
     <div

--- a/src/utils/__tests__/dateFormat.test.js
+++ b/src/utils/__tests__/dateFormat.test.js
@@ -1,0 +1,9 @@
+import { formatDaysAgo } from '../dateFormat.js'
+
+test('formats ISO date to days ago string', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
+  expect(formatDaysAgo('2025-07-07')).toBe('3 days ago')
+  expect(formatDaysAgo('2025-07-09')).toBe('1 day ago')
+  expect(formatDaysAgo('2025-07-10')).toBe('0 days ago')
+  jest.useRealTimers()
+})

--- a/src/utils/dateFormat.js
+++ b/src/utils/dateFormat.js
@@ -1,0 +1,8 @@
+import { daysAgo } from './date.js'
+
+export function formatDaysAgo(dateStr, today = new Date()) {
+  const diff = daysAgo(dateStr, today)
+  if (diff == null) return ''
+  const unit = diff === 1 ? 'day' : 'days'
+  return `${diff} ${unit} ago`
+}


### PR DESCRIPTION
## Summary
- add `formatDaysAgo` helper
- show relative last cared text in `UnifiedTaskCard`
- add tests for the helper and update existing `UnifiedTaskCard` tests

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6878316bb89c8324ac47f599501bc15d