### PR TITLE
Fix due task logic

### DIFF
--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -280,9 +280,17 @@ export default function Tasks() {
         ) : (
           <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-4'}>
           {eventsByPlant.map(({ plant, list }) => {
-            const dueWater = list.some(e => e.taskType === 'water' && !e.completed)
+            const dueWater = list.some(
+              e =>
+                e.taskType === 'water' &&
+                !e.completed &&
+                (e.overdue || e.date <= todayIso)
+            )
             const dueFertilize = list.some(
-              e => e.taskType === 'fertilize' && !e.completed
+              e =>
+                e.taskType === 'fertilize' &&
+                !e.completed &&
+                (e.overdue || e.date <= todayIso)
             )
             const urgent = list.some(e => e.urgent)
             const overdue = list.some(e => e.overdue)

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -148,3 +148,18 @@ test('completed tasks are styled', () => {
     true
   )
 })
+
+test('future watering date does not show Water Now button', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
+  render(
+    <MemoryRouter>
+      <Tasks />
+    </MemoryRouter>
+  )
+
+  const tab = screen.getByRole('tab', { name: /By Plant/i })
+  fireEvent.click(tab)
+
+  expect(screen.queryByText('Water Now')).toBeNull()
+  jest.useRealTimers()
+})


### PR DESCRIPTION
## Summary
- check due dates when flagging water/fertilizer tasks
- add regression test to ensure future water dates don't show the button

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68783166e93c8324996066007f5131e1