### PR TITLE
Fix service worker fetch handling

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -37,7 +37,12 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return
+  const url = new URL(event.request.url)
+  if (url.origin !== self.location.origin) return
   event.respondWith(
-    caches.match(event.request).then((resp) => resp || fetch(event.request))
+    caches
+      .match(event.request)
+      .then((resp) => resp || fetch(event.request))
+      .catch(() => caches.match(event.request))
   )
 })


### PR DESCRIPTION
## Summary
- handle network errors gracefully in `sw.js`
- skip caching for cross-origin requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879939a07888324964ba7d4e97247e1