### PR TITLE
Remove overdue badge from tasks

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -5,7 +5,6 @@ import Badge from './Badge.jsx'
 export default function TaskCard({
   task,
   urgent = false,
-  overdue = false,
   completed = false,
   compact = false,
   swipeable = true,
@@ -63,14 +62,6 @@ export default function TaskCard({
               )}
             </div>
           </div>
-          {overdue && (
-            <span
-              className="absolute -top-1 -right-1 bg-fertilize-500 text-white rounded-full w-4 h-4 flex items-center justify-center text-xs overdue-ping"
-              data-testid="overdue-badge"
-            >
-              !
-            </span>
-          )}
           {completed && (
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none task-complete-fade">
               <svg

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -55,21 +55,6 @@ test('applies highlight when urgent', () => {
   expect(wrapper).toHaveClass('dark:ring-green-400')
 })
 
-test('applies overdue styling', () => {
-  const { container } = render(
-    <MemoryRouter>
-      <BaseCard variant="task">
-        <TaskCard task={task} overdue />
-      </BaseCard>
-    </MemoryRouter>
-  )
-  const wrapper = container.querySelector('.shadow-sm')
-  expect(wrapper).not.toHaveClass('ring-orange-300')
-  const badge = screen.getByTestId('overdue-badge')
-  expect(badge).toBeInTheDocument()
-  expect(badge).toHaveClass('bg-fertilize-500')
-  expect(badge).toHaveClass('overdue-ping')
-})
 
 test('shows completed state', () => {
   const { container } = render(

--- a/src/index.css
+++ b/src/index.css
@@ -176,18 +176,6 @@ body {
   animation: task-complete-fade 0.4s ease-out forwards;
 }
 
-@keyframes overdue-ping {
-  0%, 100% {
-    transform: scale(1);
-  }
-  50% {
-    transform: scale(1.2);
-  }
-}
-
-.overdue-ping {
-  animation: overdue-ping 1s ease-in-out infinite;
-}
 
 /* Dropdown select styling */
 .dropdown-select {


### PR DESCRIPTION
## Summary
- remove overdue ping indicator
- drop unused CSS animation
- delete overdue test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6878e6b64454832496156371c7b3c408