### PR TITLE
Add dynamic border colors for care stats

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -79,6 +79,11 @@ export default function PlantDetail() {
       ? Math.floor((now - nextFertDate) / 86400000)
       : 0
 
+  const waterBorderClass =
+    overdueWaterDays > 0 ? 'border-red-500' : 'border-green-500'
+  const fertBorderClass =
+    overdueFertDays > 0 ? 'border-red-500' : 'border-green-500'
+
   const events = useMemo(() => buildEvents(plant), [plant])
   const groupedEvents = useMemo(
     () => groupEventsByMonth(events),
@@ -231,7 +236,7 @@ export default function PlantDetail() {
     Quick Stats
   </h3>
   <div className="space-y-3">
-    <div className="rounded-lg p-3 border-l-4 border-water-500 bg-water-50 dark:bg-water-900/30">
+    <div className={`rounded-lg p-3 border-l-4 ${waterBorderClass} bg-water-50 dark:bg-water-900/30`}>
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-1 font-headline font-semibold text-water-700 dark:text-water-200">
           <Drop className="w-4 h-4" aria-hidden="true" />
@@ -266,7 +271,7 @@ export default function PlantDetail() {
       </p>
     </div>
     {plant.nextFertilize && (
-      <div className="rounded-lg p-3 border-l-4 border-fertilize-500 bg-fertilize-50 dark:bg-fertilize-900/30">
+      <div className={`rounded-lg p-3 border-l-4 ${fertBorderClass} bg-fertilize-50 dark:bg-fertilize-900/30`}>
         <div className="flex items-center justify-between">
           <div className="flex items-center gap-1 font-headline font-semibold text-fertilize-700 dark:text-fertilize-200">
             <Flower className="w-4 h-4" aria-hidden="true" />


### PR DESCRIPTION
## Summary
- compute border color classes based on overdue days
- use the computed classes in `PlantDetail`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687927f3ed7c8324aae60d73b5ce5cbb