### PR TITLE
Fix PersistentBottomNav more menu

### DIFF
--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -11,7 +11,9 @@ export default function PersistentBottomNav() {
   const { items, Icon } = menu
   const mainCount = Math.min(4, items.length)
   const mainLinks = items.slice(0, mainCount)
-  const moreItems = items.slice(mainCount)
+  const profileLink = items[3] // link shown when available
+  const moreItems = items.slice(4)
+  const ProfileIcon = profileLink?.Icon
 
 
   useEffect(() => {
@@ -48,6 +50,22 @@ export default function PersistentBottomNav() {
             </li>
           )
         })}
+        {moreItems.length > 0 && (
+          <li>
+            <button
+              type="button"
+              aria-label="Open navigation menu"
+              aria-haspopup="menu"
+              aria-expanded={open}
+              onClick={() => setOpen(true)}
+              className="flex flex-col items-center gap-1 text-gray-500"
+              title="More"
+            >
+              <Icon className="w-6 h-6" aria-hidden="true" />
+              More
+            </button>
+          </li>
+        )}
         {profileLink && (
           <li className="relative">
             <NavLink


### PR DESCRIPTION
## Summary
- compute link groups with profile link and leftover items
- restore the "More" button to open the navigation overlay

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879897f94048324bb4ae8520eefdc2a