### PR TITLE
Fix TaskCard bottom corners

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -58,7 +58,7 @@ export default function TaskCard({
       onPointerCancel={end}
     >
         <div
-          className={`relative flex items-center gap-4 p-4 shadow-md ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
+          className={`relative flex items-center gap-4 p-4 shadow-md rounded-2xl ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
           style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
         >
           <div className="flex items-center flex-1 gap-4">

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -11,7 +11,7 @@ exports[`matches snapshot in dark mode 1`] = `
     tabindex="0"
   >
     <div
-      class="relative flex items-center gap-4 p-4 shadow-md bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
+      class="relative flex items-center gap-4 p-4 shadow-md rounded-2xl bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
       style="transform: translateX(0px); transition: transform 0.2s;"
     >
       <div


### PR DESCRIPTION
## Summary
- apply same radius to the TaskCard inner wrapper
- update snapshot

## Testing
- `npm test -- src/components/__tests__/TaskCard.test.jsx -u`
- `npm test` *(fails: SyntaxError in Settings.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_6879c1783c2c83248224143c5098ce3a