### PR TITLE
Update overdue badge with heart

### DIFF
--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -56,8 +56,8 @@ export default function MyPlants() {
               <p className="font-semibold font-headline text-[1.1rem]">{room}</p>
               <p className="text-[10px] text-gray-500">{countPlants(room)} plants</p>
               {overdue > 0 && (
-                <span className="slide-in inline-flex text-[11px] px-2 py-0.5 rounded-full bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100">
-                  ⚠️ {overdue} needs love
+                <span className="slide-in flex items-center text-[11px] px-2 py-0.5 rounded-full bg-red-100 text-red-600 animate-pulse">
+                  ❤️ {overdue} need care
                 </span>
               )}
             </Link>

--- a/src/pages/__tests__/MyPlants.test.jsx
+++ b/src/pages/__tests__/MyPlants.test.jsx
@@ -60,7 +60,7 @@ test('shows overdue badge for rooms with tasks', () => {
       <MyPlants />
     </MemoryRouter>
   )
-  const badge = screen.getByText(/needs love/i)
-  expect(badge).toHaveTextContent('⚠️ 2 needs love')
+  const badge = screen.getByText(/need care/i)
+  expect(badge).toHaveTextContent('❤️ 2 need care')
   jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- use a heart icon for overdue badges in MyPlants page
- adjust test expectation for new badge text

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879bddfd30483248484a572a0c35af9