### PR TITLE
Implement modal-style FAB menu

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -9,6 +9,7 @@ import Settings from './pages/Settings'
 import PlantDetail from './pages/PlantDetail'
 import EditPlant from './pages/EditPlant'
 import Timeline from './pages/Timeline'
+import Gallery from './pages/Gallery.jsx'
 import BottomNav from './components/BottomNav'
 import { MenuProvider } from './MenuContext.jsx'
 import NotFound from './pages/NotFound'
@@ -34,8 +35,9 @@ export default function App() {
             <Route path="/myplants" element={<MyPlants />} />
             <Route path="/tasks" element={<Tasks />} />
             <Route path="/add" element={<Add />} />
-            <Route path="/profile" element={<Settings />} />
             <Route path="/timeline" element={<Timeline />} />
+            <Route path="/gallery" element={<Gallery />} />
+            <Route path="/profile" element={<Settings />} />
             <Route path="/plant/:id" element={<PlantDetail />} />
             <Route path="/plant/:id/edit" element={<EditPlant />} />
             <Route path="*" element={<NotFound />} />

--- a/src/MenuContext.jsx
+++ b/src/MenuContext.jsx
@@ -1,10 +1,9 @@
 import { createContext, useContext, useState } from 'react'
 import {
   House,
-  ListBullets,
   CalendarBlank,
-  UserCircle,
   Plus,
+  Image,
   Hamburger,
 } from 'phosphor-react'
 
@@ -13,10 +12,9 @@ const MenuContext = createContext()
 export const defaultMenu = {
   items: [
     { to: '/', label: 'Home', Icon: House },
-    { to: '/myplants', label: 'My Plants', Icon: ListBullets },
-    { to: '/add', label: 'Add Plant', Icon: Plus },
     { to: '/timeline', label: 'Timeline', Icon: CalendarBlank },
-    { to: '/profile', label: 'Profile', Icon: UserCircle },
+    { to: '/gallery', label: 'Gallery', Icon: Image },
+    { to: '/add', label: 'Add Plant', Icon: Plus },
   ],
   Icon: Hamburger,
 }

--- a/src/__tests__/FabVisibility.test.jsx
+++ b/src/__tests__/FabVisibility.test.jsx
@@ -44,7 +44,7 @@ describe('Menu contents based on route', () => {
     expect(links.length).toBeGreaterThan(0)
   })
 
-  test.each(plantRoutes)('does not show Add Plant link on %s', route => {
+  test.each(plantRoutes)('shows Add Plant link on %s', route => {
     render(
       <MemoryRouter initialEntries={[route]}>
         <App />
@@ -53,6 +53,6 @@ describe('Menu contents based on route', () => {
 
     const button = screen.getByRole('button', { name: /open navigation menu/i })
     fireEvent.click(button)
-    expect(screen.queryByRole('link', { name: /add plant/i })).toBeNull()
+    expect(screen.getByRole('link', { name: /add plant/i })).toBeInTheDocument()
   })
 })

--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -9,42 +9,47 @@ export default function BottomNav() {
   const { items, Icon } = menu
 
   return (
-    <div className="fixed bottom-4 right-4 flex flex-col items-end z-20">
+    <div className="fixed bottom-4 right-4 z-20">
       {open && (
-        <ul className="mb-2 bg-white dark:bg-gray-700 rounded-lg shadow-lg text-sm overflow-hidden py-2">
-          {items.map(({ to, onClick, label, Icon }) => (
-            <li key={label}>
-              {to ? (
-                <NavLink
-                  to={to}
-                  onClick={() => setOpen(false)}
-                  className={({ isActive }) =>
-                    `flex items-center gap-2 px-3 py-2 w-full hover:bg-gray-100 dark:hover:bg-gray-600 ${isActive ? 'text-accent' : ''}`
-                  }
-                >
-                  {({ isActive }) => (
-                    <>
-                      <Icon weight={isActive ? 'fill' : 'regular'} className="w-4 h-4" aria-hidden="true" />
-                      {label}
-                    </>
-                  )}
-                </NavLink>
-              ) : (
-                <button
-                  type="button"
-                  onClick={() => {
-                    setOpen(false)
-                    onClick?.()
-                  }}
-                  className="flex items-center gap-2 px-3 py-2 w-full hover:bg-gray-100 dark:hover:bg-gray-600 text-left"
-                >
-                  <Icon className="w-4 h-4" aria-hidden="true" />
-                  {label}
-                </button>
-              )}
-            </li>
-          ))}
-        </ul>
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Navigation menu"
+          onClick={() => setOpen(false)}
+        >
+          <ul
+            className="bg-white dark:bg-gray-700 rounded-lg shadow-lg p-6 space-y-4 bloom-pop text-lg"
+            onClick={e => e.stopPropagation()}
+          >
+            {items.map(({ to, onClick, label, Icon }) => (
+              <li key={label}>
+                {to ? (
+                  <NavLink
+                    to={to}
+                    onClick={() => setOpen(false)}
+                    className="flex items-center gap-3 hover:text-accent"
+                  >
+                    <Icon className="w-5 h-5" aria-hidden="true" />
+                    {label}
+                  </NavLink>
+                ) : (
+                  <button
+                    type="button"
+                    onClick={() => {
+                      setOpen(false)
+                      onClick?.()
+                    }}
+                    className="flex items-center gap-3 w-full text-left hover:text-accent"
+                  >
+                    <Icon className="w-5 h-5" aria-hidden="true" />
+                    {label}
+                  </button>
+                )}
+              </li>
+            ))}
+          </ul>
+        </div>
       )}
       <button
         type="button"

--- a/src/components/__tests__/BottomNav.test.jsx
+++ b/src/components/__tests__/BottomNav.test.jsx
@@ -17,7 +17,7 @@ test('all icons are aria-hidden', () => {
   })
 })
 
-test('does not render gallery link', () => {
+test('renders gallery link', () => {
   const { container } = render(
     <MemoryRouter>
       <MenuProvider>
@@ -25,10 +25,9 @@ test('does not render gallery link', () => {
       </MenuProvider>
     </MemoryRouter>
   )
-  // open the menu
   fireEvent.click(screen.getByRole('button', { name: /open navigation menu/i }))
   const galleryLink = container.querySelector('a[href="/gallery"]')
-  expect(galleryLink).toBeNull()
+  expect(galleryLink).toBeInTheDocument()
 })
 
 test('renders timeline navigation link', () => {

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,0 +1,10 @@
+import React from 'react'
+
+export default function Gallery() {
+  return (
+    <div className="p-4">
+      <h2 className="text-2xl font-headline mb-4">Gallery</h2>
+      <p className="text-gray-700 dark:text-gray-200">Coming soon...</p>
+    </div>
+  )
+}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -110,17 +110,7 @@ export default function PlantDetail() {
     navigate(-1)
   }
 
-  const { setMenu } = useMenu()
-
-  useEffect(() => {
-    const plantItems = [
-      { onClick: handleLogEvent, label: 'Add Note', Icon: Note },
-      { onClick: openFileInput, label: 'Add Photo', Icon: Image },
-      { onClick: handleEdit, label: 'Edit Plant', Icon: Pencil1Icon },
-    ]
-    setMenu({ items: plantItems, Icon: PlusIcon })
-    return () => setMenu(defaultMenu)
-  }, [setMenu, plant?.id])
+  // Menu is now consistent across pages so no override here
 
   useEffect(() => {
     const defaults = {}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -53,7 +53,9 @@ test('renders plant details without duplicates', () => {
   ).toBeInTheDocument()
 
   const fertLabel = screen.getByText(/Last fertilized/i)
-  expect(within(fertLabel.parentElement).getByText(plant.lastFertilized)).toBeInTheDocument()
+  expect(
+    within(fertLabel.parentElement).getByText(new RegExp(plant.lastFertilized))
+  ).toBeInTheDocument()
 
   const subHeadings = screen.queryAllByRole('heading', { level: 4 })
   expect(subHeadings).toHaveLength(0)

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -37,6 +37,7 @@ beforeEach(() => {
 })
 
 test('ignores activities without valid dates when generating events', () => {
+  jest.useFakeTimers().setSystemTime(new Date("2025-07-16"))
   render(
     <MemoryRouter>
       <Tasks />
@@ -55,6 +56,7 @@ test('ignores activities without valid dates when generating events', () => {
   expect(cards[1]).toHaveTextContent('Plant B')
   expect(cards.length).toBeGreaterThan(0)
 
+  jest.useRealTimers()
 
 
 
@@ -74,6 +76,7 @@ test('shows friendly message when there are no tasks', () => {
 
 
 test('filters by type', () => {
+  jest.useFakeTimers().setSystemTime(new Date("2025-07-16"))
   render(
     <MemoryRouter>
       <Tasks />
@@ -89,6 +92,7 @@ test('filters by type', () => {
   expect(cards[0]).toHaveTextContent('Plant A')
   expect(cards[1]).toHaveTextContent('Watered!')
   expect(cards[1]).toHaveTextContent('Plant B')
+  jest.useRealTimers()
 })
 
 test('sorts by plant name', () => {


### PR DESCRIPTION
## Summary
- add gallery page and routing
- show a modal overlay for FAB navigation
- simplify default nav menu items
- remove PlantDetail menu override
- update navigation tests and tasks tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878dfec75a88324ab71f53d3a594375