### PR TITLE
Add progress indicators for add plant steps

### DIFF
--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -6,6 +6,25 @@ import ImageStep from './add/ImageStep.jsx'
 import ScheduleStep from './add/ScheduleStep.jsx'
 import OptionalInfoStep from './add/OptionalInfoStep.jsx'
 
+const totalSteps = 4
+
+function StepIndicator({ step }) {
+  const width = (step / totalSteps) * 100
+  return (
+    <div className="max-w-md mx-auto mb-4" data-testid="step-indicator">
+      <p className="text-sm font-medium text-center mb-2">
+        Step {step} of {totalSteps}
+      </p>
+      <div className="w-full bg-gray-200 rounded-full h-2">
+        <div
+          className="bg-green-600 h-2 rounded-full"
+          style={{ width: `${width}%` }}
+        />
+      </div>
+    </div>
+  )
+}
+
 const initialState = {
   name: '',
   image: '',
@@ -63,6 +82,7 @@ export default function Add() {
 
   return (
     <>
+      <StepIndicator step={step} />
       {step === 1 && (
         <NameStep name={state.name} dispatch={dispatch} onNext={next} />
       )}

--- a/src/pages/__tests__/Add.test.jsx
+++ b/src/pages/__tests__/Add.test.jsx
@@ -20,20 +20,24 @@ test('user can complete steps and add a plant', () => {
   )
 
   // step 1
+  expect(screen.getByText(/step 1 of 4/i)).toBeInTheDocument()
   fireEvent.change(screen.getByLabelText(/name/i), {
     target: { value: 'Test Plant' },
   })
   fireEvent.click(screen.getByRole('button', { name: /next/i }))
 
   // step 2
+  expect(screen.getByText(/step 2 of 4/i)).toBeInTheDocument()
   expect(screen.getByLabelText(/image url/i)).toBeInTheDocument()
   fireEvent.click(screen.getByRole('button', { name: /next/i }))
 
   // step 3
+  expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument()
   expect(screen.getByLabelText(/last watered/i)).toBeInTheDocument()
   fireEvent.click(screen.getByRole('button', { name: /next/i }))
 
   // step 4
+  expect(screen.getByText(/step 4 of 4/i)).toBeInTheDocument()
   expect(screen.getByLabelText(/room/i)).toBeInTheDocument()
   fireEvent.change(screen.getByLabelText(/room/i), { target: { value: 'Desk' } })
   fireEvent.change(screen.getByLabelText(/notes/i), { target: { value: 'Thrives' } })


### PR DESCRIPTION
## Summary
- show step progress indicator in `Add.jsx`
- test that step text appears in each step

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68793c0672b08324bfe8405dbdf263db