### PR TITLE
Move add links to global FAB

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import Timeline from './pages/Timeline'
 import Gallery from './pages/Gallery.jsx'
 
 import PersistentBottomNav from './components/PersistentBottomNav.jsx'
+import CreateFab from './components/CreateFab.jsx'
 
 import { MenuProvider } from './MenuContext.jsx'
 import NotFound from './pages/NotFound'
@@ -57,8 +58,7 @@ export default function App() {
         </motion.div>
       </AnimatePresence>
 
-
-
+        <CreateFab />
         <PersistentBottomNav />
       </div>
       </MenuProvider>

--- a/src/MenuContext.jsx
+++ b/src/MenuContext.jsx
@@ -3,7 +3,6 @@ import {
   House,
   ListBullets,
   CalendarBlank,
-  Plus,
   UserCircle,
   List,
 } from 'phosphor-react'
@@ -15,8 +14,6 @@ export const defaultMenu = {
     { to: '/', label: 'Home', Icon: House },
     { to: '/myplants', label: 'My Plants', Icon: ListBullets },
     { to: '/timeline', label: 'Timeline', Icon: CalendarBlank },
-    { to: '/add', label: 'Add Plant', Icon: Plus },
-    { to: '/room/add', label: 'Add Room', Icon: Plus },
     { to: '/profile', label: 'Profile', Icon: UserCircle },
   ],
   Icon: List,

--- a/src/__tests__/FabVisibility.test.jsx
+++ b/src/__tests__/FabVisibility.test.jsx
@@ -42,7 +42,7 @@ describe('Menu contents based on route', () => {
       </MemoryRouter>
     )
 
-    const button = screen.getByRole('button', { name: /open navigation menu/i })
+    const button = screen.getByRole('button', { name: /open create menu/i })
     fireEvent.click(button)
     const links = screen.getAllByRole('link', { name: /add plant/i })
     expect(links.length).toBeGreaterThan(0)
@@ -57,7 +57,7 @@ describe('Menu contents based on route', () => {
       </MemoryRouter>
     )
 
-    const button = screen.getByRole('button', { name: /open navigation menu/i })
+    const button = screen.getByRole('button', { name: /open create menu/i })
     fireEvent.click(button)
     expect(screen.getByRole('link', { name: /add plant/i })).toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: /add room/i }).length).toBeGreaterThan(0)

--- a/src/components/__tests__/PersistentBottomNav.test.jsx
+++ b/src/components/__tests__/PersistentBottomNav.test.jsx
@@ -53,6 +53,8 @@ test('more menu opens and closes with additional links', () => {
   const overlay = screen.getByRole('dialog', { name: /navigation menu/i })
   expect(overlay).toBeInTheDocument()
   expect(overlay).toHaveClass('backdrop-blur-sm')
+  expect(screen.queryByRole('link', { name: /add plant/i })).toBeNull()
+  expect(screen.queryByRole('link', { name: /add room/i })).toBeNull()
   expect(container.querySelector('a[href="/profile"]')).toBeInTheDocument()
   fireEvent.click(screen.getByRole('button', { name: /close menu/i }))
   expect(screen.queryByRole('dialog', { name: /navigation menu/i })).toBeNull()


### PR DESCRIPTION
## Summary
- render global FAB on every page
- remove add actions from default navigation menu
- expect add links via FAB in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687954284e0083249c752bacc6dcdb16