### PR TITLE
Add Panel component and organize settings

### DIFF
--- a/src/components/Panel.jsx
+++ b/src/components/Panel.jsx
@@ -1,0 +1,9 @@
+import React from 'react'
+
+export default function Panel({ className = '', children, ...props }) {
+  return (
+    <div className={`rounded-xl bg-white dark:bg-gray-700 shadow-sm p-4 ${className}`} {...props}>
+      {children}
+    </div>
+  )
+}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,6 +1,7 @@
 import { useTheme } from '../ThemeContext.jsx'
 import { useWeather } from '../WeatherContext.jsx'
 import { useUser } from '../UserContext.jsx'
+import Panel from '../components/Panel.jsx'
 
 export default function Settings() {
   const { theme, toggleTheme } = useTheme()
@@ -10,53 +11,61 @@ export default function Settings() {
   return (
     <div className="space-y-4 text-gray-700 dark:text-gray-200">
       <h1 className="text-2xl font-bold font-headline">Settings</h1>
-      <button
-        onClick={toggleTheme}
-        className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700"
-      >
-        Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
-      </button>
-      <div className="grid gap-1 max-w-xs">
-        <label htmlFor="username" className="font-medium">Name</label>
-        <input
-          id="username"
-          type="text"
-          value={username}
-          onChange={e => setUsername(e.target.value)}
-          className="border rounded p-2"
-        />
-      </div>
-      <div className="grid gap-1 max-w-xs">
-        <label htmlFor="location" className="font-medium">Weather Location</label>
-        <input
-          id="location"
-          type="text"
-          value={location}
-          onChange={e => setLocation(e.target.value)}
-          className="border rounded p-2"
-        />
-      </div>
-      <div className="grid gap-1 max-w-xs">
-        <label htmlFor="units" className="font-medium">Temperature Units</label>
-        <select
-          id="units"
-          value={units}
-          onChange={e => setUnits(e.target.value)}
-          className="border rounded p-2"
-        >
-          <option value="imperial">Fahrenheit</option>
-          <option value="metric">Celsius</option>
-        </select>
-      </div>
-      <div className="grid gap-1 max-w-xs">
-        <label htmlFor="timezone" className="font-medium">Time Zone</label>
-        <input
-          id="timezone"
-          type="text"
-          value={timeZone}
-          onChange={e => setTimeZone(e.target.value)}
-          className="border rounded p-2"
-        />
+      <div className="space-y-4">
+        <Panel className="space-y-4">
+          <div className="grid gap-1 max-w-xs">
+            <label htmlFor="username" className="font-medium">Name</label>
+            <input
+              id="username"
+              type="text"
+              value={username}
+              onChange={e => setUsername(e.target.value)}
+              className="border rounded p-2"
+            />
+          </div>
+          <div className="grid gap-1 max-w-xs">
+            <label htmlFor="timezone" className="font-medium">Time Zone</label>
+            <input
+              id="timezone"
+              type="text"
+              value={timeZone}
+              onChange={e => setTimeZone(e.target.value)}
+              className="border rounded p-2"
+            />
+          </div>
+        </Panel>
+        <Panel className="space-y-4">
+          <div className="grid gap-1 max-w-xs">
+            <label htmlFor="location" className="font-medium">Weather Location</label>
+            <input
+              id="location"
+              type="text"
+              value={location}
+              onChange={e => setLocation(e.target.value)}
+              className="border rounded p-2"
+            />
+          </div>
+          <div className="grid gap-1 max-w-xs">
+            <label htmlFor="units" className="font-medium">Temperature Units</label>
+            <select
+              id="units"
+              value={units}
+              onChange={e => setUnits(e.target.value)}
+              className="border rounded p-2"
+            >
+              <option value="imperial">Fahrenheit</option>
+              <option value="metric">Celsius</option>
+            </select>
+          </div>
+        </Panel>
+        <Panel className="space-y-4">
+          <button
+            onClick={toggleTheme}
+            className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700"
+          >
+            Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
+          </button>
+        </Panel>
       </div>
     </div>
   )

--- a/src/pages/__tests__/MyPlants.test.jsx
+++ b/src/pages/__tests__/MyPlants.test.jsx
@@ -62,9 +62,9 @@ test('shows overdue badge for rooms with tasks', () => {
   )
 
   const badge = screen
-    .getAllByText(/needs love/i)
+    .getAllByText(/need care/i)
     .find(el => el.tagName === 'SPAN')
-  expect(badge).toHaveTextContent('⚠️ 2 needs love')
+  expect(badge).toHaveTextContent('❤️ 2 need care')
 
   jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- create `Panel` component to reuse rounded panel style
- wrap user settings sections in `Settings` page with `Panel`
- update tests for text change in MyPlants badge

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879c0b56dd083249e2beee0a78477ca