### PR TITLE
Add blur effect overlay

### DIFF
--- a/src/components/BottomNav.jsx
+++ b/src/components/BottomNav.jsx
@@ -12,7 +12,7 @@ export default function BottomNav() {
     <div className="fixed bottom-4 right-4 z-20">
       {open && (
         <div
-          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30"
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
           role="dialog"
           aria-modal="true"
           aria-label="Navigation menu"

--- a/src/components/__tests__/BottomNav.test.jsx
+++ b/src/components/__tests__/BottomNav.test.jsx
@@ -68,3 +68,16 @@ test('renders add room navigation link', () => {
   const addRoomLink = container.querySelector('a[href="/room/add"]')
   expect(addRoomLink).toBeInTheDocument()
 })
+
+test('overlay has blur effect', () => {
+  const { container } = render(
+    <MemoryRouter>
+      <MenuProvider>
+        <BottomNav />
+      </MenuProvider>
+    </MemoryRouter>
+  )
+  fireEvent.click(screen.getByRole('button', { name: /open navigation menu/i }))
+  const overlay = container.querySelector('div[role="dialog"]')
+  expect(overlay).toHaveClass('backdrop-blur-sm')
+})


### PR DESCRIPTION
## Summary
- give the BottomNav overlay a backdrop blur
- check for blur class in BottomNav tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879282e671c83249006233809c9db74