### PR TITLE
Fix fab overlapping nav

### DIFF
--- a/src/components/CreateFab.jsx
+++ b/src/components/CreateFab.jsx
@@ -20,7 +20,7 @@ export default function CreateFab() {
   ]
 
   return (
-    <div className="fixed bottom-4 right-20 z-30">
+    <div className="fixed bottom-24 right-20 z-30">
       {open && (
         <div
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"


### PR DESCRIPTION
## Summary
- adjust CreateFab bottom offset so the button clears the bottom navigation bar

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879bb8d0c7083249c6e50532e6ad2ff