### PR TITLE
Add OS theme preference

### DIFF
--- a/src/ThemeContext.jsx
+++ b/src/ThemeContext.jsx
@@ -8,6 +8,12 @@ export function ThemeProvider({ children }) {
       const stored = localStorage.getItem('theme')
       if (stored) return stored
     }
+    if (
+      typeof window !== 'undefined' &&
+      window.matchMedia('(prefers-color-scheme: dark)').matches
+    ) {
+      return 'dark'
+    }
     return 'light'
   })
 
@@ -23,7 +29,8 @@ export function ThemeProvider({ children }) {
     }
   }, [theme])
 
-  const toggleTheme = () => setTheme(prev => (prev === 'dark' ? 'light' : 'dark'))
+  const toggleTheme = () =>
+    setTheme(prev => (prev === 'dark' ? 'light' : 'dark'))
 
   return (
     <ThemeContext.Provider value={{ theme, toggleTheme }}>


### PR DESCRIPTION
## Summary
- adjust theme context to default to the user's OS preference when no theme is stored
- tidy toggleTheme function formatting

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68793c0a46c88324a21214cd6b79eb8b