### PR TITLE
Improve task card styling

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -2,7 +2,7 @@ import React from 'react'
 
 export default function Badge({ children, Icon, colorClass = 'bg-gray-200 text-gray-800' }) {
   return (
-    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full shadow-sm ${colorClass}`}>
+    <span className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${colorClass}`}>
       {Icon && <Icon className="w-3 h-3" aria-hidden="true" />}
       {children}
     </span>

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -51,73 +51,68 @@ export default function TaskCard({
       data-testid="task-card"
       tabIndex="0"
       aria-label={`Task card for ${task.plantName}`}
-        className="relative overflow-hidden rounded-xl"
+      className={`relative flex items-center p-4 gap-4 rounded-2xl shadow-sm ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
+      style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
       onPointerDown={start}
       onPointerMove={move}
       onPointerUp={end}
       onPointerCancel={end}
     >
+      <div className="flex items-center flex-1 gap-4">
         <div
-          className={`relative flex items-center gap-4 shadow-md ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
-          style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
+          className={`w-16 h-16 rounded-full flex items-center justify-center bg-green-50 dark:bg-gray-800 ${
+            task.type === 'Water'
+              ? 'ring-2 ring-water-300'
+              : task.type === 'Fertilize'
+              ? 'ring-2 ring-fertilize-300'
+              : 'ring-2 ring-healthy-300'
+          }`}
         >
-          <div className="flex items-center flex-1 gap-4">
-            <div
-              className={`w-16 h-16 rounded-full flex items-center justify-center bg-green-50 dark:bg-gray-800 ${
-                task.type === 'Water'
-                  ? 'ring-2 ring-water-300'
-                  : task.type === 'Fertilize'
-                  ? 'ring-2 ring-fertilize-300'
-                  : 'ring-2 ring-healthy-300'
-              }`}
-            >
-              <img
-                src={task.image}
-                alt={task.plantName}
-                className="w-12 h-12 rounded-full object-cover"
-              />
-            </div>
-            <div className="w-px self-stretch bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
-            <div className="flex-1 min-w-0">
-              <div className="flex items-center justify-between gap-2">
-                <p className="font-semibold text-lg text-gray-900 dark:text-gray-100 truncate">
-                  {task.plantName}
-                </p>
-              </div>
-              <div className="text-sm flex flex-wrap items-center gap-1 text-gray-400 mt-0.5">
-                <Badge
-                  Icon={task.type === 'Water' ? Drop : task.type === 'Fertilize' ? Sun : undefined}
-                  colorClass={`text-sm font-medium ${
-                    task.type === 'Water'
-                      ? 'bg-water-100/90 text-water-800'
-                      : task.type === 'Fertilize'
-                        ? 'bg-fertilize-100/90 text-fertilize-800'
-                        : 'bg-healthy-100/90 text-healthy-800'
-                  }`}
-                >
-                  {completed
-                    ? task.type === 'Water'
-                      ? 'Watered!'
-                      : task.type === 'Fertilize'
-                        ? 'Fertilized!'
-                        : task.type
-                    : task.type === 'Water'
-                    ? 'To Water'
-                    : task.type === 'Fertilize'
-                    ? 'To Fertilize'
-                    : task.type}
-                </Badge>
-                {daysSince != null && (
-                  <span className="text-xs text-gray-400">
-                    {daysSince} {daysSince === 1 ? 'day' : 'days'} since care
-                  </span>
-                )}
-              </div>
-              {!compact && task.reason && (
-                <p className="text-xs text-gray-500 font-body mt-0.5">{task.reason}</p>
-              )}
-            </div>
+          <img
+            src={task.image}
+            alt={task.plantName}
+            className="w-12 h-12 rounded-full object-cover"
+          />
+        </div>
+        <div className="w-px self-stretch bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
+        <div className="flex-1 min-w-0">
+          <div className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">
+            {task.plantName}
           </div>
+          <div className="flex items-center gap-2 mt-1">
+            <Badge
+              Icon={task.type === 'Water' ? Drop : task.type === 'Fertilize' ? Sun : undefined}
+              colorClass={
+                task.type === 'Water'
+                  ? 'bg-water-100/90 text-water-800'
+                  : task.type === 'Fertilize'
+                  ? 'bg-fertilize-100/90 text-fertilize-800'
+                  : 'bg-healthy-100/90 text-healthy-800'
+              }
+            >
+              {completed
+                ? task.type === 'Water'
+                  ? 'Watered!'
+                  : task.type === 'Fertilize'
+                  ? 'Fertilized!'
+                  : task.type
+                : task.type === 'Water'
+                ? 'To Water'
+                : task.type === 'Fertilize'
+                ? 'To Fertilize'
+                : task.type}
+            </Badge>
+            {daysSince != null && (
+              <span className="text-xs text-gray-400">
+                {daysSince} {daysSince === 1 ? 'day' : 'days'} since care
+              </span>
+            )}
+          </div>
+          {!compact && task.reason && (
+            <p className="text-xs text-gray-500 font-body mt-0.5">{task.reason}</p>
+          )}
+        </div>
+      </div>
           {completed && (
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none task-complete-fade">
               <svg
@@ -145,7 +140,6 @@ export default function TaskCard({
             </div>
           )}
         </div>
-      </div>
       <Snackbar />
     </>
   )

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -55,6 +55,7 @@ test('renders task text', () => {
   expect(badge).toHaveClass('inline-flex')
   expect(badge).toHaveClass('bg-water-100/90')
   expect(badge).toHaveClass('text-water-800')
+  expect(badge).toHaveClass('text-xs')
   expect(badge).toHaveClass('font-medium')
 })
 
@@ -66,7 +67,7 @@ test('incomplete tasks show alert style', () => {
       </BaseCard>
     </MemoryRouter>
   )
-  const wrapper = container.querySelector('.shadow-md')
+  const wrapper = container.querySelector('.shadow-sm')
   expect(wrapper).toHaveClass('bg-white')
 })
 
@@ -78,7 +79,7 @@ test('applies highlight when urgent', () => {
       </BaseCard>
     </MemoryRouter>
   )
-  const wrapper = container.querySelector('.shadow-md')
+  const wrapper = container.querySelector('.shadow-sm')
   expect(wrapper).toHaveClass('ring-green-300')
   expect(wrapper).toHaveClass('dark:ring-green-400')
 })
@@ -92,7 +93,7 @@ test('shows completed state', () => {
       </BaseCard>
     </MemoryRouter>
   )
-  const wrapper = container.querySelector('.shadow-md')
+  const wrapper = container.querySelector('.shadow-sm')
   expect(wrapper).toHaveClass('opacity-50')
   expect(wrapper).toHaveClass('bg-gray-100')
   expect(container.querySelector('.check-pop')).toBeInTheDocument()

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -6,107 +6,99 @@ exports[`matches snapshot in dark mode 1`] = `
 >
   <div
     aria-label="Task card for Monstera"
-    class="relative overflow-hidden rounded-xl"
+    class="relative flex items-center p-4 gap-4 rounded-2xl shadow-sm bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
     data-testid="task-card"
+    style="transform: translateX(0px); transition: transform 0.2s;"
     tabindex="0"
   >
     <div
-      class="relative flex items-center gap-4 shadow-md bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
-      style="transform: translateX(0px); transition: transform 0.2s;"
+      class="flex items-center flex-1 gap-4"
     >
       <div
-        class="flex items-center flex-1 gap-4"
+        class="w-16 h-16 rounded-full flex items-center justify-center bg-green-50 dark:bg-gray-800 ring-2 ring-water-300"
       >
-        <div
-          class="w-16 h-16 rounded-full flex items-center justify-center bg-green-50 dark:bg-gray-800 ring-2 ring-water-300"
-        >
-          <img
-            alt="Monstera"
-            class="w-12 h-12 rounded-full object-cover"
-            src="https://images.pexels.com/photos/5699660/pexels-photo-5699660.jpeg"
-          />
-        </div>
-        <div
-          aria-hidden="true"
-          class="w-px self-stretch bg-gray-200 dark:bg-gray-600"
+        <img
+          alt="Monstera"
+          class="w-12 h-12 rounded-full object-cover"
+          src="https://images.pexels.com/photos/5699660/pexels-photo-5699660.jpeg"
         />
-        <div
-          class="flex-1 min-w-0"
-        >
-          <div
-            class="flex items-center justify-between gap-2"
-          >
-            <p
-              class="font-semibold text-lg text-gray-900 dark:text-gray-100 truncate"
-            >
-              Monstera
-            </p>
-          </div>
-          <div
-            class="text-sm flex flex-wrap items-center gap-1 text-gray-400 mt-0.5"
-          >
-            <span
-              class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full shadow-sm text-sm font-medium bg-water-100/90 text-water-800"
-            >
-              <svg
-                aria-hidden="true"
-                class="w-3 h-3"
-                fill="currentColor"
-                height="1em"
-                viewBox="0 0 256 256"
-                width="1em"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <rect
-                  fill="none"
-                  height="256"
-                  width="256"
-                />
-                <path
-                  d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="16"
-                />
-                <path
-                  d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
-                  fill="none"
-                  stroke="currentColor"
-                  stroke-linecap="round"
-                  stroke-linejoin="round"
-                  stroke-width="16"
-                />
-              </svg>
-              To Water
-            </span>
-            <span
-              class="text-xs text-gray-400"
-            >
-              9
-               
-              days
-               since care
-            </span>
-          </div>
-        </div>
       </div>
       <div
-        class="mt-2"
+        aria-hidden="true"
+        class="w-px self-stretch bg-gray-200 dark:bg-gray-600"
+      />
+      <div
+        class="flex-1 min-w-0"
       >
-        <span
-          aria-label="Evapotranspiration (ET₀): N/A mm | Last watered 9 days ago"
-          class="px-2 py-0.5 text-sm rounded-xl bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-gray-100 opacity-70"
-          title="Evapotranspiration (ET₀) is water lost from soil and plants"
+        <div
+          class="text-base font-semibold text-gray-900 dark:text-gray-100 truncate"
         >
-          Evapotranspiration (ET₀): 
-          —
-           mm | Last watered 
-          9
-           days ago
-        </span>
+          Monstera
+        </div>
+        <div
+          class="flex items-center gap-2 mt-1"
+        >
+          <span
+            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-water-100/90 text-water-800"
+          >
+            <svg
+              aria-hidden="true"
+              class="w-3 h-3"
+              fill="currentColor"
+              height="1em"
+              viewBox="0 0 256 256"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                fill="none"
+                height="256"
+                width="256"
+              />
+              <path
+                d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+              <path
+                d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
+                fill="none"
+                stroke="currentColor"
+                stroke-linecap="round"
+                stroke-linejoin="round"
+                stroke-width="16"
+              />
+            </svg>
+            To Water
+          </span>
+          <span
+            class="text-xs text-gray-400"
+          >
+            9
+             
+            days
+             since care
+          </span>
+        </div>
       </div>
+    </div>
+    <div
+      class="mt-2"
+    >
+      <span
+        aria-label="Evapotranspiration (ET₀): N/A mm | Last watered 9 days ago"
+        class="px-2 py-0.5 text-sm rounded-xl bg-gray-200 dark:bg-gray-600 text-gray-800 dark:text-gray-100 opacity-70"
+        title="Evapotranspiration (ET₀) is water lost from soil and plants"
+      >
+        Evapotranspiration (ET₀): 
+        —
+         mm | Last watered 
+        9
+         days ago
+      </span>
     </div>
   </div>
 </div>

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -290,7 +290,7 @@ export default function Tasks() {
               : 'No tasks coming up.'}
           </p>
         ) : (
-          <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-2'}>
+          <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-4'}>
           {eventsByPlant.map(({ plant, list }, i) => {
             const dueWater = list.some(
               e =>
@@ -352,7 +352,7 @@ export default function Tasks() {
           return (
             <div key={dateKey}>
               <h3 className="mt-4 text-sm font-semibold text-gray-500">{heading}</h3>
-              <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-2'}>
+              <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-4'}>
                 {list.map((e, i) => {
                   const task = {
                     id: `${e.taskType}-${e.plantId}-${i}`,

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -141,8 +141,7 @@ test('completed tasks are styled', () => {
     </MemoryRouter>
   )
   const cards = screen.getAllByTestId('task-card')
-  const inner = cards[0].querySelector('.shadow-md')
-  expect(inner).toHaveClass('opacity-50')
+  expect(cards[0]).toHaveClass('opacity-50')
   expect(Array.from(cards).some(c => c.textContent.includes('Watered'))).toBe(
     true
   )


### PR DESCRIPTION
## Summary
- refine Badge default styling
- restyle TaskCard with padding, spacing and simpler markup
- space out task lists more
- update tests and snapshots

## Testing
- `npm test -- -u --silent`


------
https://chatgpt.com/codex/tasks/task_e_6879d253e3208324a02ac6824c7ca440