### PR TITLE
Update nav tests for profile links

### DIFF
--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -8,8 +8,9 @@ export default function PersistentBottomNav() {
   const overdueCount = useOverdueCount()
   const { menu } = useMenu()
   const { items, Icon } = menu
-  const mainLinks = items.slice(0, 3)
-  const moreItems = items.slice(3)
+  const mainCount = Math.min(4, items.length)
+  const mainLinks = items.slice(0, mainCount)
+  const moreItems = items.slice(mainCount)
 
   useEffect(() => {
     if (!open) return

--- a/src/components/__tests__/PersistentBottomNav.test.jsx
+++ b/src/components/__tests__/PersistentBottomNav.test.jsx
@@ -42,6 +42,7 @@ test('renders main navigation links', () => {
   expect(container.querySelector('a[href="/"]')).toBeInTheDocument()
   expect(container.querySelector('a[href="/myplants"]')).toBeInTheDocument()
   expect(container.querySelector('a[href="/timeline"]')).toBeInTheDocument()
+  expect(container.querySelector('a[href="/profile"]')).toBeInTheDocument()
 })
 
 test('shows overdue badge when tasks pending', () => {
@@ -72,7 +73,7 @@ test('more menu opens and closes with additional links', () => {
   expect(overlay).toHaveClass('backdrop-blur-sm')
   expect(screen.queryByRole('link', { name: /add plant/i })).toBeNull()
   expect(screen.queryByRole('link', { name: /add room/i })).toBeNull()
-  expect(container.querySelector('a[href="/profile"]')).toBeInTheDocument()
+  expect(overlay.querySelector('a[href="/profile"]')).toBeInTheDocument()
   fireEvent.click(screen.getByRole('button', { name: /close menu/i }))
   expect(screen.queryByRole('dialog', { name: /navigation menu/i })).toBeNull()
 


### PR DESCRIPTION
## Summary
- check that `/profile` appears in the main navigation
- validate profile entry in overlay menu
- handle up to four main nav links in `PersistentBottomNav`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68798247c25c8324a9e2e08bbc7cba46