### PR TITLE
Position Fabs relative to sections

### DIFF
--- a/src/components/NoteFab.jsx
+++ b/src/components/NoteFab.jsx
@@ -14,7 +14,7 @@ export default function NoteFab({ onAddNote }) {
   }, [open])
 
   return (
-    <div className="fixed bottom-24 right-20 z-30">
+    <div className="absolute bottom-4 right-4 z-30">
       {open && (
         <div
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"

--- a/src/components/PlantDetailFab.jsx
+++ b/src/components/PlantDetailFab.jsx
@@ -24,7 +24,7 @@ export default function PlantDetailFab({ onAddPhoto, onAddNote }) {
   }
 
   return (
-    <div className="fixed bottom-24 right-20 z-30">
+    <div className="absolute bottom-4 right-4 z-30">
       {open && (
         <div
           className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -53,7 +53,7 @@ export default function Timeline() {
   }
 
   return (
-    <div className="overflow-y-auto max-h-full max-w-md mx-auto space-y-8 py-4 px-4 text-gray-700 dark:text-gray-200">
+    <div className="relative overflow-y-auto max-h-full max-w-md mx-auto space-y-8 py-4 px-4 text-gray-700 dark:text-gray-200">
       <SectionCard className="border border-gray-100">
 
         <div className="relative">


### PR DESCRIPTION
## Summary
- anchor PlantDetailFab and NoteFab within their nearest section instead of the viewport
- make timeline page container `relative` so its NoteFab anchors correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a3e6a60548324a39049cd9b739b56