### PR TITLE
Apply UI refinements to task cards

### DIFF
--- a/src/components/BaseCard.jsx
+++ b/src/components/BaseCard.jsx
@@ -1,10 +1,10 @@
 import React from 'react'
 
 export default function BaseCard({ variant = 'task', className = '', children, ...props }) {
-  const base = variant === 'task' ? '' : 'rounded-2xl p-4'
+  const base = 'rounded-2xl'
   const variants = {
     task: '',
-    summary: 'border dark:border-gray-600 bg-white dark:bg-gray-700',
+    summary: 'p-4 border dark:border-gray-600 bg-white dark:bg-gray-700',
   }
   const variantClass = variants[variant] ?? ''
   return (

--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -70,7 +70,7 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
       onTouchEnd={end}
 
 
-      className="relative block overflow-hidden rounded-2xl shadow bg-sage dark:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
+      className="relative block overflow-hidden rounded-3xl shadow bg-sage dark:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
       style={{ transform: `translateX(${deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
     >
       <img
@@ -79,7 +79,7 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
         className="w-full h-64 object-cover"
       />
       <div
-        className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent"
+        className="absolute inset-0 bg-[radial-gradient(ellipse_at_center,rgba(0,0,0,0.6),rgba(0,0,0,0.2),transparent)]"
         aria-hidden="true"
       ></div>
       <div className="absolute bottom-3 left-4 right-4 text-white space-y-1 drop-shadow">
@@ -98,7 +98,7 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
           <button
             type="button"
             aria-label={`Mark ${name} as watered`}
-            className="px-3 py-1 bg-blue-600 text-white rounded text-sm animate-bounce-once"
+            className="px-4 py-2 bg-blue-600 text-white rounded-full shadow text-sm animate-bounce-once"
           >
             Water Now
           </button>

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -51,7 +51,7 @@ export default function TaskCard({
       data-testid="task-card"
       tabIndex="0"
       aria-label={`Task card for ${task.plantName}`}
-      className={`relative flex items-center p-4 gap-4 rounded-2xl shadow-sm ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-white dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
+      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow-sm border border-neutral-200 dark:border-gray-600 ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-neutral-50 dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
       style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
       onPointerDown={start}
       onPointerMove={move}
@@ -60,7 +60,7 @@ export default function TaskCard({
     >
       <div className="flex items-center flex-1 gap-4">
         <div
-          className={`w-16 h-16 rounded-full flex items-center justify-center bg-green-50 dark:bg-gray-800 ${
+          className={`w-16 h-16 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-800 ${
             task.type === 'Water'
               ? 'ring-2 ring-water-300'
               : task.type === 'Fertilize'

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -24,10 +24,12 @@ export default function UnifiedTaskCard({ plant, urgent = false, overdue = false
   return (
     <div
       data-testid="unified-task-card"
-      className={`rounded-xl overflow-hidden ${bgClass}`}
+      className={`rounded-2xl border border-neutral-200 dark:border-gray-600 shadow-sm overflow-hidden ${bgClass}`}
     >
-      <div className="flex items-center gap-3 p-4">
-        <img src={image} alt={name} className="w-12 h-12 rounded-lg object-cover" />
+      <div className="flex items-center gap-4 p-5">
+        <div className="w-16 h-16 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-700">
+          <img src={image} alt={name} className="w-12 h-12 rounded-full object-cover" />
+        </div>
         <div className="flex-1 min-w-0">
           <p className="font-semibold font-headline text-gray-900 dark:text-gray-100 truncate">
             {name}

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -68,7 +68,7 @@ test('incomplete tasks show alert style', () => {
     </MemoryRouter>
   )
   const wrapper = container.querySelector('.shadow-sm')
-  expect(wrapper).toHaveClass('bg-white')
+  expect(wrapper).toHaveClass('bg-neutral-50')
 })
 
 test('applies highlight when urgent', () => {

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -2,11 +2,11 @@
 
 exports[`matches snapshot in dark mode 1`] = `
 <div
-  class="  "
+  class="rounded-2xl  "
 >
   <div
     aria-label="Task card for Monstera"
-    class="relative flex items-center p-4 gap-4 rounded-2xl shadow-sm bg-white dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
+    class="relative flex items-center p-5 gap-4 rounded-2xl shadow-sm border border-neutral-200 dark:border-gray-600 bg-neutral-50 dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
     data-testid="task-card"
     style="transform: translateX(0px); transition: transform 0.2s;"
     tabindex="0"
@@ -15,7 +15,7 @@ exports[`matches snapshot in dark mode 1`] = `
       class="flex items-center flex-1 gap-4"
     >
       <div
-        class="w-16 h-16 rounded-full flex items-center justify-center bg-green-50 dark:bg-gray-800 ring-2 ring-water-300"
+        class="w-16 h-16 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-800 ring-2 ring-water-300"
       >
         <img
           alt="Monstera"

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -2,17 +2,21 @@
 
 exports[`matches snapshot in dark mode 1`] = `
 <div
-  class="rounded-xl overflow-hidden bg-gray-50 dark:bg-gray-800"
+  class="rounded-2xl border border-neutral-200 dark:border-gray-600 shadow-sm overflow-hidden bg-gray-50 dark:bg-gray-800"
   data-testid="unified-task-card"
 >
   <div
-    class="flex items-center gap-3 p-4"
+    class="flex items-center gap-4 p-5"
   >
-    <img
-      alt="Fern"
-      class="w-12 h-12 rounded-lg object-cover"
-      src="fern.jpg"
-    />
+    <div
+      class="w-16 h-16 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-700"
+    >
+      <img
+        alt="Fern"
+        class="w-12 h-12 rounded-full object-cover"
+        src="fern.jpg"
+      />
+    </div>
     <div
       class="flex-1 min-w-0"
     >


### PR DESCRIPTION
## Summary
- tweak TaskCard styles and spacing
- update UnifiedTaskCard layout
- soften FeaturedCard overlay and button
- adjust tests and snapshots

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6879d71b4fe8832498ab1de42b085655