### PR TITLE
Add time zone setting

### DIFF
--- a/src/UserContext.jsx
+++ b/src/UserContext.jsx
@@ -10,6 +10,13 @@ export function UserProvider({ children }) {
     }
     return 'Jon'
   })
+  const [timeZone, setTimeZone] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('timeZone')
+      if (stored) return stored
+    }
+    return Intl.DateTimeFormat().resolvedOptions().timeZone
+  })
 
   useEffect(() => {
     if (typeof localStorage !== 'undefined') {
@@ -17,8 +24,14 @@ export function UserProvider({ children }) {
     }
   }, [username])
 
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('timeZone', timeZone)
+    }
+  }, [timeZone])
+
   return (
-    <UserContext.Provider value={{ username, setUsername }}>
+    <UserContext.Provider value={{ username, setUsername, timeZone, setTimeZone }}>
       {children}
     </UserContext.Provider>
   )

--- a/src/__tests__/FabVisibility.test.jsx
+++ b/src/__tests__/FabVisibility.test.jsx
@@ -11,7 +11,7 @@ jest.mock('../WeatherContext.jsx', () => ({
 }))
 
 jest.mock('../UserContext.jsx', () => ({
-  useUser: () => ({ username: 'Jon' }),
+  useUser: () => ({ username: 'Jon', timeZone: 'UTC' }),
 }))
 
 jest.mock('../ThemeContext.jsx', () => ({

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -33,7 +33,7 @@ export default function Home() {
 
   const weatherCtx = useWeather()
   const forecast = weatherCtx?.forecast
-  const { username } = useUser()
+  const { username, timeZone } = useUser()
   const weatherData = { rainTomorrow: forecast?.rainfall || 0 }
 
   const weatherIcons = {
@@ -126,10 +126,12 @@ export default function Home() {
 
   const weekday = new Date().toLocaleDateString(undefined, {
     weekday: 'long',
+    timeZone,
   })
   const monthDay = new Date().toLocaleDateString(undefined, {
     month: 'long',
     day: 'numeric',
+    timeZone,
   })
 
   const scrollToTasks = () =>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -5,7 +5,7 @@ import { useUser } from '../UserContext.jsx'
 export default function Settings() {
   const { theme, toggleTheme } = useTheme()
   const { location, setLocation, units, setUnits } = useWeather()
-  const { username, setUsername } = useUser()
+  const { username, setUsername, timeZone, setTimeZone } = useUser()
 
   return (
     <div className="space-y-4 text-gray-700 dark:text-gray-200">
@@ -47,6 +47,16 @@ export default function Settings() {
           <option value="imperial">Fahrenheit</option>
           <option value="metric">Celsius</option>
         </select>
+      </div>
+      <div className="grid gap-1 max-w-xs">
+        <label htmlFor="timezone" className="font-medium">Time Zone</label>
+        <input
+          id="timezone"
+          type="text"
+          value={timeZone}
+          onChange={e => setTimeZone(e.target.value)}
+          className="border rounded p-2"
+        />
       </div>
     </div>
   )

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -7,7 +7,7 @@ jest.mock('../../WeatherContext.jsx', () => ({
 }))
 
 jest.mock('../../UserContext.jsx', () => ({
-  useUser: () => ({ username: 'Jon' }),
+  useUser: () => ({ username: 'Jon', timeZone: 'UTC' }),
 }))
 
 const mockPlants = []

--- a/src/pages/__tests__/ProfileRoute.test.jsx
+++ b/src/pages/__tests__/ProfileRoute.test.jsx
@@ -11,7 +11,7 @@ jest.mock('../../WeatherContext.jsx', () => ({
 }))
 
 jest.mock('../../UserContext.jsx', () => ({
-  useUser: () => ({ username: 'Jon', setUsername: () => {} }),
+  useUser: () => ({ username: 'Jon', setUsername: () => {}, timeZone: 'UTC', setTimeZone: () => {} }),
 }))
 
 jest.mock('../../ThemeContext.jsx', () => ({


### PR DESCRIPTION
## Summary
- extend `UserContext` to store a `timeZone`
- allow time zone editing on the Settings page
- format dates using the chosen time zone on the Home page
- update tests for new context shape

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687951ecfae48324a1bc49b5f7b3e458