### PR TITLE
Standardize plant image styling

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -213,7 +213,7 @@ export default function PlantCard({ plant }) {
           }
           className="block mb-2"
         >
-          <img src={plant.image} alt={plant.name} loading="lazy" className="w-full h-48 object-cover rounded-xl" />
+          <img src={plant.image} alt={plant.name} loading="lazy" className="plant-thumb" />
           <h2 className="font-bold text-[1.1rem] font-headline mt-2">{plant.name}</h2>
         </Link>
         <p className="text-sm text-green-700 font-medium font-body">Next: {plant.nextWater}</p>

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -184,7 +184,7 @@ exports[`matches snapshot in dark mode 1`] = `
     >
       <img
         alt="Aloe Vera"
-        class="w-full h-48 object-cover rounded-xl"
+        class="plant-thumb"
         loading="lazy"
         src="test.jpg"
       />

--- a/src/index.css
+++ b/src/index.css
@@ -225,3 +225,8 @@ body {
      -moz-appearance: none;
           appearance: none;
 }
+
+/* Standardized plant image */
+.plant-thumb {
+  @apply w-full aspect-[3/4] object-cover rounded-xl;
+}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -420,7 +420,7 @@ export default function PlantDetail() {
                   <img
                     src={src}
                     alt={caption || `${plant.name} photo ${i + 1}`}
-                    className="object-cover w-full h-24 rounded-lg"
+                    className="plant-thumb w-24"
                   />
                 </button>
                 {caption && (

--- a/src/pages/RoomList.jsx
+++ b/src/pages/RoomList.jsx
@@ -83,7 +83,7 @@ export default function RoomList() {
                     src={src}
                     alt={plant.name}
                     loading="lazy"
-                    className="w-full h-40 object-cover rounded-lg"
+                    className="plant-thumb"
                   />
                   <span className="absolute top-1 left-1 bg-black/60 text-white text-xs px-1 rounded">
                     {plant.name}


### PR DESCRIPTION
## Summary
- unify thumbnail look with new `plant-thumb` class
- update PlantCard, RoomList and gallery images
- update snapshot

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687a57ce66548324b8a7d452505edf26