### PR TITLE
Adjust task card spacing and rounding

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -51,7 +51,7 @@ export default function TaskCard({
       data-testid="task-card"
       tabIndex="0"
       aria-label={`Task card for ${task.plantName}`}
-      className="relative overflow-hidden min-h-[130px]"
+      className="relative overflow-hidden min-h-[130px] rounded-xl"
       onPointerDown={start}
       onPointerMove={move}
       onPointerUp={end}

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`matches snapshot in dark mode 1`] = `
 >
   <div
     aria-label="Task card for Monstera"
-    class="relative overflow-hidden min-h-[130px]"
+    class="relative overflow-hidden min-h-[130px] rounded-xl"
     data-testid="task-card"
     tabindex="0"
   >

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -198,11 +198,11 @@ export default function Home() {
         data-testid="tasks-container"
         className="mt-4 border-t border-neutral-200 dark:border-gray-600 bg-sage dark:bg-gray-700 rounded-xl p-4"
       >
-        <section className="space-y-5">
+        <section className="space-y-2">
           <div className="flex items-center justify-between">
             <h2 className="font-semibold font-headline">Today’s Tasks</h2>
           </div>
-          <div className="space-y-5">
+          <div className="space-y-2">
             {visibleTasks.length > 0 ? (
               visibleTasks.map((task, i) => (
                 <BaseCard

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -290,7 +290,7 @@ export default function Tasks() {
               : 'No tasks coming up.'}
           </p>
         ) : (
-          <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-5'}>
+          <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-2'}>
           {eventsByPlant.map(({ plant, list }, i) => {
             const dueWater = list.some(
               e =>
@@ -352,7 +352,7 @@ export default function Tasks() {
           return (
             <div key={dateKey}>
               <h3 className="mt-4 text-sm font-semibold text-gray-500">{heading}</h3>
-              <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-5'}>
+              <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-2'}>
                 {list.map((e, i) => {
                   const task = {
                     id: `${e.taskType}-${e.plantId}-${i}`,


### PR DESCRIPTION
## Summary
- tighten spacing between task cards on Home and Tasks pages
- round task card corners
- update snapshots

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6879c81ac13083249391f82c49a2dde7