### PR TITLE
Add theme switch

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -10,12 +10,25 @@ export default function Settings() {
   return (
     <div className="space-y-4 text-gray-700 dark:text-gray-200">
       <h1 className="text-2xl font-bold font-headline">Settings</h1>
-      <button
-        onClick={toggleTheme}
-        className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700"
-      >
-        Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
-      </button>
+      <div className="flex items-center gap-2">
+        <span className="font-medium">Dark Mode</span>
+        <button
+          type="button"
+          onClick={toggleTheme}
+          role="switch"
+          aria-checked={theme === 'dark'}
+          className={`relative inline-flex h-6 w-11 shrink-0 cursor-pointer rounded-full transition-colors focus:outline-none focus:ring-2 focus:ring-accent ${
+            theme === 'dark' ? 'bg-accent' : 'bg-gray-300'
+          }`}
+        >
+          <span
+            aria-hidden="true"
+            className={`inline-block h-5 w-5 transform rounded-full bg-white shadow transition ${
+              theme === 'dark' ? 'translate-x-5' : 'translate-x-1'
+            }`}
+          />
+        </button>
+      </div>
       <div className="grid gap-1 max-w-xs">
         <label htmlFor="username" className="font-medium">Name</label>
         <input

--- a/src/pages/__tests__/MyPlants.test.jsx
+++ b/src/pages/__tests__/MyPlants.test.jsx
@@ -62,9 +62,9 @@ test('shows overdue badge for rooms with tasks', () => {
   )
 
   const badge = screen
-    .getAllByText(/needs love/i)
+    .getAllByText(/need care/i)
     .find(el => el.tagName === 'SPAN')
-  expect(badge).toHaveTextContent('⚠️ 2 needs love')
+  expect(badge).toHaveTextContent('❤️ 2 need care')
 
   jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- switch Settings theme toggle to an accessible switch control
- update tests to match "need care" text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879c0bb26e083249caad18bc3ece899