### PR TITLE
Update overdue messages for plants

### DIFF
--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -55,7 +55,7 @@ export default function MyPlants() {
               <p className="text-[10px] text-gray-500">{countPlants(room)} plants</p>
               {overdue > 0 && (
                 <span className="slide-in inline-flex text-[11px] px-2 py-0.5 rounded-full bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100">
-                  ⚠️ {overdue} overdue
+                  ⚠️ {overdue} needs love
                 </span>
               )}
             </Link>

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -260,7 +260,7 @@ export default function PlantDetail() {
         <span className={overdueWaterDays > 0 ? '' : 'text-gray-900 dark:text-gray-100'}>{plant.nextWater}</span>
         {overdueWaterDays > 0 && (
           <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-red-100 text-red-700 dark:bg-red-800 dark:text-red-100">
-            Overdue by {overdueWaterDays} {overdueWaterDays === 1 ? 'day' : 'days'}
+            Needs love soon – overdue by {overdueWaterDays} {overdueWaterDays === 1 ? 'day' : 'days'}
           </span>
         )}
       </p>
@@ -297,7 +297,7 @@ export default function PlantDetail() {
           <span className={overdueFertDays > 0 ? '' : 'text-gray-900 dark:text-gray-100'}>{plant.nextFertilize}</span>
           {overdueFertDays > 0 && (
             <span className="ml-2 px-2 py-0.5 text-xs rounded-full bg-red-100 text-red-700 dark:bg-red-800 dark:text-red-100">
-              Overdue by {overdueFertDays} {overdueFertDays === 1 ? 'day' : 'days'}
+              Needs love soon – overdue by {overdueFertDays} {overdueFertDays === 1 ? 'day' : 'days'}
             </span>
           )}
         </p>

--- a/src/pages/__tests__/MyPlants.test.jsx
+++ b/src/pages/__tests__/MyPlants.test.jsx
@@ -60,7 +60,7 @@ test('shows overdue badge for rooms with tasks', () => {
       <MyPlants />
     </MemoryRouter>
   )
-  const badge = screen.getByText(/overdue/i)
-  expect(badge).toHaveTextContent('⚠️ 2 overdue')
+  const badge = screen.getByText(/needs love/i)
+  expect(badge).toHaveTextContent('⚠️ 2 needs love')
   jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- soften overdue watering/fertilizing labels in `PlantDetail`
- change MyPlants badge wording
- adjust MyPlants page tests for new wording

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687927d1799c8324ad827e0a131d7c27