### PR TITLE
Improve task card visuals

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export default function Badge({ children, Icon, colorClass = 'bg-gray-200 text-gray-800' }) {
   return (
-    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-xl ${colorClass}`}>
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full shadow-sm ${colorClass}`}>
       {Icon && <Icon className="w-3 h-3" aria-hidden="true" />}
       {children}
     </span>

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -51,33 +51,44 @@ export default function TaskCard({
       data-testid="task-card"
       tabIndex="0"
       aria-label={`Task card for ${task.plantName}`}
-      className="relative overflow-hidden rounded-xl"
+      className="relative overflow-hidden rounded-2xl min-h-[130px]"
       onPointerDown={start}
       onPointerMove={move}
       onPointerUp={end}
       onPointerCancel={end}
     >
         <div
-          className={`relative flex items-center gap-3 px-4 py-3 shadow-sm ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
+          className={`relative flex items-center gap-4 px-4 py-4 shadow-sm ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
           style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
         >
-          <div className="flex items-center flex-1 gap-3">
-            <img src={task.image} alt={task.plantName} className="w-12 h-12 rounded-lg object-cover" />
+          <div className="flex items-center flex-1 gap-4">
+            <img
+              src={task.image}
+              alt={task.plantName}
+              className={`w-[60px] h-[60px] rounded-full object-cover bg-gray-100 dark:bg-gray-800 ${
+                task.type === 'Water'
+                  ? 'ring-2 ring-water-300'
+                  : task.type === 'Fertilize'
+                  ? 'ring-2 ring-fertilize-300'
+                  : 'ring-2 ring-healthy-300'
+              }`}
+            />
             <div className="w-px self-stretch bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
             <div className="flex-1 min-w-0">
               <div className="flex items-center justify-between gap-2">
-                <p className="font-semibold text-gray-900 dark:text-gray-100 truncate">
+                <p className="font-semibold text-lg text-gray-900 dark:text-gray-100 truncate">
                   {task.plantName}
                 </p>
               </div>
-              <div className="text-sm flex flex-wrap items-center gap-1 text-gray-500 mt-0.5">
+              <div className="text-sm flex flex-wrap items-center gap-1 text-gray-400 mt-0.5">
                 <Badge
+                  Icon={task.type === 'Water' ? Drop : task.type === 'Fertilize' ? Sun : undefined}
                   colorClass={`text-sm font-medium ${
                     task.type === 'Water'
-                      ? 'bg-water-100 text-water-800'
+                      ? 'bg-water-100/90 text-water-800'
                       : task.type === 'Fertilize'
-                        ? 'bg-fertilize-100 text-fertilize-800'
-                        : 'bg-healthy-100 text-healthy-800'
+                        ? 'bg-fertilize-100/90 text-fertilize-800'
+                        : 'bg-healthy-100/90 text-healthy-800'
                   }`}
                 >
                   {completed
@@ -93,7 +104,7 @@ export default function TaskCard({
                     : task.type}
                 </Badge>
                 {daysSince != null && (
-                  <span className="text-xs text-gray-500">
+                  <span className="text-xs text-gray-400">
                     {daysSince} {daysSince === 1 ? 'day' : 'days'} since care
                   </span>
                 )}

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -53,7 +53,7 @@ test('renders task text', () => {
   const badge = screen.getByText('To Water')
   expect(badge).toBeInTheDocument()
   expect(badge).toHaveClass('inline-flex')
-  expect(badge).toHaveClass('bg-water-100')
+  expect(badge).toHaveClass('bg-water-100/90')
   expect(badge).toHaveClass('text-water-800')
   expect(badge).toHaveClass('font-medium')
 })
@@ -98,7 +98,7 @@ test('shows completed state', () => {
   expect(container.querySelector('.check-pop')).toBeInTheDocument()
 })
 
-test('does not render an icon svg', () => {
+test('renders badge icon', () => {
   const { container } = render(
     <MemoryRouter>
       <BaseCard variant="task">
@@ -107,7 +107,7 @@ test('does not render an icon svg', () => {
     </MemoryRouter>
   )
   const svg = container.querySelector('svg')
-  expect(svg).toBeNull()
+  expect(svg).toBeInTheDocument()
 })
 
 test('shows info chip with accessibility label', () => {

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -6,20 +6,20 @@ exports[`matches snapshot in dark mode 1`] = `
 >
   <div
     aria-label="Task card for Monstera"
-    class="relative overflow-hidden rounded-xl"
+    class="relative overflow-hidden rounded-2xl min-h-[130px]"
     data-testid="task-card"
     tabindex="0"
   >
     <div
-      class="relative flex items-center gap-3 px-4 py-3 shadow-sm bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
+      class="relative flex items-center gap-4 px-4 py-4 shadow-sm bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
       style="transform: translateX(0px); transition: transform 0.2s;"
     >
       <div
-        class="flex items-center flex-1 gap-3"
+        class="flex items-center flex-1 gap-4"
       >
         <img
           alt="Monstera"
-          class="w-12 h-12 rounded-lg object-cover"
+          class="w-[60px] h-[60px] rounded-full object-cover bg-gray-100 dark:bg-gray-800 ring-2 ring-water-300"
           src="https://images.pexels.com/photos/5699660/pexels-photo-5699660.jpeg"
         />
         <div
@@ -33,21 +33,52 @@ exports[`matches snapshot in dark mode 1`] = `
             class="flex items-center justify-between gap-2"
           >
             <p
-              class="font-semibold text-gray-900 dark:text-gray-100 truncate"
+              class="font-semibold text-lg text-gray-900 dark:text-gray-100 truncate"
             >
               Monstera
             </p>
           </div>
           <div
-            class="text-sm flex flex-wrap items-center gap-1 text-gray-500 mt-0.5"
+            class="text-sm flex flex-wrap items-center gap-1 text-gray-400 mt-0.5"
           >
             <span
-              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-xl text-sm font-medium bg-water-100 text-water-800"
+              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full shadow-sm text-sm font-medium bg-water-100/90 text-water-800"
             >
+              <svg
+                aria-hidden="true"
+                class="w-3 h-3"
+                fill="currentColor"
+                height="1em"
+                viewBox="0 0 256 256"
+                width="1em"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <rect
+                  fill="none"
+                  height="256"
+                  width="256"
+                />
+                <path
+                  d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="16"
+                />
+                <path
+                  d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
+                  fill="none"
+                  stroke="currentColor"
+                  stroke-linecap="round"
+                  stroke-linejoin="round"
+                  stroke-width="16"
+                />
+              </svg>
               To Water
             </span>
             <span
-              class="text-xs text-gray-500"
+              class="text-xs text-gray-400"
             >
               9
                


### PR DESCRIPTION
## Summary
- redesign `TaskCard` to have larger rounded corners and bigger thumbnails
- add icons and subtle shadows to `Badge`
- update tests and snapshots for the new design

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6879bb2f98bc83248f168b2597c552ab