### PR TITLE
Fix timeline month sorting

### DIFF
--- a/src/utils/__tests__/events.test.js
+++ b/src/utils/__tests__/events.test.js
@@ -56,3 +56,17 @@ test('groupEventsByMonth groups by YYYY-MM', () => {
     ['2025-08', [events[2]]],
   ])
 })
+
+test('groupEventsByMonth sorts months chronologically', () => {
+  const events = [
+    { date: '2099-12-25', label: 'Future' },
+    { date: '2025-07-01', label: 'Past' },
+  ]
+
+  const grouped = groupEventsByMonth(events)
+
+  expect(grouped).toEqual([
+    ['2025-07', [events[1]]],
+    ['2099-12', [events[0]]],
+  ])
+})

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -96,5 +96,10 @@ export function groupEventsByMonth(events) {
     if (!map.has(key)) map.set(key, [])
     map.get(key).push(e)
   })
-  return Array.from(map.entries())
+  for (const [, list] of map) {
+    list.sort((a, b) => new Date(a.date) - new Date(b.date))
+  }
+  return Array.from(map.entries()).sort(
+    (a, b) => new Date(a[0] + '-01') - new Date(b[0] + '-01')
+  )
 }


### PR DESCRIPTION
## Summary
- sort months and events in timeline utilities
- test chronology sorting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879218b69c083249c0a06cfb7fdaa05