### PR TITLE
Implement iNaturalist fallback images

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ Includes:
 - Tasks generated dynamically from plant data
 - Floating action button for adding plants or rooms
 - Persistent bottom navigation tabs for easy access
+- Placeholder photos fetched from iNaturalist when a plant has none
 
 ## Using the UI
 

--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -5,6 +5,7 @@ import { formatCareSummary } from '../utils/date.js'
 
 
 import useSwipe from '../hooks/useSwipe.js'
+import useINatPhoto from '../hooks/useINatPhoto.js'
 import { createRipple } from '../utils/interactions.js'
 
 
@@ -46,9 +47,13 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
   const plant = items[index]
   const name = plant.plantName || plant.name
   const id = plant.plantId || plant.id
+  const placeholder = useINatPhoto(name)
   const preview = formatCareSummary(plant.lastWatered, plant.nextWater)
   const imageSrc =
-    (plant.photos && plant.photos[0]?.src) || plant.image || '/demo-image-01.jpg'
+    (plant.photos && plant.photos[0]?.src) ||
+    plant.image ||
+    placeholder?.src ||
+    '/demo-image-01.jpg'
 
   return (
     <Link

--- a/src/hooks/useINatPhoto.js
+++ b/src/hooks/useINatPhoto.js
@@ -1,0 +1,54 @@
+import { useState, useEffect } from 'react'
+
+export default function useINatPhoto(name) {
+  const [photo, setPhoto] = useState(null)
+
+  useEffect(() => {
+    if (!name) return
+    const key = `inat_${name.toLowerCase()}`
+    const cached = typeof localStorage !== 'undefined' && localStorage.getItem(key)
+    if (cached) {
+      try {
+        setPhoto(JSON.parse(cached))
+        return
+      } catch {}
+    }
+
+    if (typeof fetch !== 'function') return
+
+    let aborted = false
+    async function fetchPhoto() {
+      try {
+        const searchUrl =
+          `https://api.inaturalist.org/v1/search?q=${encodeURIComponent(name)}&sources=taxa`
+        const searchRes = await fetch(searchUrl)
+        const searchData = await searchRes.json()
+        const id = searchData?.results?.[0]?.record?.id || searchData?.results?.[0]?.id
+        if (!id) return
+        const taxonRes = await fetch(`https://api.inaturalist.org/v1/taxa/${id}`)
+        const taxonData = await taxonRes.json()
+        const defaultPhoto = taxonData?.results?.[0]?.default_photo
+        if (defaultPhoto?.medium_url) {
+          const info = {
+            src: defaultPhoto.medium_url,
+            attribution: defaultPhoto.attribution,
+          }
+          if (!aborted) {
+            setPhoto(info)
+            if (typeof localStorage !== 'undefined') {
+              localStorage.setItem(key, JSON.stringify(info))
+            }
+          }
+        }
+      } catch (err) {
+        console.error('Failed to load iNaturalist photo', err)
+      }
+    }
+    fetchPhoto()
+    return () => {
+      aborted = true
+    }
+  }, [name])
+
+  return photo
+}


### PR DESCRIPTION
## Summary
- add a `useINatPhoto` hook that fetches plant images from iNaturalist
- use placeholder photos in `FeaturedCard`
- document placeholder feature in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a3f86ace88324b9cf7e4c478825cb