### PR TITLE
Add sort and filter to MyPlants

### DIFF
--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react'
 import { Link } from 'react-router-dom'
 import { FolderSimple, Plus } from 'phosphor-react'
 import { getNextWateringDate } from '../utils/watering.js'
@@ -8,6 +9,9 @@ import CreateFab from '../components/CreateFab.jsx'
 export default function MyPlants() {
   const { rooms } = useRooms()
   const { plants } = usePlants()
+
+  const [sortBy, setSortBy] = useState('name')
+  const [needsLoveOnly, setNeedsLoveOnly] = useState(false)
 
   const countPlants = room => plants.filter(p => p.room === room).length
   const todayIso = new Date().toISOString().slice(0, 10)
@@ -20,6 +24,13 @@ export default function MyPlants() {
         if (p.nextFertilize && p.nextFertilize < todayIso) m += 1
         return m
       }, 0)
+
+  const sortedRooms = [...rooms]
+    .filter(r => !needsLoveOnly || countOverdue(r) > 0)
+    .sort((a, b) => {
+      if (sortBy === 'name') return a.localeCompare(b)
+      return countPlants(b) - countPlants(a)
+    })
 
   if (rooms.length === 0) {
     return (
@@ -39,8 +50,29 @@ export default function MyPlants() {
   return (
     <div>
       <h1 className="text-2xl font-bold font-headline mb-4">All Plants</h1>
+      <div className="flex items-center gap-2 mb-2">
+        <label className="text-sm">
+          Sort
+          <select
+            className="ml-1 border rounded p-1"
+            value={sortBy}
+            onChange={e => setSortBy(e.target.value)}
+          >
+            <option value="name">Name</option>
+            <option value="count"># Plants</option>
+          </select>
+        </label>
+        <label className="flex items-center gap-1 text-sm">
+          <input
+            type="checkbox"
+            checked={needsLoveOnly}
+            onChange={e => setNeedsLoveOnly(e.target.checked)}
+          />
+          Needs Love
+        </label>
+      </div>
       <div className="grid grid-cols-2 gap-4">
-        {rooms.map((room, i) => {
+        {sortedRooms.map((room, i) => {
           const overdue = countOverdue(room)
           return (
             <Link
@@ -67,7 +99,7 @@ export default function MyPlants() {
           to="/room/add"
           aria-label="Add Room"
           className="flex items-center justify-center w-full h-40 rounded-lg border-2 border-dashed text-gray-500 animate-fade-in-up"
-          style={{ animationDelay: `${rooms.length * 50}ms` }}
+          style={{ animationDelay: `${sortedRooms.length * 50}ms` }}
         >
           <Plus className="w-10 h-10" aria-hidden="true" />
         </Link>

--- a/src/pages/__tests__/MyPlants.test.jsx
+++ b/src/pages/__tests__/MyPlants.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import MyPlants from '../MyPlants.jsx'
 
@@ -60,7 +60,62 @@ test('shows overdue badge for rooms with tasks', () => {
       <MyPlants />
     </MemoryRouter>
   )
-  const badge = screen.getByText(/needs love/i)
+  const badge = screen
+    .getAllByText(/needs love/i)
+    .find(el => el.tagName === 'SPAN')
   expect(badge).toHaveTextContent('⚠️ 2 needs love')
+  jest.useRealTimers()
+})
+
+test('sorts rooms by plant count', () => {
+  mockRooms = ['Kitchen', 'Living']
+  mockPlants = [
+    { id: 1, name: 'A', room: 'Living', lastWatered: '2025-07-01' },
+    { id: 2, name: 'B', room: 'Living', lastWatered: '2025-07-01' },
+    { id: 3, name: 'C', room: 'Kitchen', lastWatered: '2025-07-01' },
+  ]
+  render(
+    <MemoryRouter>
+      <MyPlants />
+    </MemoryRouter>
+  )
+
+  const select = screen.getByRole('combobox')
+  fireEvent.change(select, { target: { value: 'count' } })
+
+  const links = screen
+    .getAllByRole('link')
+    .filter(l => l.getAttribute('href') !== '/room/add')
+  expect(links[0]).toHaveTextContent('Living')
+})
+
+test('filters rooms needing love', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
+  mockRooms = ['Kitchen', 'Living']
+  mockPlants = [
+    {
+      id: 1,
+      name: 'A',
+      room: 'Living',
+      lastWatered: '2025-07-01',
+      nextFertilize: '2025-07-05',
+    },
+    { id: 2, name: 'B', room: 'Kitchen', lastWatered: '2025-07-09' },
+  ]
+  render(
+    <MemoryRouter>
+      <MyPlants />
+    </MemoryRouter>
+  )
+
+  const checkbox = screen.getByRole('checkbox')
+  fireEvent.click(checkbox)
+
+  const links = screen
+    .getAllByRole('link')
+    .filter(l => l.getAttribute('href') !== '/room/add')
+  expect(screen.queryByText('Kitchen')).toBeNull()
+  expect(links).toHaveLength(1)
+  expect(links[0]).toHaveTextContent('Living')
   jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- manage sort and filter state in MyPlants
- render dropdown and checkbox controls
- sort/filter rooms before listing
- test new sorting and filtering behaviour

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6879bde34d4c8324a82b9d5b28469e71