### PR TITLE
Add pastel accent colors for rooms

### DIFF
--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -1,6 +1,7 @@
 import { Link } from 'react-router-dom'
 import { FolderSimple, Plus } from 'phosphor-react'
 import { getNextWateringDate } from '../utils/watering.js'
+import { colorHash } from '../utils/colorHash.js'
 import { useRooms } from '../RoomContext.jsx'
 import { usePlants } from '../PlantContext.jsx'
 import CreateFab from '../components/CreateFab.jsx'
@@ -42,12 +43,13 @@ export default function MyPlants() {
       <div className="grid grid-cols-2 gap-4">
         {rooms.map((room, i) => {
           const overdue = countOverdue(room)
+          const accent = colorHash(room)
           return (
             <Link
               key={room}
               to={`/room/${encodeURIComponent(room)}`}
-              className="p-4 bg-white dark:bg-gray-700 rounded-lg shadow space-y-1 animate-fade-in-up"
-              style={{ animationDelay: `${i * 50}ms` }}
+              className="p-4 bg-white dark:bg-gray-700 rounded-lg shadow space-y-1 animate-fade-in-up border-t-4"
+              style={{ animationDelay: `${i * 50}ms`, borderTopColor: accent }}
             >
               <FolderSimple
                 className="w-6 h-6 p-1 rounded bg-gray-100 dark:bg-gray-600 text-gray-700 dark:text-gray-200"

--- a/src/utils/__tests__/colorHash.test.js
+++ b/src/utils/__tests__/colorHash.test.js
@@ -1,0 +1,7 @@
+import { colorHash } from '../colorHash.js'
+
+test('generates deterministic pastel colors', () => {
+  expect(colorHash('Kitchen')).toBe('hsl(4, 60%, 85%)')
+  expect(colorHash('Kitchen')).toBe(colorHash('Kitchen'))
+  expect(colorHash('Living')).not.toBe(colorHash('Kitchen'))
+})

--- a/src/utils/colorHash.js
+++ b/src/utils/colorHash.js
@@ -1,0 +1,8 @@
+export function colorHash(str = '') {
+  let hash = 0
+  for (let i = 0; i < str.length; i++) {
+    hash = str.charCodeAt(i) + ((hash << 5) - hash)
+  }
+  const hue = Math.abs(hash) % 360
+  return `hsl(${hue}, 60%, 85%)`
+}


### PR DESCRIPTION
## Summary
- generate a pastel HSL color from a room name
- highlight rooms in MyPlants with a color-tinted border
- test new colorHash helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879bddde03c832495c4a5d1aa295f81