### PR TITLE
Add icons and overdue badge

### DIFF
--- a/src/MenuContext.jsx
+++ b/src/MenuContext.jsx
@@ -1,19 +1,33 @@
 import { createContext, useContext, useState } from 'react'
 import {
-  House,
-  ListBullets,
   CalendarBlank,
   Plus,
   UserCircle,
   List,
 } from 'phosphor-react'
 
+function EmojiHomeIcon(props) {
+  return (
+    <span role="img" aria-label="Home" {...props}>
+      🏠
+    </span>
+  )
+}
+
+function EmojiPlantIcon(props) {
+  return (
+    <span role="img" aria-label="My Plants" {...props}>
+      🌿
+    </span>
+  )
+}
+
 const MenuContext = createContext()
 
 export const defaultMenu = {
   items: [
-    { to: '/', label: 'Home', Icon: House },
-    { to: '/myplants', label: 'My Plants', Icon: ListBullets },
+    { to: '/', label: 'Home', Icon: EmojiHomeIcon },
+    { to: '/myplants', label: 'My Plants', Icon: EmojiPlantIcon },
     { to: '/timeline', label: 'Timeline', Icon: CalendarBlank },
     { to: '/add', label: 'Add Plant', Icon: Plus },
     { to: '/room/add', label: 'Add Room', Icon: Plus },

--- a/src/components/__tests__/PersistentBottomNav.test.jsx
+++ b/src/components/__tests__/PersistentBottomNav.test.jsx
@@ -6,6 +6,16 @@ import { Gear } from 'phosphor-react'
 import PersistentBottomNav from '../PersistentBottomNav.jsx'
 import { MenuProvider, defaultMenu, useMenu } from '../../MenuContext.jsx'
 
+let mockPlants = []
+
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: () => ({ plants: mockPlants }),
+}))
+
+afterEach(() => {
+  mockPlants = []
+})
+
 const customMenu = {
   ...defaultMenu,
   items: [...defaultMenu.items, { to: '/profile', label: 'Profile', Icon: Gear }],
@@ -57,4 +67,27 @@ test('more menu opens and closes with additional links', () => {
   fireEvent.click(screen.getByRole('button', { name: /close menu/i }))
   expect(screen.queryByRole('dialog', { name: /navigation menu/i })).toBeNull()
 
+})
+
+test('shows overdue count on My Plants when tasks exist', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
+  mockPlants = [
+    {
+      id: 1,
+      name: 'Plant A',
+      image: 'a.jpg',
+      lastWatered: '2025-07-01',
+      nextFertilize: '2025-07-05',
+    },
+  ]
+  render(
+    <MemoryRouter>
+      <MenuProvider>
+        <PersistentBottomNav />
+      </MenuProvider>
+    </MemoryRouter>
+  )
+  const badge = screen.getByLabelText(/overdue tasks/i)
+  expect(badge).toHaveTextContent('2')
+  jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- swap Home and My Plants icons for emoji variants
- show overdue task count on My Plants tab
- test nav badge behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687950b553a88324ad7e8d36a663d8d5