### PR TITLE
Improve timeline interactions

### DIFF
--- a/src/components/LogDetailsModal.jsx
+++ b/src/components/LogDetailsModal.jsx
@@ -1,0 +1,35 @@
+import actionIcons from './ActionIcons.jsx'
+import { formatDate } from '../utils/date.js'
+
+export default function LogDetailsModal({ event, onClose }) {
+  if (!event) return null
+  const Icon = actionIcons[event.type]
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Log details"
+      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50"
+    >
+      <div className="bg-white dark:bg-gray-700 rounded-lg shadow-lg p-4 w-72 max-w-full">
+        <div className="flex items-center gap-2 mb-2">
+          {Icon && <Icon className="w-5 h-5" aria-hidden="true" />}
+          <h3 className="font-headline text-lg">{event.label}</h3>
+        </div>
+        <p className="text-sm mb-2">{formatDate(event.date)}</p>
+        {event.note && (
+          <p className="italic text-green-700 text-sm mb-2">{event.note}</p>
+        )}
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 bg-gray-200 dark:bg-gray-600 rounded"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -1,6 +1,8 @@
 import { usePlants } from '../PlantContext.jsx'
-import { useMemo } from 'react'
+import { useMemo, useState } from 'react'
+import { motion } from 'framer-motion'
 import actionIcons from '../components/ActionIcons.jsx'
+import LogDetailsModal from '../components/LogDetailsModal.jsx'
 import { formatMonth, formatDate } from '../utils/date.js'
 import { buildEvents, groupEventsByMonth } from '../utils/events.js'
 
@@ -17,6 +19,8 @@ export default function Timeline() {
     [events]
   )
 
+  const [selectedEvent, setSelectedEvent] = useState(null)
+
 
 
   const bulletColors = {
@@ -29,36 +33,53 @@ export default function Timeline() {
   return (
     <div className="overflow-y-auto max-h-full p-4 text-gray-700 dark:text-gray-200">
       <div className="rounded-xl bg-white shadow-sm p-4 border border-gray-100">
-        {groupedEvents.map(([monthKey, list]) => (
-          <div key={monthKey} className="mt-6 first:mt-0">
-            <h3 className="text-[0.7rem] uppercase tracking-wider text-gray-300 mb-2">
-              {formatMonth(monthKey)}
-            </h3>
-            <ul className="ml-3 border-l-2 border-gray-200 space-y-6 pl-5">
-              {list.map((e, i) => {
-                const Icon = actionIcons[e.type]
-                return (
-                  <li key={`${e.date}-${e.label}-${i}`} className="relative text-sm">
-                    {Icon && (
-                      <div className={`absolute -left-5 top-[0.25rem] w-4 h-4 flex items-center justify-center rounded-full ${bulletColors[e.type]}`}>
-                        <Icon className="w-3 h-3 text-white" aria-hidden="true" />
-                      </div>
-                    )}
-                    <div className={`flex items-start ${e.note ? 'bg-gray-50 dark:bg-gray-700 rounded-xl p-3 shadow-sm' : ''}`}> 
-                      <div>
-                        <span className="font-medium">{formatDate(e.date)}</span> — {e.label}
-                        {e.note && (
-                          <div className="text-xs italic text-green-700 mt-1">{e.note}</div>
-                        )}
-                      </div>
-                    </div>
-                  </li>
-                )
-              })}
-            </ul>
-          </div>
-        ))}
+        <div className="relative">
+          <div className="absolute left-1/2 top-0 bottom-0 w-px bg-gray-200" aria-hidden="true" />
+          {groupedEvents.map(([monthKey, list]) => (
+            <div key={monthKey} className="mt-6 first:mt-0">
+              <h3 className="sticky top-0 z-10 bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm px-1 text-[0.7rem] uppercase tracking-wider text-gray-500 mb-2">
+                {formatMonth(monthKey)}
+              </h3>
+              <ul className="space-y-6">
+                {list.map((e, i) => {
+                  const Icon = actionIcons[e.type]
+                  return (
+                    <motion.li
+                      key={`${e.date}-${e.label}-${i}`}
+                      initial={{ opacity: 0, x: 20 }}
+                      animate={{ opacity: 1, x: 0 }}
+                      className="relative text-sm pl-8"
+                    >
+                      {Icon && (
+                        <div
+                          className={`absolute left-1/2 -translate-x-1/2 top-[0.25rem] w-4 h-4 flex items-center justify-center rounded-full ${bulletColors[e.type]}`}
+                        >
+                          <Icon className="w-3 h-3 text-white" aria-hidden="true" />
+                        </div>
+                      )}
+                      <button
+                        type="button"
+                        onClick={() => setSelectedEvent(e)}
+                        className={`text-left w-full flex items-start ${e.note ? 'bg-gray-50 dark:bg-gray-700 rounded-xl p-3 shadow-sm' : ''}`}
+                      >
+                        <div>
+                          <span className="font-medium">{formatDate(e.date)}</span> — {e.label}
+                          {e.note && (
+                            <div className="text-xs italic text-green-700 mt-1">{e.note}</div>
+                          )}
+                        </div>
+                      </button>
+                    </motion.li>
+                  )
+                })}
+              </ul>
+            </div>
+          ))}
+        </div>
       </div>
+      {selectedEvent && (
+        <LogDetailsModal event={selectedEvent} onClose={() => setSelectedEvent(null)} />
+      )}
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- darken timeline month headers and make them sticky
- add a centered vertical track with animated entries
- clicking an entry now opens a log details modal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879dc2ddd888324b33d9b1fecc0748c