### PR TITLE
Update settings layout

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -8,55 +8,63 @@ export default function Settings() {
   const { username, setUsername, timeZone, setTimeZone } = useUser()
 
   return (
-    <div className="space-y-4 text-gray-700 dark:text-gray-200">
+    <div className="space-y-6 text-gray-700 dark:text-gray-200">
       <h1 className="text-2xl font-bold font-headline">Settings</h1>
-      <button
-        onClick={toggleTheme}
-        className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700"
-      >
-        Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
-      </button>
-      <div className="grid gap-1 max-w-xs">
-        <label htmlFor="username" className="font-medium">Name</label>
-        <input
-          id="username"
-          type="text"
-          value={username}
-          onChange={e => setUsername(e.target.value)}
-          className="border rounded p-2"
-        />
+
+      <h2 className="text-lg font-semibold">Profile</h2>
+      <div className="space-y-6">
+        <div className="grid gap-1 max-w-xs">
+          <label htmlFor="username" className="font-medium">Name</label>
+          <input
+            id="username"
+            type="text"
+            value={username}
+            onChange={e => setUsername(e.target.value)}
+            className="border rounded p-2"
+          />
+        </div>
+        <div className="grid gap-1 max-w-xs">
+          <label htmlFor="timezone" className="font-medium">Time Zone</label>
+          <input
+            id="timezone"
+            type="text"
+            value={timeZone}
+            onChange={e => setTimeZone(e.target.value)}
+            className="border rounded p-2"
+          />
+        </div>
       </div>
-      <div className="grid gap-1 max-w-xs">
-        <label htmlFor="location" className="font-medium">Weather Location</label>
-        <input
-          id="location"
-          type="text"
-          value={location}
-          onChange={e => setLocation(e.target.value)}
-          className="border rounded p-2"
-        />
-      </div>
-      <div className="grid gap-1 max-w-xs">
-        <label htmlFor="units" className="font-medium">Temperature Units</label>
-        <select
-          id="units"
-          value={units}
-          onChange={e => setUnits(e.target.value)}
-          className="border rounded p-2"
+
+      <h2 className="text-lg font-semibold mt-6">Preferences</h2>
+      <div className="space-y-6">
+        <div className="grid gap-1 max-w-xs">
+          <label htmlFor="location" className="font-medium">Weather Location</label>
+          <input
+            id="location"
+            type="text"
+            value={location}
+            onChange={e => setLocation(e.target.value)}
+            className="border rounded p-2"
+          />
+        </div>
+        <div className="grid gap-1 max-w-xs">
+          <label htmlFor="units" className="font-medium">Temperature Units</label>
+          <select
+            id="units"
+            value={units}
+            onChange={e => setUnits(e.target.value)}
+            className="dropdown-select"
+          >
+            <option value="imperial">Fahrenheit</option>
+            <option value="metric">Celsius</option>
+          </select>
+        </div>
+        <button
+          onClick={toggleTheme}
+          className="mt-6 px-4 py-2 rounded bg-gray-200 dark:bg-gray-700"
         >
-          <option value="imperial">Fahrenheit</option>
-          <option value="metric">Celsius</option>
-        </select>
-      </div>
-      <div className="grid gap-1 max-w-xs">
-        <label htmlFor="timezone" className="font-medium">Time Zone</label>
-        <input
-          id="timezone"
-          type="text"
-          value={timeZone}
-          onChange={e => setTimeZone(e.target.value)}
-          className="border rounded p-2"
-        />
+          Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
+        </button>
       </div>
     </div>
   )

--- a/src/pages/__tests__/MyPlants.test.jsx
+++ b/src/pages/__tests__/MyPlants.test.jsx
@@ -62,9 +62,9 @@ test('shows overdue badge for rooms with tasks', () => {
   )
 
   const badge = screen
-    .getAllByText(/needs love/i)
+    .getAllByText(/need care/i)
     .find(el => el.tagName === 'SPAN')
-  expect(badge).toHaveTextContent('⚠️ 2 needs love')
+  expect(badge).toHaveTextContent('❤️ 2 need care')
 
   jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- reorganize Settings with Profile and Preferences headings
- apply dropdown-select class for units
- adjust margin between setting groups
- update MyPlants test to match new text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879c0bdc1a4832492e9d27b38d876e4