### PR TITLE
Add drip pulse animation to watering button

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -178,6 +178,21 @@ body {
   animation: ring-complete 0.8s ease-in-out;
 }
 
+@keyframes drip-pulse {
+  0%, 100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+  50% {
+    transform: scale(1.2);
+    opacity: 0.5;
+  }
+}
+
+.drip-pulse {
+  animation: drip-pulse 0.4s ease-out;
+}
+
 @keyframes task-complete-fade {
   from {
     background-color: rgba(74, 222, 128, 0.4);

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -241,9 +241,10 @@ export default function PlantDetail() {
           type="button"
           onClick={handleWatered}
           aria-label={`Mark ${plant.name} as watered`}
-          className="px-2 py-1 border border-water-600 text-water-600 rounded text-xs flex items-center gap-1"
+          className="px-2 py-1 border border-water-600 text-water-600 rounded text-xs flex items-center gap-1 group"
         >
-          <Drop className="w-3 h-3" aria-hidden="true" /> Mark Watered
+          <Drop className="w-3 h-3 group-active:drip-pulse" aria-hidden="true" />
+          Mark Watered
         </button>
       </div>
       <p className="text-sm mt-1">


### PR DESCRIPTION
## Summary
- define `drip-pulse` animation in CSS
- pulse the Drop icon when the "Mark Watered" button is clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687927f55df88324af07c781e1737011