### PR TITLE
Add /plants redirect route and tests

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,4 +1,4 @@
-import { Routes, Route, useLocation } from 'react-router-dom'
+import { Routes, Route, useLocation, Navigate } from 'react-router-dom'
 import { AnimatePresence, motion } from 'framer-motion'
 import Home from './pages/Home'
 import MyPlants from './pages/MyPlants'
@@ -41,6 +41,7 @@ export default function App() {
         <motion.div key={location.pathname}>
           <Routes location={location}>
             <Route path="/" element={<Home />} />
+            <Route path="/plants" element={<Navigate to="/myplants" replace />} />
             <Route path="/myplants" element={<PageTransition><MyPlants /></PageTransition>} />
             <Route path="/tasks" element={<Tasks />} />
             <Route path="/add" element={<Add />} />

--- a/src/pages/__tests__/PlantsRoute.test.jsx
+++ b/src/pages/__tests__/PlantsRoute.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import App from '../../App.jsx'
+
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: () => ({ plants: [] }),
+}))
+
+jest.mock('../../RoomContext.jsx', () => ({
+  useRooms: () => ({ rooms: [] }),
+}))
+
+jest.mock('../../components/CreateFab.jsx', () => () => null)
+jest.mock('../../components/PersistentBottomNav.jsx', () => () => null)
+
+test("navigating to /plants redirects to My Plants", () => {
+  render(
+    <MemoryRouter initialEntries={['/plants']}>
+      <App />
+    </MemoryRouter>
+  )
+  expect(screen.getByRole('heading', { name: /my plants/i })).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- add redirect from `/plants` to `/myplants`
- keep bottom navigation and breadcrumbs linking to `/myplants`
- add unit test for redirect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68799f38b314832496bbb3e802607f11