### PR TITLE
Change forecast text color

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -153,12 +153,12 @@ export default function Home() {
     <div className="space-y-8">
       <header className="flex flex-col items-start text-left space-y-1">
         <p className="text-base font-medium text-gray-600">Hi {username}, let’s check on your plants.</p>
-        <p className="text-xs text-gray-400 font-body flex items-center gap-1">
+        <p className="text-xs text-gray-500 font-body flex items-center gap-1">
           {forecast && (() => {
             const Icon = weatherIcons[forecast.condition] || Sun
             return (
               <Icon
-                className="w-4 h-4 text-gray-400 align-middle"
+                className="w-4 h-4 text-gray-500 align-middle"
                 aria-label={forecast.condition}
               />
             )


### PR DESCRIPTION
## Summary
- adjust forecast section text colors to use `text-gray-500`

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68793f200ccc83248cb14e13ed3faef9