### PR TITLE
Improve gallery alt text and add FAB tooltips

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -28,6 +28,7 @@ export default function BottomNav() {
                   <NavLink
                     to={to}
                     onClick={() => setOpen(false)}
+                    title={label}
                     className="flex items-center gap-3 hover:text-accent"
                   >
                     <Icon className="w-5 h-5" aria-hidden="true" />
@@ -40,6 +41,7 @@ export default function BottomNav() {
                       setOpen(false)
                       onClick?.()
                     }}
+                    title={label}
                     className="flex items-center gap-3 w-full text-left hover:text-accent"
                   >
                     <Icon className="w-5 h-5" aria-hidden="true" />
@@ -55,6 +57,7 @@ export default function BottomNav() {
         type="button"
         onClick={() => setOpen(v => !v)}
         aria-label="Open navigation menu"
+        title="Open navigation menu"
         className="bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700"
       >
         <Icon className="w-6 h-6" aria-hidden="true" />

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -56,7 +56,7 @@ export default function Lightbox({ images, startIndex = 0, onClose, label = 'Ima
           <>
             <img
               src={current.src}
-              alt="Gallery image"
+              alt={current.caption || 'Gallery image'}
               className="max-w-full max-h-full object-contain"
             />
             {current.caption && (

--- a/src/components/__tests__/Lightbox.test.jsx
+++ b/src/components/__tests__/Lightbox.test.jsx
@@ -15,7 +15,7 @@ test('keyboard navigation and close', () => {
   expect(dialog).toHaveAttribute('aria-modal', 'true')
   expect(dialog).toHaveAttribute('aria-label', label)
 
-  const img = screen.getByAltText(/gallery image/i)
+  const img = screen.getByAltText(images[0].caption)
   expect(img).toHaveAttribute('src', 'a.jpg')
   expect(screen.getByText('first')).toBeInTheDocument()
 

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -391,7 +391,7 @@ export default function PlantDetail() {
                 <button type="button" onClick={() => setLightboxIndex(i)} className="block focus:outline-none">
                   <img
                     src={src}
-                    alt={`${plant.name} ${i}`}
+                    alt={caption || `${plant.name} photo ${i + 1}`}
                     className="object-cover w-full h-24 rounded-lg"
                   />
                 </button>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -114,7 +114,9 @@ test('opens lightbox from gallery', () => {
     </MenuProvider>
   )
 
-  const img = screen.getByAltText(`${plant.name} 0`)
+  const img = screen.getByAltText(
+    plant.photos[0].caption || `${plant.name} photo 1`
+  )
   fireEvent.click(img.closest('button'))
 
   const dialogsAfterOpen = screen.getAllByRole('dialog', {
@@ -122,8 +124,7 @@ test('opens lightbox from gallery', () => {
   })
   // First dialog is the gallery overlay
   expect(dialogsAfterOpen[0]).toBeInTheDocument()
-  const thumb = screen.getByAltText(`${plant.name} 0`)
-  fireEvent.click(thumb)
+  fireEvent.click(img)
 
   const dialogs = screen.getAllByRole('dialog', {
     name: `${plant.name} gallery`,
@@ -132,7 +133,9 @@ test('opens lightbox from gallery', () => {
   const viewerDialog = dialogs[1]
   expect(viewerDialog).toBeInTheDocument()
 
-  const viewerImg = screen.getByAltText(/gallery image/i)
+  const viewerImg = screen.getAllByAltText(
+    plant.photos[0].caption || /gallery image/i
+  )[1]
   expect(viewerImg).toHaveAttribute('src', plant.photos[0].src)
   expect(screen.getAllByText(plant.photos[0].caption).length).toBeGreaterThan(0)
 
@@ -166,7 +169,9 @@ test('view all button opens the viewer from first image', () => {
   const viewAll = screen.getByRole('button', { name: /view all photos/i })
   fireEvent.click(viewAll)
 
-  const viewerImg = screen.getByAltText(/gallery image/i)
+  const viewerImg = screen.getAllByAltText(
+    plant.photos[0].caption || /gallery image/i
+  )[1]
   expect(viewerImg).toHaveAttribute('src', plant.photos[0].src)
 })
 


### PR DESCRIPTION
## Summary
- make gallery thumbnails use caption or plant name in alt text
- surface photo caption in Lightbox `alt` attribute
- show tooltip text on all floating action button items
- update tests for new alt text behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687921a69a308324ba852f9f200b9e59