### PR TITLE
Remove back button in plant detail view

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -10,7 +10,6 @@ import {
   Image,
   Note,
   Info,
-  ArrowLeft,
   CaretDown,
   CaretRight,
 } from 'phosphor-react'
@@ -134,10 +133,6 @@ export default function PlantDetail() {
     navigate(`/plant/${plant.id}/edit`)
   }
 
-  const handleBack = () => {
-    const room = encodeURIComponent(plant.room || '')
-    navigate(`/room/${room}`)
-  }
 
   // Menu is now consistent across pages so no override here
 
@@ -191,14 +186,6 @@ export default function PlantDetail() {
             className="w-full h-64 object-cover"
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent" aria-hidden="true"></div>
-          <button
-            type="button"
-            onClick={handleBack}
-            aria-label="Back"
-            className="absolute top-2 left-2 bg-white bg-opacity-70 rounded p-2 text-sm"
-          >
-            <ArrowLeft className="w-4 h-4" aria-hidden="true" />
-          </button>
           <div className="absolute bottom-3 left-4 text-white drop-shadow">
             <h2 className="text-2xl font-semibold font-headline">{plant.name}</h2>
             {plant.nickname && (

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -175,7 +175,7 @@ test('view all button opens the viewer from first image', () => {
   expect(viewerImg).toHaveAttribute('src', plant.photos[0].src)
 })
 
-test('back button navigates to room page', () => {
+test('breadcrumb link navigates to room page and no back button is shown', () => {
   const plant = plants[0]
   render(
     <MenuProvider>
@@ -191,7 +191,8 @@ test('back button navigates to room page', () => {
     </MenuProvider>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /back/i }))
+  expect(screen.queryByRole('button', { name: /back/i })).toBeNull()
+  fireEvent.click(screen.getByRole('link', { name: plant.room }))
 
   expect(screen.getByText(/room view/i)).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- remove the back button and related ArrowLeft import
- check navigation to room via breadcrumb in tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879c8d136488324b110fb54f5493738