### PR TITLE
Add breadcrumb navigation

### DIFF
--- a/src/components/Breadcrumb.jsx
+++ b/src/components/Breadcrumb.jsx
@@ -1,0 +1,29 @@
+import { Link } from 'react-router-dom'
+
+export default function Breadcrumb({ room, plant }) {
+  return (
+    <nav aria-label="Breadcrumb" className="flex items-center gap-1 text-sm mb-2">
+      <Link to="/myplants" className="text-blue-600 hover:underline">
+        My Plants
+      </Link>
+      {room && (
+        <>
+          <span className="mx-1">&gt;</span>
+          {plant ? (
+            <Link to={`/room/${encodeURIComponent(room)}`} className="text-blue-600 hover:underline">
+              {room}
+            </Link>
+          ) : (
+            <span>{room}</span>
+          )}
+        </>
+      )}
+      {plant && (
+        <>
+          <span className="mx-1">&gt;</span>
+          <span>{plant}</span>
+        </>
+      )}
+    </nav>
+  )
+}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -23,6 +23,7 @@ import NoteModal from '../components/NoteModal.jsx'
 import { useMenu, defaultMenu } from '../MenuContext.jsx'
 import LegendModal from '../components/LegendModal.jsx'
 import ProgressRing from '../components/ProgressRing.jsx'
+import Breadcrumb from '../components/Breadcrumb.jsx'
 
 import useToast from "../hooks/useToast.jsx"
 import confetti from 'canvas-confetti'
@@ -170,7 +171,7 @@ export default function PlantDetail() {
   return (
 
     <div className="space-y-8 pt-4 pb-safe px-4 relative text-left">
-
+      <Breadcrumb room={plant.room} plant={plant.name} />
       <Toast />
       <div className="space-y-4">
         <div className="relative">

--- a/src/pages/RoomList.jsx
+++ b/src/pages/RoomList.jsx
@@ -1,8 +1,9 @@
-import { Link, useParams } from 'react-router-dom'
+import { useParams } from 'react-router-dom'
 import { useState } from 'react'
 import { usePlants } from '../PlantContext.jsx'
 import { formatDaysAgo } from '../utils/dateFormat.js'
 import { createRipple } from '../utils/interactions.js'
+import Breadcrumb from '../components/Breadcrumb.jsx'
 
 export default function RoomList() {
   const { roomName } = useParams()
@@ -24,14 +25,7 @@ export default function RoomList() {
 
   return (
     <div>
-      <div className="flex items-center gap-2 mb-2">
-        <Link
-          to="/myplants"
-          className="text-sm text-blue-600 hover:underline"
-        >
-          &larr; My Plants
-        </Link>
-      </div>
+      <Breadcrumb room={roomName} />
       <h1 className="text-2xl font-bold font-headline mb-4">{roomName}</h1>
       {list.length > 0 && (
         <div className="mb-4">


### PR DESCRIPTION
## Summary
- show navigation path with new `Breadcrumb` component
- include breadcrumbs in RoomList and PlantDetail pages

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687954348c1083249f63da5c4f050845