### PR TITLE
Remove TaskCard min height

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -51,7 +51,7 @@ export default function TaskCard({
       data-testid="task-card"
       tabIndex="0"
       aria-label={`Task card for ${task.plantName}`}
-      className="relative overflow-hidden min-h-[130px] rounded-xl"
+        className="relative overflow-hidden rounded-xl"
       onPointerDown={start}
       onPointerMove={move}
       onPointerUp={end}

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`matches snapshot in dark mode 1`] = `
 >
   <div
     aria-label="Task card for Monstera"
-    class="relative overflow-hidden min-h-[130px] rounded-xl"
+    class="relative overflow-hidden rounded-xl"
     data-testid="task-card"
     tabindex="0"
   >


### PR DESCRIPTION
## Summary
- drop fixed `min-h-[130px]` on `<TaskCard>` wrapper
- update snapshots

## Testing
- `npm test`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_6879cecb4784832491eca725f94a7fe3