### PR TITLE
Add clickable thumbnail to TaskCard

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -18,6 +18,12 @@ export default function TaskCard({
   const { plants, markWatered, markFertilized, updatePlant } = usePlants()
   const { Snackbar, showSnackbar } = useSnackbar()
 
+  const goToDetail = e => {
+    e.stopPropagation()
+    const room = task.room ? encodeURIComponent(task.room) : null
+    navigate(room ? `/room/${room}/plant/${task.plantId}` : `/plant/${task.plantId}`)
+  }
+
   const handleComplete = () => {
     const prev = plants.find(p => p.id === task.plantId)
     if (task.type === 'Water') {
@@ -59,21 +65,23 @@ export default function TaskCard({
       onPointerCancel={end}
     >
       <div className="flex items-center flex-1 gap-4">
-        <div
-          className={`w-16 h-16 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-800 ${
+      <button
+        type="button"
+        onClick={goToDetail}
+        className={`w-16 h-16 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-800 ${
             task.type === 'Water'
               ? 'ring-2 ring-water-300'
               : task.type === 'Fertilize'
               ? 'ring-2 ring-fertilize-300'
               : 'ring-2 ring-healthy-300'
           }`}
-        >
-          <img
-            src={task.image}
-            alt={task.plantName}
-            className="w-12 h-12 rounded-full object-cover"
-          />
-        </div>
+      >
+        <img
+          src={task.image}
+          alt={task.plantName}
+          className="w-12 h-12 rounded-full object-cover"
+        />
+      </button>
         <div className="w-px self-stretch bg-gray-200 dark:bg-gray-600" aria-hidden="true" />
         <div className="flex-1 min-w-0">
           <div className="text-base font-semibold text-gray-900 dark:text-gray-100 truncate">

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -14,15 +14,16 @@ exports[`matches snapshot in dark mode 1`] = `
     <div
       class="flex items-center flex-1 gap-4"
     >
-      <div
+      <button
         class="w-16 h-16 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-800 ring-2 ring-water-300"
+        type="button"
       >
         <img
           alt="Monstera"
           class="w-12 h-12 rounded-full object-cover"
           src="https://images.pexels.com/photos/5699660/pexels-photo-5699660.jpeg"
         />
-      </div>
+      </button>
       <div
         aria-hidden="true"
         class="w-px self-stretch bg-gray-200 dark:bg-gray-600"


### PR DESCRIPTION
## Summary
- allow tapping the thumbnail on a task card to open the plant detail page
- update snapshots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6879e22dc2b08324bc9dc828012e38b2