### PR TITLE
Fix duplicate profile link in bottom nav

### DIFF
--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -9,10 +9,10 @@ export default function PersistentBottomNav() {
   const { menu } = useMenu()
 
   const { items, Icon } = menu
-  const mainCount = Math.min(4, items.length)
-  const mainLinks = items.slice(0, mainCount)
-  const profileLink = items[3] // link shown when available
-  const moreItems = items.slice(4)
+  const hasProfileLink = items.length > 3
+  const mainLinks = items.slice(0, hasProfileLink ? 3 : items.length)
+  const profileLink = hasProfileLink ? items[3] : null
+  const moreItems = hasProfileLink ? items.slice(4) : []
   const ProfileIcon = profileLink?.Icon
 
 


### PR DESCRIPTION
## Summary
- clean up nav logic to avoid rendering the profile link twice

## Testing
- `npm run lint`
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_68798d1d0bc08324800f75d61fb4b211