### PR TITLE
Add note FAB on timeline

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -53,6 +53,31 @@ export function PlantProvider({ children }) {
     }
   }, [plants])
 
+  const [timelineNotes, setTimelineNotes] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('timelineNotes')
+      if (stored) {
+        try {
+          return JSON.parse(stored)
+        } catch {
+          // ignore
+        }
+      }
+    }
+    return []
+  })
+
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('timelineNotes', JSON.stringify(timelineNotes))
+    }
+  }, [timelineNotes])
+
+  const addTimelineNote = text => {
+    const date = new Date().toISOString().slice(0, 10)
+    setTimelineNotes(prev => [...prev, { date, text }])
+  }
+
   const logEvent = (id, type, note = '') => {
     const date = new Date().toISOString().slice(0, 10)
     setPlants(prev =>
@@ -172,6 +197,8 @@ export function PlantProvider({ children }) {
         restorePlant,
         addPhoto,
         removePhoto,
+        timelineNotes,
+        addTimelineNote,
       }}
     >
       {children}

--- a/src/components/NoteFab.jsx
+++ b/src/components/NoteFab.jsx
@@ -1,0 +1,70 @@
+import { useState, useEffect } from 'react'
+import { Plus, Note } from 'phosphor-react'
+
+export default function NoteFab({ onAddNote }) {
+  const [open, setOpen] = useState(false)
+
+  useEffect(() => {
+    if (!open) return
+    const handleKey = e => {
+      if (e.key === 'Escape') setOpen(false)
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [open])
+
+  return (
+    <div className="fixed bottom-24 right-20 z-30">
+      {open && (
+        <div
+          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Add menu"
+          onClick={() => setOpen(false)}
+        >
+          <ul
+            className="relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
+            onClick={e => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              aria-label="Close menu"
+              onClick={() => setOpen(false)}
+              className="absolute top-2 right-2 text-gray-500"
+            >
+              &times;
+            </button>
+            <li>
+              <button
+                type="button"
+                onClick={() => {
+                  setOpen(false)
+                  onAddNote?.()
+                }}
+                title="Add Note"
+                className="flex items-center gap-3 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
+              >
+                <span className="p-2 rounded-full bg-violet-100">
+                  <Note className="w-5 h-5 text-violet-600" aria-hidden="true" />
+                </span>
+                <span className="text-sm text-gray-800 dark:text-gray-200">Add Note</span>
+              </button>
+            </li>
+          </ul>
+        </div>
+      )}
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-label="Open create menu"
+        title="Open create menu"
+        aria-expanded={open}
+        aria-haspopup="menu"
+        className={`bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
+      >
+        <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
+      </button>
+    </div>
+  )
+}

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -1,15 +1,34 @@
 import { usePlants } from '../PlantContext.jsx'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
 import actionIcons from '../components/ActionIcons.jsx'
 import { formatMonth, formatDate } from '../utils/date.js'
 import { buildEvents, groupEventsByMonth } from '../utils/events.js'
+import NoteModal from '../components/NoteModal.jsx'
+import NoteFab from '../components/NoteFab.jsx'
 
 export default function Timeline() {
-  const { plants } = usePlants()
+  const { plants, timelineNotes = [], addTimelineNote = () => {} } = usePlants()
+  const [showNoteModal, setShowNoteModal] = useState(false)
 
-  const events = useMemo(
+  const plantEvents = useMemo(
     () => buildEvents(plants, { includePlantName: true }),
     [plants]
+  )
+
+  const noteEvents = useMemo(
+    () =>
+      timelineNotes.map(n => ({
+        date: n.date,
+        label: 'Note',
+        note: n.text,
+        type: 'log',
+      })),
+    [timelineNotes]
+  )
+
+  const events = useMemo(
+    () => [...plantEvents, ...noteEvents].sort((a, b) => new Date(a.date) - new Date(b.date)),
+    [plantEvents, noteEvents]
   )
 
   const groupedEvents = useMemo(
@@ -58,7 +77,18 @@ export default function Timeline() {
             </ul>
           </div>
         ))}
+        {showNoteModal && (
+          <NoteModal
+            label="Note"
+            onSave={text => {
+              if (text) addTimelineNote(text)
+              setShowNoteModal(false)
+            }}
+            onCancel={() => setShowNoteModal(false)}
+          />
+        )}
       </div>
+      <NoteFab onAddNote={() => setShowNoteModal(true)} />
     </div>
   )
 }

--- a/src/pages/__tests__/TimelineFab.test.jsx
+++ b/src/pages/__tests__/TimelineFab.test.jsx
@@ -1,0 +1,35 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Timeline from '../Timeline.jsx'
+import { usePlants } from '../../PlantContext.jsx'
+
+const addTimelineNote = jest.fn()
+
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: jest.fn(),
+}))
+
+const usePlantsMock = usePlants
+
+beforeEach(() => {
+  addTimelineNote.mockClear()
+  usePlantsMock.mockReturnValue({ plants: [], timelineNotes: [], addTimelineNote })
+})
+
+test('fab opens note modal', () => {
+  render(<Timeline />)
+  fireEvent.click(screen.getByRole('button', { name: /open create menu/i }))
+  fireEvent.click(screen.getByRole('button', { name: /add note/i }))
+  expect(screen.getByRole('dialog', { name: /note/i })).toBeInTheDocument()
+})
+
+test('saving note calls addTimelineNote', () => {
+  render(<Timeline />)
+  fireEvent.click(screen.getByRole('button', { name: /open create menu/i }))
+  fireEvent.click(screen.getByRole('button', { name: /add note/i }))
+  fireEvent.change(
+    screen.getByRole('textbox', { name: /note/i }),
+    { target: { value: 'hi' } }
+  )
+  fireEvent.click(screen.getByRole('button', { name: /save/i }))
+  expect(addTimelineNote).toHaveBeenCalledWith('hi')
+})


### PR DESCRIPTION
## Summary
- support storing timeline notes in PlantContext
- add a floating action button for notes
- wire NoteFab into the Timeline page
- test that the new FAB opens a note modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879d9c3ab288324a22e13a68832a40b