### PR TITLE
Swap out hamburger icon for menu icon

### DIFF
--- a/src/MenuContext.jsx
+++ b/src/MenuContext.jsx
@@ -4,8 +4,8 @@ import {
   ListBullets,
   CalendarBlank,
   Plus,
-  Hamburger,
 } from 'phosphor-react'
+import { HamburgerMenuIcon } from '@radix-ui/react-icons'
 
 const MenuContext = createContext()
 
@@ -16,7 +16,7 @@ export const defaultMenu = {
     { to: '/timeline', label: 'Timeline', Icon: CalendarBlank },
     { to: '/add', label: 'Add Plant', Icon: Plus },
   ],
-  Icon: Hamburger,
+  Icon: HamburgerMenuIcon,
 }
 
 export function MenuProvider({ children }) {


### PR DESCRIPTION
## Summary
- use `HamburgerMenuIcon` from Radix for navigation menu

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879041c72c883248e1c845de6c1c845