### PR TITLE
Compute overdue count in nav

### DIFF
--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -1,9 +1,11 @@
 import { useState, useEffect } from 'react'
 import { NavLink } from 'react-router-dom'
 import { useMenu } from '../MenuContext.jsx'
+import useOverdueCount from '../hooks/useOverdueCount.js'
 
 export default function PersistentBottomNav() {
   const [open, setOpen] = useState(false)
+  const overdueCount = useOverdueCount()
   const { menu } = useMenu()
   const { items, Icon } = menu
   const mainLinks = items.slice(0, 3)
@@ -21,20 +23,28 @@ export default function PersistentBottomNav() {
   return (
     <nav className="fixed bottom-0 inset-x-0 bg-white dark:bg-gray-700 border-t border-gray-200 dark:border-gray-600 pb-safe z-20">
       <ul className="flex justify-around items-center py-2 text-xs">
-        {mainLinks.map(({ to, label, Icon: LinkIcon }) => (
-          <li key={label}>
-            <NavLink
-              to={to}
-              title={label}
-              className={({ isActive }) =>
-                `flex flex-col items-center gap-1 ${isActive ? 'text-accent' : 'text-gray-500'}`
-              }
-            >
-              <LinkIcon className="w-6 h-6" aria-hidden="true" />
-              {label}
-            </NavLink>
-          </li>
-        ))}
+        {mainLinks.map(({ to, label, Icon: LinkIcon }) => {
+          const showBadge = label === 'My Plants' && overdueCount > 0
+          return (
+            <li key={label} className="relative">
+              <NavLink
+                to={to}
+                title={label}
+                className={({ isActive }) =>
+                  `flex flex-col items-center gap-1 ${isActive ? 'text-accent' : 'text-gray-500'}`
+                }
+              >
+                <LinkIcon className="w-6 h-6" aria-hidden="true" />
+                {label}
+                {showBadge && (
+                  <span className="absolute -top-1 -right-2 bg-red-600 text-white text-[10px] rounded-full px-1">
+                    {overdueCount}
+                  </span>
+                )}
+              </NavLink>
+            </li>
+          )
+        })}
         <li>
           <button
             type="button"

--- a/src/components/__tests__/PersistentBottomNav.test.jsx
+++ b/src/components/__tests__/PersistentBottomNav.test.jsx
@@ -5,6 +5,9 @@ import { useEffect } from 'react'
 import { Gear } from 'phosphor-react'
 import PersistentBottomNav from '../PersistentBottomNav.jsx'
 import { MenuProvider, defaultMenu, useMenu } from '../../MenuContext.jsx'
+import useOverdueCount from '../../hooks/useOverdueCount.js'
+
+jest.mock('../../hooks/useOverdueCount.js')
 
 const customMenu = {
   ...defaultMenu,
@@ -28,6 +31,7 @@ function MenuSetter({ children }) {
 }
 
 test('renders main navigation links', () => {
+  useOverdueCount.mockReturnValue(0)
   const { container } = render(
     <MemoryRouter>
       <CustomMenuProvider>
@@ -40,7 +44,20 @@ test('renders main navigation links', () => {
   expect(container.querySelector('a[href="/timeline"]')).toBeInTheDocument()
 })
 
+test('shows overdue badge when tasks pending', () => {
+  useOverdueCount.mockReturnValue(3)
+  render(
+    <MemoryRouter>
+      <CustomMenuProvider>
+        <PersistentBottomNav />
+      </CustomMenuProvider>
+    </MemoryRouter>
+  )
+  expect(screen.getByText('3')).toBeInTheDocument()
+})
+
 test('more menu opens and closes with additional links', () => {
+  useOverdueCount.mockReturnValue(0)
   const { container } = render(
     <MemoryRouter>
       <CustomMenuProvider>

--- a/src/hooks/useOverdueCount.js
+++ b/src/hooks/useOverdueCount.js
@@ -1,0 +1,17 @@
+import { useMemo } from 'react'
+import { usePlants } from '../PlantContext.jsx'
+import { getNextWateringDate } from '../utils/watering.js'
+
+export default function useOverdueCount() {
+  const { plants } = usePlants()
+  const todayIso = new Date().toISOString().slice(0, 10)
+
+  return useMemo(() => {
+    return plants.reduce((m, p) => {
+      const { date } = getNextWateringDate(p.lastWatered)
+      if (date < todayIso) m += 1
+      if (p.nextFertilize && p.nextFertilize < todayIso) m += 1
+      return m
+    }, 0)
+  }, [plants, todayIso])
+}


### PR DESCRIPTION
## Summary
- compute overdue task totals via new `useOverdueCount` hook
- show badge on "My Plants" tab in `PersistentBottomNav`
- test nav badge behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68795431b2a4832481fa92aa6d4dfe6f