### PR TITLE
Enhance care progress visuals

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -65,6 +65,10 @@ export default function PlantDetail() {
 
   const ringClass = ringColors[plant?.urgency] || 'text-green-600'
   const progressPct = getWateringProgress(plant?.lastWatered, plant?.nextWater)
+  const fertProgressPct = getWateringProgress(
+    plant?.lastFertilized,
+    plant?.nextFertilize
+  )
 
   const now = new Date()
   const nextWaterDate = plant?.nextWater ? new Date(plant.nextWater) : null
@@ -219,9 +223,24 @@ export default function PlantDetail() {
             aria-label={`Watering progress ${Math.round(progressPct * 100)}%`}
           >
             <div className="relative" style={{ width: 48, height: 48 }}>
-              <ProgressRing percent={progressPct} size={48} colorClass={ringClass} />
-              <div className="absolute inset-1 rounded-full bg-white/80 flex items-center justify-center text-[10px] font-semibold">
-                {Math.round(progressPct * 100)}%
+              <ProgressRing
+                percent={progressPct}
+                size={48}
+                colorClass={ringClass}
+              />
+              {plant.nextFertilize && plant.lastFertilized && (
+                <ProgressRing
+                  percent={fertProgressPct}
+                  size={34}
+                  colorClass="text-yellow-600"
+                />
+              )}
+              <div
+                className={`absolute inset-1 rounded-full bg-white/80 flex items-center justify-center text-[10px] font-semibold ${ringClass}`}
+              >
+                {progressPct >= 1
+                  ? 'Water Now'
+                  : `${Math.round(progressPct * 100)}%`}
               </div>
             </div>
           </div>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -98,6 +98,43 @@ test('shows watering progress ring', () => {
   expect(screen.getByTestId('watering-ring')).toBeInTheDocument()
 })
 
+test('fertilizing ring is displayed', () => {
+  const plant = plants[0]
+  render(
+    <MenuProvider>
+      <PlantProvider>
+        <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+          <Routes>
+            <Route path="/plant/:id" element={<PlantDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </PlantProvider>
+    </MenuProvider>
+  )
+
+  const ring = screen.getByTestId('watering-ring')
+  expect(ring.querySelectorAll('svg')).toHaveLength(2)
+})
+
+test('percent text adopts urgency color', () => {
+  const plant = plants[0]
+  render(
+    <MenuProvider>
+      <PlantProvider>
+        <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+          <Routes>
+            <Route path="/plant/:id" element={<PlantDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </PlantProvider>
+    </MenuProvider>
+  )
+
+  const ring = screen.getByTestId('watering-ring')
+  const pctText = within(ring).getByText(/%|Water Now/i)
+  expect(pctText.className).toMatch(/text-red-600/)
+})
+
 
 test('opens lightbox from gallery', () => {
 


### PR DESCRIPTION
## Summary
- color code watering percentage text and show "Water Now" when due
- display fertilizing ring inside watering ring
- test for fertilizing ring and text color

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_6879c8ed9b588324995a557e8ce8e99c