### PR TITLE
Add weather icon and clickable care rings

### DIFF
--- a/src/components/CareStats.jsx
+++ b/src/components/CareStats.jsx
@@ -2,20 +2,24 @@ import React from 'react'
 import { ListChecks, Drop, Sun } from 'phosphor-react'
 import ProgressRing from './ProgressRing.jsx'
 
-function StatBlock({ label, Icon, completed, total, ringClass }) {
+function StatBlock({ id, label, Icon, completed, total, ringClass, onClick }) {
   const pct = total > 0 ? Math.min(completed / total, 1) : 0
   const display = `${completed}/${total}`
 
   const size = 64
 
-  const ariaLabel = `${completed} of ${total} ${label.toLowerCase()} tasks done`
+  const ariaLabel =
+    label === 'All Tasks'
+      ? `${completed} of ${total} tasks done`
+      : `${completed} of ${total} ${label.toLowerCase()} tasks done`
 
   return (
     <div
-      className="flex flex-col items-center"
+      className={`flex flex-col items-center ${onClick ? 'cursor-pointer' : ''}`}
       style={{ width: size }}
-      data-testid={`stat-${label.toLowerCase()}`}
+      data-testid={`stat-${id}`}
       aria-label={ariaLabel}
+      onClick={onClick}
     >
       <div className="relative" style={{ width: size, height: size }}>
         <ProgressRing percent={pct} size={size} colorClass={ringClass} />
@@ -45,30 +49,39 @@ export default function CareStats({
   waterTotal = 0,
   fertCompleted = 0,
   fertTotal = 0,
+  onTotalClick,
+  onWaterClick,
+  onFertClick,
 }) {
   const totalCompleted = waterCompleted + fertCompleted
   const totalTasks = waterTotal + fertTotal
   const stats = [
     {
-      label: 'Total',
+      id: 'total',
+      label: 'All Tasks',
       Icon: ListChecks,
       completed: totalCompleted,
       total: totalTasks,
       ringClass: 'text-green-600',
+      onClick: onTotalClick,
     },
     {
+      id: 'water',
       label: 'Water',
       Icon: Drop,
       completed: waterCompleted,
       total: waterTotal,
       ringClass: 'text-blue-500',
+      onClick: onWaterClick,
     },
     {
+      id: 'fertilize',
       label: 'Fertilize',
       Icon: Sun,
       completed: fertCompleted,
       total: fertTotal,
       ringClass: 'text-yellow-700',
+      onClick: onFertClick,
     },
   ]
   return (

--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -1,5 +1,6 @@
 import { Link } from 'react-router-dom'
 import { useState } from 'react'
+import { useWeather } from '../WeatherContext.jsx'
 import { formatCareSummary } from '../utils/date.js'
 
 
@@ -13,6 +14,18 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
   if (!items.length) return null
 
   const [index, setIndex] = useState(startIndex)
+  const { forecast } = useWeather() || {}
+  const weatherEmojis = {
+    Clear: '☀️',
+    Clouds: '☁️',
+    Rain: '🌧️',
+    Drizzle: '🌦️',
+    Thunderstorm: '⛈️',
+    Snow: '❄️',
+    Mist: '🌫️',
+    Fog: '🌫️',
+  }
+  const suggestion = forecast ? weatherEmojis[forecast.condition] || '☀️' : null
 
   const { dx: deltaX, start, move, end } = useSwipe(diff => {
     if (diff > 50) setIndex(i => (i - 1 + items.length) % items.length)
@@ -70,15 +83,22 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
 
         <h2 className="font-display text-2xl font-semibold">{name}</h2>
         {preview && (
-          <p className="text-sm opacity-90">{preview}</p>
+          <div className="flex items-center justify-center gap-1">
+            <p className="text-sm opacity-90">{preview}</p>
+            {suggestion && (
+              <span aria-label={`Weather: ${forecast?.condition}`}>{suggestion}</span>
+            )}
+          </div>
         )}
-        <button
-          type="button"
-          aria-label={`Mark ${name} as watered`}
-          className="mt-2 px-3 py-1 bg-blue-600 text-white rounded text-sm animate-bounce-once"
-        >
-          Water Now
-        </button>
+        <div className="flex justify-center">
+          <button
+            type="button"
+            aria-label={`Mark ${name} as watered`}
+            className="px-3 py-1 bg-blue-600 text-white rounded text-sm animate-bounce-once"
+          >
+            Water Now
+          </button>
+        </div>
 
       </div>
     </Link>

--- a/src/components/__tests__/CareStats.test.jsx
+++ b/src/components/__tests__/CareStats.test.jsx
@@ -13,7 +13,7 @@ test('renders stats with numbers and icons', () => {
   expect(screen.getByTestId('stat-water')).toBeInTheDocument()
   expect(screen.getByTestId('stat-fertilize')).toBeInTheDocument()
   expect(screen.getByTestId('stat-total')).toBeInTheDocument()
-  expect(screen.getByLabelText('3 of 4 total tasks done')).toBeInTheDocument()
+  expect(screen.getByLabelText('3 of 4 tasks done')).toBeInTheDocument()
   expect(screen.getByLabelText('1 of 2 water tasks done')).toBeInTheDocument()
   expect(screen.getByLabelText('2 of 2 fertilize tasks done')).toBeInTheDocument()
   const svgs = container.querySelectorAll('svg')

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -27,6 +27,7 @@ import useHappyPlant from '../hooks/useHappyPlant.js'
 export default function Home() {
   const { plants } = usePlants()
   const [showSummary, setShowSummary] = useState(false)
+  const [typeFilter, setTypeFilter] = useState('all')
   const happyPlant = useHappyPlant()
 
 
@@ -90,6 +91,10 @@ export default function Home() {
   const tasks = [...waterTasks, ...fertilizeTasks].sort(
     (a, b) => new Date(a.date) - new Date(b.date)
   )
+  const visibleTasks =
+    typeFilter === 'all'
+      ? tasks
+      : tasks.filter(t => t.type.toLowerCase() === typeFilter)
   const totalCount = tasks.length
   const waterCount = waterTasks.length
   const fertilizeCount = fertilizeTasks.length
@@ -124,6 +129,24 @@ export default function Home() {
     month: 'long',
     day: 'numeric',
   })
+
+  const scrollToTasks = () =>
+    document.getElementById('tasks-container')?.scrollIntoView({ behavior: 'smooth' })
+
+  const handleTotalClick = () => {
+    setTypeFilter('all')
+    scrollToTasks()
+  }
+
+  const handleWaterClick = () => {
+    setTypeFilter('water')
+    scrollToTasks()
+  }
+
+  const handleFertClick = () => {
+    setTypeFilter('fertilize')
+    scrollToTasks()
+  }
 
 
   return (
@@ -160,6 +183,9 @@ export default function Home() {
       waterTotal={totalWaterToday}
       fertCompleted={fertilizedTodayCount}
       fertTotal={totalFertilizeToday}
+      onTotalClick={handleTotalClick}
+      onWaterClick={handleWaterClick}
+      onFertClick={handleFertClick}
     />
       {showSummary && (
         <CareSummaryModal tasks={tasks} onClose={() => setShowSummary(false)} />
@@ -173,8 +199,8 @@ export default function Home() {
             <h2 className="font-semibold font-headline">Today’s Tasks</h2>
           </div>
           <div className="space-y-4">
-            {tasks.length > 0 ? (
-              tasks.map(task => (
+            {visibleTasks.length > 0 ? (
+              visibleTasks.map(task => (
                 <BaseCard key={task.id} variant="task">
                   <TaskCard
                     task={task}


### PR DESCRIPTION
## Summary
- show forecast emoji and center action button on Featured plant card
- rename total stats ring to "All Tasks" and add click handlers
- filter home screen tasks when care stats are clicked

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68793c9026b08324bdbf448e04e01fa8