### PR TITLE
Add plant detail FAB

### DIFF
--- a/src/components/PlantDetailFab.jsx
+++ b/src/components/PlantDetailFab.jsx
@@ -1,0 +1,75 @@
+import { useState, useEffect } from 'react'
+import { Plus, Image as ImageIcon, Note } from 'phosphor-react'
+
+export default function PlantDetailFab({ onAddPhoto, onAddNote }) {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    const handleKey = e => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [open])
+
+  const items = [
+    { label: 'Add Photo', Icon: ImageIcon, action: onAddPhoto },
+    { label: 'Add Note', Icon: Note, action: onAddNote },
+  ]
+
+  return (
+    <div className="fixed bottom-24 right-20 z-30">
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Add menu"
+          onClick={() => setOpen(false)}
+        >
+          <ul
+            className="relative bg-white dark:bg-gray-700 rounded-xl shadow-xl p-8 space-y-4 animate-fade-in-up"
+            onClick={e => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              aria-label="Close menu"
+              onClick={() => setOpen(false)}
+              className="absolute top-2 right-2 text-gray-500"
+            >
+              &times;
+            </button>
+            {items.map(({ label, Icon, action }) => (
+              <li key={label}>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOpen(false)
+                    action?.()
+                  }}
+                  title={label}
+                  className="flex items-center gap-3 hover:text-accent"
+                >
+                  <Icon className="w-5 h-5" aria-hidden="true" />
+                  {label}
+                </button>
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-label="Open create menu"
+        title="Open create menu"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className={`bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
+      >
+        <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
+      </button>
+    </div>
+  )
+}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -23,6 +23,7 @@ import { useMenu, defaultMenu } from '../MenuContext.jsx'
 import LegendModal from '../components/LegendModal.jsx'
 import ProgressRing from '../components/ProgressRing.jsx'
 import Breadcrumb from '../components/Breadcrumb.jsx'
+import PlantDetailFab from '../components/PlantDetailFab.jsx'
 
 import useToast from "../hooks/useToast.jsx"
 import confetti from 'canvas-confetti'
@@ -449,6 +450,7 @@ export default function PlantDetail() {
           </div>
         )}
       </section>
+      <PlantDetailFab onAddPhoto={openFileInput} onAddNote={handleLogEvent} />
       {showNoteModal && (
         <NoteModal label="Note" onSave={saveNote} onCancel={cancelNote} />
       )}

--- a/src/pages/__tests__/PlantDetailActions.test.jsx
+++ b/src/pages/__tests__/PlantDetailActions.test.jsx
@@ -60,3 +60,40 @@ test('quick stats action buttons trigger handlers', () => {
   )
   expect(markFertilized).toHaveBeenCalledWith(1, '')
 })
+
+test('fab opens note modal', () => {
+  render(
+    <MenuProvider>
+      <MemoryRouter initialEntries={['/plant/1']}>
+        <Routes>
+          <Route path="/plant/:id" element={<PlantDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </MenuProvider>
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /open create menu/i }))
+  fireEvent.click(screen.getByRole('button', { name: /add note/i }))
+  expect(screen.getByRole('dialog', { name: /note/i })).toBeInTheDocument()
+})
+
+test('fab triggers file input click', () => {
+  const clickSpy = jest
+    .spyOn(HTMLInputElement.prototype, 'click')
+    .mockImplementation(() => {})
+
+  render(
+    <MenuProvider>
+      <MemoryRouter initialEntries={['/plant/1']}>
+        <Routes>
+          <Route path="/plant/:id" element={<PlantDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </MenuProvider>
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /open create menu/i }))
+  fireEvent.click(screen.getByRole('button', { name: /add photo/i }))
+  expect(clickSpy).toHaveBeenCalled()
+  clickSpy.mockRestore()
+})


### PR DESCRIPTION
## Summary
- add `PlantDetailFab` component for image and note actions
- integrate the FAB into PlantDetail page
- test FAB actions open note modal and trigger file input

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879cb3fad608324a88b1ebb38db7aa9