### PR TITLE
Add ToggleSwitch component

### DIFF
--- a/src/components/ToggleSwitch.jsx
+++ b/src/components/ToggleSwitch.jsx
@@ -1,0 +1,27 @@
+import { useId } from 'react'
+
+export default function ToggleSwitch({ checked = false, onChange, label, className = '', ...props }) {
+  const id = useId()
+  return (
+    <label htmlFor={id} className={`inline-flex items-center cursor-pointer ${className}`}>
+      <input
+        id={id}
+        type="checkbox"
+        role="switch"
+        aria-checked={checked}
+        checked={checked}
+        onChange={e => onChange?.(e.target.checked)}
+        className="sr-only peer focus:outline-none"
+        {...props}
+      />
+      <span
+        className="relative inline-block w-10 h-6 rounded-full bg-gray-300 dark:bg-gray-600 peer-checked:bg-green-600 transition-colors peer-focus:ring-2 peer-focus:ring-offset-2 peer-focus:ring-accent"
+      >
+        <span
+          className="absolute left-0.5 top-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-4 peer-active:w-6"
+        ></span>
+      </span>
+      {label && <span className="ml-2 select-none">{label}</span>}
+    </label>
+  )
+}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -4,6 +4,7 @@ import { useUser } from '../UserContext.jsx'
 
 import { User, MapPin, Clock } from 'phosphor-react'
 import Panel from '../components/Panel.jsx'
+import ToggleSwitch from '../components/ToggleSwitch.jsx'
 
 import useSnackbar from '../hooks/useSnackbar.jsx'
 
@@ -84,12 +85,12 @@ export default function Settings() {
             <Clock className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
             Preferences
           </h2>
-          <button
-            onClick={toggleTheme}
-            className="px-4 py-2 rounded bg-gray-200 dark:bg-gray-700"
-          >
-            Switch to {theme === 'dark' ? 'Light' : 'Dark'} Mode
-          </button>
+          <ToggleSwitch
+            checked={theme === 'dark'}
+            onChange={toggleTheme}
+            label="Dark Mode"
+            className="mt-2"
+          />
         </Panel>
       </div>
 

--- a/src/pages/__tests__/ProfileRoute.test.jsx
+++ b/src/pages/__tests__/ProfileRoute.test.jsx
@@ -26,4 +26,5 @@ test('navigating to /profile renders the Settings page', () => {
   )
 
   expect(screen.getByRole('heading', { name: /settings/i })).toBeInTheDocument()
+  expect(screen.getByRole('switch', { name: /dark mode/i })).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- create `ToggleSwitch` reusable switch component
- use switch on Settings page for dark mode preference
- update profile route test to look for switch element

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6879da9566c883249259a073c48253e2