### PR TITLE
Improve task card layout

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -58,21 +58,25 @@ export default function TaskCard({
       onPointerCancel={end}
     >
         <div
-          className={`relative flex items-center gap-4 px-4 py-4 shadow-sm ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
+          className={`relative flex items-center gap-4 p-4 shadow-md ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
           style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
         >
           <div className="flex items-center flex-1 gap-4">
-            <img
-              src={task.image}
-              alt={task.plantName}
-              className={`w-[60px] h-[60px] rounded-full object-cover bg-gray-100 dark:bg-gray-800 ${
+            <div
+              className={`w-16 h-16 rounded-full flex items-center justify-center bg-green-50 dark:bg-gray-800 ${
                 task.type === 'Water'
                   ? 'ring-2 ring-water-300'
                   : task.type === 'Fertilize'
                   ? 'ring-2 ring-fertilize-300'
                   : 'ring-2 ring-healthy-300'
               }`}
-            />
+            >
+              <img
+                src={task.image}
+                alt={task.plantName}
+                className="w-12 h-12 rounded-full object-cover"
+              />
+            </div>
             <div className="w-px self-stretch bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
             <div className="flex-1 min-w-0">
               <div className="flex items-center justify-between gap-2">

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -66,7 +66,7 @@ test('incomplete tasks show alert style', () => {
       </BaseCard>
     </MemoryRouter>
   )
-  const wrapper = container.querySelector('.shadow-sm')
+  const wrapper = container.querySelector('.shadow-md')
   expect(wrapper).toHaveClass('bg-white')
 })
 
@@ -78,7 +78,7 @@ test('applies highlight when urgent', () => {
       </BaseCard>
     </MemoryRouter>
   )
-  const wrapper = container.querySelector('.shadow-sm')
+  const wrapper = container.querySelector('.shadow-md')
   expect(wrapper).toHaveClass('ring-green-300')
   expect(wrapper).toHaveClass('dark:ring-green-400')
 })
@@ -92,7 +92,7 @@ test('shows completed state', () => {
       </BaseCard>
     </MemoryRouter>
   )
-  const wrapper = container.querySelector('.shadow-sm')
+  const wrapper = container.querySelector('.shadow-md')
   expect(wrapper).toHaveClass('opacity-50')
   expect(wrapper).toHaveClass('bg-gray-100')
   expect(container.querySelector('.check-pop')).toBeInTheDocument()

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -11,17 +11,21 @@ exports[`matches snapshot in dark mode 1`] = `
     tabindex="0"
   >
     <div
-      class="relative flex items-center gap-4 px-4 py-4 shadow-sm bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
+      class="relative flex items-center gap-4 p-4 shadow-md bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
       style="transform: translateX(0px); transition: transform 0.2s;"
     >
       <div
         class="flex items-center flex-1 gap-4"
       >
-        <img
-          alt="Monstera"
-          class="w-[60px] h-[60px] rounded-full object-cover bg-gray-100 dark:bg-gray-800 ring-2 ring-water-300"
-          src="https://images.pexels.com/photos/5699660/pexels-photo-5699660.jpeg"
-        />
+        <div
+          class="w-16 h-16 rounded-full flex items-center justify-center bg-green-50 dark:bg-gray-800 ring-2 ring-water-300"
+        >
+          <img
+            alt="Monstera"
+            class="w-12 h-12 rounded-full object-cover"
+            src="https://images.pexels.com/photos/5699660/pexels-photo-5699660.jpeg"
+          />
+        </div>
         <div
           aria-hidden="true"
           class="w-px self-stretch bg-gray-200 dark:bg-gray-600"

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -198,11 +198,11 @@ export default function Home() {
         data-testid="tasks-container"
         className="mt-4 border-t border-neutral-200 dark:border-gray-600 bg-sage dark:bg-gray-700 rounded-xl p-4"
       >
-        <section className="space-y-4">
+        <section className="space-y-5">
           <div className="flex items-center justify-between">
             <h2 className="font-semibold font-headline">Today’s Tasks</h2>
           </div>
-          <div className="space-y-4">
+          <div className="space-y-5">
             {visibleTasks.length > 0 ? (
               visibleTasks.map((task, i) => (
                 <BaseCard

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -290,7 +290,7 @@ export default function Tasks() {
               : 'No tasks coming up.'}
           </p>
         ) : (
-          <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-4'}>
+          <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-5'}>
           {eventsByPlant.map(({ plant, list }, i) => {
             const dueWater = list.some(
               e =>
@@ -352,7 +352,7 @@ export default function Tasks() {
           return (
             <div key={dateKey}>
               <h3 className="mt-4 text-sm font-semibold text-gray-500">{heading}</h3>
-              <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-4'}>
+              <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-5'}>
                 {list.map((e, i) => {
                   const task = {
                     id: `${e.taskType}-${e.plantId}-${i}`,

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -141,7 +141,7 @@ test('completed tasks are styled', () => {
     </MemoryRouter>
   )
   const cards = screen.getAllByTestId('task-card')
-  const inner = cards[0].querySelector('.shadow-sm')
+  const inner = cards[0].querySelector('.shadow-md')
   expect(inner).toHaveClass('opacity-50')
   expect(Array.from(cards).some(c => c.textContent.includes('Watered'))).toBe(
     true


### PR DESCRIPTION
## Summary
- refactor TaskCard layout for larger avatar and stronger shadow
- bump spacing around tasks in Home and Tasks pages
- update related tests and snapshots

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879beb3af708324ba545cc770855d88