### PR TITLE
Update nav to surface profile link

### DIFF
--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -7,9 +7,11 @@ export default function PersistentBottomNav() {
   const [open, setOpen] = useState(false)
   const overdueCount = useOverdueCount()
   const { menu } = useMenu()
-  const { items, Icon } = menu
+  const { items } = menu
   const mainLinks = items.slice(0, 3)
-  const moreItems = items.slice(3)
+  const profileLink = items[3]
+  const moreItems = items.slice(4)
+  const ProfileIcon = profileLink?.Icon
 
   useEffect(() => {
     if (!open) return
@@ -45,22 +47,22 @@ export default function PersistentBottomNav() {
             </li>
           )
         })}
-        <li>
-          <button
-            type="button"
-            aria-label="Open navigation menu"
-            aria-haspopup="menu"
-            aria-expanded={open}
-            onClick={() => setOpen(true)}
-            className="flex flex-col items-center gap-1 text-gray-500"
-            title="More"
-          >
-            <Icon className="w-6 h-6" aria-hidden="true" />
-            More
-          </button>
-        </li>
+        {profileLink && (
+          <li className="relative">
+            <NavLink
+              to={profileLink.to}
+              title={profileLink.label}
+              className={({ isActive }) =>
+                `flex flex-col items-center gap-1 ${isActive ? 'text-accent' : 'text-gray-500'}`
+              }
+            >
+              {ProfileIcon && <ProfileIcon className="w-6 h-6" aria-hidden="true" />}
+              {profileLink.label}
+            </NavLink>
+          </li>
+        )}
       </ul>
-      {open && (
+      {open && moreItems.length > 0 && (
         <div
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
           role="dialog"

--- a/src/components/__tests__/PersistentBottomNav.test.jsx
+++ b/src/components/__tests__/PersistentBottomNav.test.jsx
@@ -42,6 +42,7 @@ test('renders main navigation links', () => {
   expect(container.querySelector('a[href="/"]')).toBeInTheDocument()
   expect(container.querySelector('a[href="/myplants"]')).toBeInTheDocument()
   expect(container.querySelector('a[href="/timeline"]')).toBeInTheDocument()
+  expect(container.querySelector('a[href="/profile"]')).toBeInTheDocument()
 })
 
 test('shows overdue badge when tasks pending', () => {
@@ -56,7 +57,7 @@ test('shows overdue badge when tasks pending', () => {
   expect(screen.getByText('3')).toBeInTheDocument()
 })
 
-test('more menu opens and closes with additional links', () => {
+test('profile link replaces more button when additional links exist', () => {
   useOverdueCount.mockReturnValue(0)
   const { container } = render(
     <MemoryRouter>
@@ -65,15 +66,7 @@ test('more menu opens and closes with additional links', () => {
       </CustomMenuProvider>
     </MemoryRouter>
   )
-  const button = screen.getByRole('button', { name: /open navigation menu/i })
-  fireEvent.click(button)
-  const overlay = screen.getByRole('dialog', { name: /navigation menu/i })
-  expect(overlay).toBeInTheDocument()
-  expect(overlay).toHaveClass('backdrop-blur-sm')
-  expect(screen.queryByRole('link', { name: /add plant/i })).toBeNull()
-  expect(screen.queryByRole('link', { name: /add room/i })).toBeNull()
+  expect(screen.queryByRole('button', { name: /open navigation menu/i })).toBeNull()
   expect(container.querySelector('a[href="/profile"]')).toBeInTheDocument()
-  fireEvent.click(screen.getByRole('button', { name: /close menu/i }))
   expect(screen.queryByRole('dialog', { name: /navigation menu/i })).toBeNull()
-
 })


### PR DESCRIPTION
## Summary
- show profile link directly in the bottom nav
- avoid displaying modal when there are no extra links
- update tests for profile link

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68798246745c8324977eceef74c59ab3