### PR TITLE
Revamp add flow

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,7 +13,6 @@ import Timeline from './pages/Timeline'
 import Gallery from './pages/Gallery.jsx'
 
 import PersistentBottomNav from './components/PersistentBottomNav.jsx'
-import CreateFab from './components/CreateFab.jsx'
 
 import { MenuProvider } from './MenuContext.jsx'
 import NotFound from './pages/NotFound'
@@ -58,7 +57,6 @@ export default function App() {
         </motion.div>
       </AnimatePresence>
 
-        <CreateFab />
         <PersistentBottomNav />
       </div>
       </MenuProvider>

--- a/src/MenuContext.jsx
+++ b/src/MenuContext.jsx
@@ -4,6 +4,7 @@ import {
   Flower,
   CalendarBlank,
   UserCircle,
+  PlusCircle,
   List,
 } from 'phosphor-react'
 
@@ -15,6 +16,7 @@ export const defaultMenu = {
     { to: '/myplants', label: 'My Plants', Icon: Flower },
     { to: '/timeline', label: 'Timeline', Icon: CalendarBlank },
     { to: '/profile', label: 'Profile', Icon: UserCircle },
+    { label: 'Add', Icon: PlusCircle },
   ],
   Icon: List,
 }

--- a/src/__tests__/FabVisibility.test.jsx
+++ b/src/__tests__/FabVisibility.test.jsx
@@ -42,7 +42,7 @@ describe('Menu contents based on route', () => {
       </MemoryRouter>
     )
 
-    const button = screen.getByRole('button', { name: /open create menu/i })
+    const button = screen.getByRole('button', { name: /open add menu/i })
     fireEvent.click(button)
     const links = screen.getAllByRole('link', { name: /add plant/i })
     expect(links.length).toBeGreaterThan(0)
@@ -57,7 +57,7 @@ describe('Menu contents based on route', () => {
       </MemoryRouter>
     )
 
-    const button = screen.getByRole('button', { name: /open create menu/i })
+    const button = screen.getByRole('button', { name: /open add menu/i })
     fireEvent.click(button)
     expect(screen.getByRole('link', { name: /add plant/i })).toBeInTheDocument()
     expect(screen.getAllByRole('link', { name: /add room/i }).length).toBeGreaterThan(0)

--- a/src/components/AddMenu.jsx
+++ b/src/components/AddMenu.jsx
@@ -1,0 +1,47 @@
+import { NavLink } from 'react-router-dom'
+import { Plus, Note } from 'phosphor-react'
+
+export default function AddMenu({ open = false, onClose = () => {} }) {
+  if (!open) return null
+  const items = [
+    { to: '/add', label: 'Add Plant', Icon: Plus },
+    { to: '/room/add', label: 'Add Room', Icon: Plus },
+    // Future: { to: '/note/add', label: 'Add Note', Icon: Note }
+  ]
+  return (
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
+      role="dialog"
+      aria-modal="true"
+      aria-label="Add menu"
+      onClick={onClose}
+    >
+      <ul
+        className="relative bg-white dark:bg-gray-700 rounded-lg shadow-lg p-6 space-y-4 bloom-pop text-lg"
+        onClick={e => e.stopPropagation()}
+      >
+        <button
+          type="button"
+          aria-label="Close menu"
+          onClick={onClose}
+          className="absolute top-2 right-2 text-gray-500"
+        >
+          &times;
+        </button>
+        {items.map(({ to, label, Icon }) => (
+          <li key={label}>
+            <NavLink
+              to={to}
+              onClick={onClose}
+              title={label}
+              className="flex items-center gap-3 hover:text-accent"
+            >
+              <Icon className="w-5 h-5" aria-hidden="true" />
+              {label}
+            </NavLink>
+          </li>
+        ))}
+      </ul>
+    </div>
+  )
+}

--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -2,18 +2,18 @@ import { useState, useEffect } from 'react'
 import { NavLink } from 'react-router-dom'
 import { useMenu } from '../MenuContext.jsx'
 import useOverdueCount from '../hooks/useOverdueCount.js'
+import AddMenu from './AddMenu.jsx'
 
 export default function PersistentBottomNav() {
   const [open, setOpen] = useState(false)
+  const [addOpen, setAddOpen] = useState(false)
   const overdueCount = useOverdueCount()
   const { menu } = useMenu()
 
   const { items, Icon } = menu
-  const hasProfileLink = items.length > 3
-  const mainLinks = items.slice(0, hasProfileLink ? 3 : items.length)
-  const profileLink = hasProfileLink ? items[3] : null
-  const moreItems = hasProfileLink ? items.slice(4) : []
-  const ProfileIcon = profileLink?.Icon
+  const maxVisible = 5
+  const mainLinks = items.slice(0, maxVisible)
+  const moreItems = items.slice(maxVisible)
 
 
   useEffect(() => {
@@ -30,23 +30,38 @@ export default function PersistentBottomNav() {
       <ul className="flex justify-around items-center py-2 text-xs">
         {mainLinks.map(({ to, label, Icon: LinkIcon }) => {
           const showBadge = label === 'My Plants' && overdueCount > 0
+          const isAdd = label === 'Add'
           return (
             <li key={label} className="relative">
-              <NavLink
-                to={to}
-                title={label}
-                className={({ isActive }) =>
-                  `flex flex-col items-center gap-1 ${isActive ? 'text-accent' : 'text-gray-500'}`
-                }
-              >
-                <LinkIcon className="w-6 h-6" aria-hidden="true" />
-                {label}
-                {showBadge && (
-                  <span className="absolute -top-1 -right-2 bg-red-600 text-white text-[10px] rounded-full px-1">
-                    {overdueCount}
-                  </span>
-                )}
-              </NavLink>
+              {to && !isAdd ? (
+                <NavLink
+                  to={to}
+                  title={label}
+                  className={({ isActive }) =>
+                    `flex flex-col items-center gap-1 ${isActive ? 'text-accent' : 'text-gray-500'}`
+                  }
+                >
+                  <LinkIcon className="w-6 h-6" aria-hidden="true" />
+                  {label}
+                  {showBadge && (
+                    <span className="absolute -top-1 -right-2 bg-red-600 text-white text-[10px] rounded-full px-1">
+                      {overdueCount}
+                    </span>
+                  )}
+                </NavLink>
+              ) : (
+                <button
+                  type="button"
+                  onClick={() => setAddOpen(true)}
+                  aria-label="Open add menu"
+                  aria-haspopup="menu"
+                  aria-expanded={addOpen}
+                  className="flex flex-col items-center gap-1 text-gray-500"
+                >
+                  <LinkIcon className="w-6 h-6" aria-hidden="true" />
+                  {label}
+                </button>
+              )}
             </li>
           )
         })}
@@ -64,20 +79,6 @@ export default function PersistentBottomNav() {
               <Icon className="w-6 h-6" aria-hidden="true" />
               More
             </button>
-          </li>
-        )}
-        {profileLink && (
-          <li className="relative">
-            <NavLink
-              to={profileLink.to}
-              title={profileLink.label}
-              className={({ isActive }) =>
-                `flex flex-col items-center gap-1 ${isActive ? 'text-accent' : 'text-gray-500'}`
-              }
-            >
-              {ProfileIcon && <ProfileIcon className="w-6 h-6" aria-hidden="true" />}
-              {profileLink.label}
-            </NavLink>
           </li>
         )}
       </ul>
@@ -131,6 +132,9 @@ export default function PersistentBottomNav() {
             ))}
           </ul>
         </div>
+      )}
+      {addOpen && (
+        <AddMenu open={addOpen} onClose={() => setAddOpen(false)} />
       )}
     </nav>
   )

--- a/src/components/__tests__/PersistentBottomNav.test.jsx
+++ b/src/components/__tests__/PersistentBottomNav.test.jsx
@@ -43,6 +43,9 @@ test('renders main navigation links', () => {
   expect(container.querySelector('a[href="/myplants"]')).toBeInTheDocument()
   expect(container.querySelector('a[href="/timeline"]')).toBeInTheDocument()
   expect(container.querySelector('a[href="/profile"]')).toBeInTheDocument()
+  expect(
+    screen.getByRole('button', { name: /open add menu/i })
+  ).toBeInTheDocument()
 })
 
 test('shows overdue badge when tasks pending', () => {


### PR DESCRIPTION
## Summary
- add new `AddMenu` component
- integrate Add tab into `MenuContext` and bottom nav
- remove floating FAB
- adjust tests for new navigation

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879b40aded08324a667028ea1e89e72