### PR TITLE
Add Card component and standardize card styling

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,0 +1,7 @@
+export default function Card({ as: Component = 'div', className = '', children, ...props }) {
+  return (
+    <Component className={`bg-white dark:bg-gray-700 rounded-2xl shadow-sm p-4 ${className}`} {...props}>
+      {children}
+    </Component>
+  )
+}

--- a/src/components/Panel.jsx
+++ b/src/components/Panel.jsx
@@ -1,7 +1,9 @@
+import Card from './Card.jsx'
+
 export default function Panel({ className = '', children, ...props }) {
   return (
-    <div className={`rounded-xl bg-white dark:bg-gray-700 shadow-sm p-4 ${className}`} {...props}>
+    <Card className={className} {...props}>
       {children}
-    </div>
+    </Card>
   )
 }

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -10,6 +10,7 @@ import { usePlants } from '../PlantContext.jsx'
 import useSnackbar from '../hooks/useSnackbar.jsx'
 import NoteModal from './NoteModal.jsx'
 import ConfirmModal from './ConfirmModal.jsx'
+import Card from './Card.jsx'
 
 export default function PlantCard({ plant }) {
   const navigate = useNavigate()
@@ -201,8 +202,7 @@ export default function PlantCard({ plant }) {
           )}
         </div>
       )}
