### PR TITLE
Use badges in unified task card

### DIFF
--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -1,14 +1,12 @@
 import React from 'react'
 
+import { Drop, Sun } from 'phosphor-react'
 import { formatDaysAgo } from '../utils/dateFormat.js'
+import Badge from './Badge.jsx'
 
 export default function UnifiedTaskCard({ plant, urgent = false, overdue = false }) {
   if (!plant) return null
   const { name, image, dueWater, dueFertilize, lastCared } = plant
-  const needs = []
-  if (dueWater) needs.push('water \uD83D\uDCA7')
-  if (dueFertilize) needs.push('fertilizer \u2600\uFE0F')
-  const summary = needs.length ? `Needs ${needs.join(' and ')}` : 'No care needed'
 
   const bgClass = overdue
     ? 'bg-red-50 dark:bg-red-900'
@@ -34,26 +32,27 @@ export default function UnifiedTaskCard({ plant, urgent = false, overdue = false
           <p className="font-semibold font-headline text-gray-900 dark:text-gray-100 truncate">
             {name}
           </p>
-          <p className="text-sm text-gray-600 dark:text-gray-300">{summary}</p>
+          <div className="flex items-center gap-2 mt-1">
+            {dueWater && (
+              <Badge Icon={Drop} colorClass="bg-water-100/90 text-water-800">
+                Water
+              </Badge>
+            )}
+            {dueFertilize && (
+              <Badge
+                Icon={Sun}
+                colorClass="bg-fertilize-100/90 text-fertilize-800"
+              >
+                Fertilize
+              </Badge>
+            )}
+            {!dueWater && !dueFertilize && (
+              <Badge colorClass="bg-healthy-100/90 text-healthy-800">
+                No care needed
+              </Badge>
+            )}
+          </div>
           {last}
-        </div>
-        <div className="flex flex-col gap-1 items-end">
-          {dueWater && (
-            <button
-              type="button"
-              className="px-3 py-1 border border-blue-600 text-blue-600 rounded-full text-xs flex items-center gap-1"
-            >
-              Water Now
-            </button>
-          )}
-          {dueFertilize && (
-            <button
-              type="button"
-              className="px-3 py-1 border border-yellow-600 text-yellow-600 rounded-full text-xs flex items-center gap-1"
-            >
-              Fertilize Now
-            </button>
-          )}
         </div>
       </div>
     </div>

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -12,12 +12,13 @@ const plant = {
   lastCared: '2025-07-07',
 }
 
-test('renders plant info and water button', () => {
+test('renders plant info and badges', () => {
   render(<UnifiedTaskCard plant={plant} />)
   expect(screen.getByText('Fern')).toBeInTheDocument()
-  expect(screen.getByText(/Needs water/)).toBeInTheDocument()
-  expect(screen.getByText('Water Now')).toBeInTheDocument()
-  expect(screen.queryByText('Fertilize Now')).toBeNull()
+  const waterBadge = screen.getByText('Water')
+  expect(waterBadge).toBeInTheDocument()
+  expect(waterBadge).toHaveClass('bg-water-100/90')
+  expect(screen.queryByText('Fertilize')).toBeNull()
   expect(screen.getByText('Last cared for 3 days ago')).toBeInTheDocument()
 })
 

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -25,27 +25,52 @@ exports[`matches snapshot in dark mode 1`] = `
       >
         Fern
       </p>
-      <p
-        class="text-sm text-gray-600 dark:text-gray-300"
+      <div
+        class="flex items-center gap-2 mt-1"
       >
-        Needs water 💧
-      </p>
+        <span
+          class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-water-100/90 text-water-800"
+        >
+          <svg
+            aria-hidden="true"
+            class="w-3 h-3"
+            fill="currentColor"
+            height="1em"
+            viewBox="0 0 256 256"
+            width="1em"
+            xmlns="http://www.w3.org/2000/svg"
+          >
+            <rect
+              fill="none"
+              height="256"
+              width="256"
+            />
+            <path
+              d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="16"
+            />
+            <path
+              d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
+              fill="none"
+              stroke="currentColor"
+              stroke-linecap="round"
+              stroke-linejoin="round"
+              stroke-width="16"
+            />
+          </svg>
+          Water
+        </span>
+      </div>
       <p
         class="text-xs text-gray-500"
       >
         Last cared for 
         3 days ago
       </p>
-    </div>
-    <div
-      class="flex flex-col gap-1 items-end"
-    >
-      <button
-        class="px-3 py-1 border border-blue-600 text-blue-600 rounded-full text-xs flex items-center gap-1"
-        type="button"
-      >
-        Water Now
-      </button>
     </div>
   </div>
 </div>

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -148,7 +148,7 @@ test('completed tasks are styled', () => {
 })
 
 
-test('future watering date does not show Water Now button', async () => {
+test('future watering date does not show Water badge', async () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
 
   render(
@@ -160,7 +160,8 @@ test('future watering date does not show Water Now button', async () => {
   const tab = screen.getByRole('tab', { name: /By Plant/i })
   fireEvent.click(tab)
 
-  expect(screen.queryByText('Water Now')).toBeNull()
+  const firstCard = screen.getAllByTestId('unified-task-card')[0]
+  expect(within(firstCard).queryByText('Water', { exact: true })).toBeNull()
   jest.useRealTimers()
 
   const pastTab = screen.getByRole('tab', { name: /Past/i })
@@ -181,8 +182,8 @@ test('future watering date does not show Water Now button', async () => {
   const cards = screen.getAllByTestId('unified-task-card')
   expect(cards).toHaveLength(2)
 
-  expect(within(cards[0]).getByText('Water Now')).toBeInTheDocument()
-  expect(within(cards[1]).queryByText('Water Now')).toBeNull()
+  expect(within(cards[0]).getByText('Water', { exact: true })).toBeInTheDocument()
+  expect(within(cards[1]).queryByText('Water', { exact: true })).toBeNull()
 
 })
 
@@ -223,9 +224,9 @@ test('by plant view shows due and future tasks correctly', async () => {
     within(card).queryByText('Future Plant')
   )
 
-  expect(within(dueCard).getByText('Water Now')).toBeInTheDocument()
-  expect(within(dueCard).getByText('Fertilize Now')).toBeInTheDocument()
+  expect(within(dueCard).getByText('Water', { exact: true })).toBeInTheDocument()
+  expect(within(dueCard).getByText('Fertilize', { exact: true })).toBeInTheDocument()
 
-  expect(within(futureCard).queryByText('Water Now')).toBeNull()
-  expect(within(futureCard).queryByText('Fertilize Now')).toBeNull()
+  expect(within(futureCard).queryByText('Water', { exact: true })).toBeNull()
+  expect(within(futureCard).queryByText('Fertilize', { exact: true })).toBeNull()
 })


### PR DESCRIPTION
## Summary
- display care tasks as badges on the unified task card
- test for water and fertilize badges
- adjust task page tests for new badges

## Testing
- `npm test -- -u` *(fails: some suites fail to run due to Babel parsing errors)*

------
https://chatgpt.com/codex/tasks/task_e_6879e046a36c83248be7e5c8c7d174cc