-      <div
-        className="p-4 rounded-2xl shadow-md bg-white dark:bg-gray-700"
+      <Card
         style={{ transform: `translateX(${deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
       >
         <Link
@@ -226,7 +226,7 @@ export default function PlantCard({ plant }) {
           <Drop className="w-4 h-4" aria-hidden="true" />
           Watered
         </button>
-      </div>
+      </Card>
     </div>
     {showNote && (
       <NoteModal label="Optional note" onSave={handleSaveNote} onCancel={handleCancelNote} />

--- a/src/components/SectionCard.jsx
+++ b/src/components/SectionCard.jsx
@@ -1,7 +1,9 @@
+import Card from './Card.jsx'
+
 export default function SectionCard({ className = '', children, ...props }) {
   return (
-    <section className={`rounded-xl bg-white dark:bg-gray-700 shadow-sm p-4 ${className}`} {...props}>
+    <Card as="section" className={className} {...props}>
       {children}
-    </section>
+    </Card>
   )
 }

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -175,7 +175,7 @@ exports[`matches snapshot in dark mode 1`] = `
     </div>
   </div>
   <div
-    class="p-4 rounded-2xl shadow-md bg-white dark:bg-gray-700"
+    class="bg-white dark:bg-gray-700 rounded-2xl shadow-sm p-4 "
     style="transform: translateX(0px); transition: transform 0.2s;"
   >
     <a

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -21,6 +21,7 @@ import {
 } from 'phosphor-react'
 import CareStats from '../components/CareStats.jsx'
 import FeaturedCard from '../components/FeaturedCard.jsx'
+import Card from '../components/Card.jsx'
 import useHappyPlant from '../hooks/useHappyPlant.js'
 
 
@@ -303,12 +304,11 @@ export default function Home() {
         </section>
       </div>
       <div className="mt-4">
-        <Link
-          to="/myplants"
-          className="block px-4 py-2 bg-white dark:bg-gray-700 rounded-lg shadow text-center font-semibold"
-        >
-          All Plants
-        </Link>
+        <Card className="p-0 text-center font-semibold">
+          <Link to="/myplants" className="block px-4 py-2">
+            All Plants
+          </Link>
+        </Card>
       </div>
     </PageContainer>
   )

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -12,6 +12,7 @@ import { usePlants } from '../PlantContext.jsx'
 import { createRipple } from '../utils/interactions.js'
 import CreateFab from '../components/CreateFab.jsx'
 import PageContainer from "../components/PageContainer.jsx"
+import Card from '../components/Card.jsx'
 
 export default function MyPlants() {
   const { rooms } = useRooms()
@@ -108,46 +109,48 @@ export default function MyPlants() {
             <Link
               key={room}
               to={`/room/${encodeURIComponent(room)}`}
-              className="p-4 bg-white dark:bg-gray-700 rounded-lg shadow-md hover:shadow-lg space-y-2 animate-fade-in-up transition-transform hover:-translate-y-1 active:shadow"
+              className="animate-fade-in-up transition-transform hover:-translate-y-1 active:shadow"
               style={{ animationDelay: `${i * 50}ms` }}
               onMouseDown={createRipple}
               onTouchStart={createRipple}
             >
-              <div className="relative">
-                <img
-                  src={thumbnail}
-                  className="w-full h-24 object-cover rounded-md"
-                  alt={`Photo of the ${room} room`}
-                />
-                <div
-                  className="absolute inset-0 rounded-md bg-gradient-to-t from-black/60 via-black/30 to-transparent"
-                  aria-hidden="true"
-                ></div>
-                <div className="absolute bottom-1 left-2 right-2 text-white drop-shadow space-y-0.5">
-                  <p className="font-bold text-lg font-headline leading-none">{room}</p>
-                  <p className="text-sm text-gray-500 leading-none">{countPlants(room)} plants</p>
+              <Card className="space-y-2 hover:shadow-lg">
+                <div className="relative">
+                  <img
+                    src={thumbnail}
+                    className="w-full h-24 object-cover rounded-md"
+                    alt={`Photo of the ${room} room`}
+                  />
+                  <div
+                    className="absolute inset-0 rounded-md bg-gradient-to-t from-black/60 via-black/30 to-transparent"
+                    aria-hidden="true"
+                  ></div>
+                  <div className="absolute bottom-1 left-2 right-2 text-white drop-shadow space-y-0.5">
+                    <p className="font-bold text-lg font-headline leading-none">{room}</p>
+                    <p className="text-sm text-gray-500 leading-none">{countPlants(room)} plants</p>
+                  </div>
                 </div>
-              </div>
-              <div className="flex gap-1 text-[10px]">
-                {wateredToday && (
-                  <span role="img" aria-label="Watered today">💧</span>
+                <div className="flex gap-1 text-[10px]">
+                  {wateredToday && (
+                    <span role="img" aria-label="Watered today">💧</span>
+                  )}
+                  {lowLight && (
+                    <span role="img" aria-label="Low light">☀️</span>
+                  )}
+                  {pestAlert && (
+                    <span role="img" aria-label="Pest alert">🐛</span>
+                  )}
+                  {lastUpdated && <span>{formatDaysAgo(lastUpdated)}</span>}
+                </div>
+                {overdue > 0 && (
+                  <Badge
+                    variant="overdue"
+                    colorClass="slide-in animate-pulse rounded-full text-[11px]"
+                  >
+                    ⚠️ {overdue} needs love
+                  </Badge>
                 )}
-                {lowLight && (
-                  <span role="img" aria-label="Low light">☀️</span>
-                )}
-                {pestAlert && (
-                  <span role="img" aria-label="Pest alert">🐛</span>
-                )}
-                {lastUpdated && <span>{formatDaysAgo(lastUpdated)}</span>}
-              </div>
-              {overdue > 0 && (
-                <Badge
-                  variant="overdue"
-                  colorClass="slide-in animate-pulse rounded-full text-[11px]"
-                >
-                  ⚠️ {overdue} needs love
-                </Badge>
-              )}
+              </Card>
             </Link>
           )
         })}

--- a/src/pages/RoomList.jsx
+++ b/src/pages/RoomList.jsx
@@ -8,6 +8,7 @@ import { createRipple } from '../utils/interactions.js'
 import Breadcrumb from '../components/Breadcrumb.jsx'
 import Badge from '../components/Badge.jsx'
 import PageContainer from "../components/PageContainer.jsx"
+import Card from '../components/Card.jsx'
 
 export default function RoomList() {
   const { roomName } = useParams()
@@ -74,25 +75,27 @@ export default function RoomList() {
               <Link
                 key={plant.id}
                 to={`/room/${encodeURIComponent(roomName)}/plant/${plant.id}`}
-                className="block relative overflow-hidden rounded-lg shadow transition-transform hover:-translate-y-1 hover:shadow-lg active:shadow"
+                className="block transition-transform hover:-translate-y-1 active:shadow"
                 onMouseDown={createRipple}
                 onTouchStart={createRipple}
               >
-                <img
-                  src={src}
-                  alt={plant.name}
-                  loading="lazy"
-                  className="w-full h-40 object-cover rounded-lg"
-                />
-                <span className="absolute top-1 left-1 bg-black/60 text-white text-xs px-1 rounded">
-                  {plant.name}
-                </span>
-                <Badge
-                  Icon={Drop}
-                  colorClass={`absolute bottom-1 left-1 text-xs ${colorClass}`}
-                >
-                  {status}
-                </Badge>
+                <Card className="relative overflow-hidden hover:shadow-lg">
+                  <img
+                    src={src}
+                    alt={plant.name}
+                    loading="lazy"
+                    className="w-full h-40 object-cover rounded-lg"
+                  />
+                  <span className="absolute top-1 left-1 bg-black/60 text-white text-xs px-1 rounded">
+                    {plant.name}
+                  </span>
+                  <Badge
+                    Icon={Drop}
+                    colorClass={`absolute bottom-1 left-1 text-xs ${colorClass}`}
+                  >
+                    {status}
+                  </Badge>
+                </Card>
               </Link>
             )
           })}


### PR DESCRIPTION
## Summary
- add generic `Card` component
- use `<Card>` for Panel, SectionCard, PlantCard, and several pages
- update snapshots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687a536b10c083248fdcfd2b4a6b1d91