### PR TITLE
Add typography utility classes

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -16,7 +16,7 @@ export default function Badge({
 
   return (
     <span
-      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium ${cls}`}
+      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-badge font-medium ${cls}`}
     >
       {Icon && <Icon className="w-3 h-3" aria-hidden="true" />}
       {children}

--- a/src/components/CareSummaryModal.jsx
+++ b/src/components/CareSummaryModal.jsx
@@ -28,7 +28,7 @@ export default function CareSummaryModal({ tasks = [], onClose }) {
         >
           &times;
         </button>
-        <h2 className="text-lg font-semibold font-headline mb-2">Care Summary</h2>
+        <h2 className="text-heading font-semibold font-headline mb-2">Care Summary</h2>
         {tasks.length > 0 ? (
           <ul className="list-disc pl-4 mb-4 text-left">
             {tasks.map(t => (

--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -84,7 +84,7 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
       <div className="absolute bottom-3 left-4 right-4 text-white space-y-1 drop-shadow">
         <span className="text-xs uppercase tracking-wide opacity-90">🌿 Featured Plant of the Day</span>
 
-        <h2 className="font-display text-2xl font-semibold">{name}</h2>
+        <h2 className="font-display text-heading font-semibold">{name}</h2>
         {preview && (
           <div className="flex items-center gap-1">
             <p className="text-sm opacity-90">{preview}</p>

--- a/src/components/LogDetailsModal.jsx
+++ b/src/components/LogDetailsModal.jsx
@@ -14,7 +14,7 @@ export default function LogDetailsModal({ event, onClose }) {
       <div className="bg-white dark:bg-gray-700 rounded-lg shadow-lg p-4 w-72 max-w-full">
         <div className="flex items-center gap-2 mb-2">
           {Icon && <Icon className="w-5 h-5" aria-hidden="true" />}
-          <h3 className="font-headline text-lg">{event.label}</h3>
+          <h3 className="font-headline text-heading">{event.label}</h3>
         </div>
         <p className="text-sm mb-2">{formatDate(event.date)}</p>
         {event.note && (

--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -4,7 +4,7 @@ export default function PageHeader({ title, breadcrumb }) {
   return (
     <header className="mb-4 space-y-1 text-left">
       {breadcrumb && <Breadcrumb {...breadcrumb} />}
-      <h1 className="text-2xl font-bold font-headline">{title}</h1>
+      <h1 className="text-heading font-bold font-headline">{title}</h1>
     </header>
   )
 }

--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -40,7 +40,7 @@ export default function PersistentBottomNav() {
                 <LinkIcon className="w-6 h-6" aria-hidden="true" />
                 {label}
                 {showBadge && (
-                  <span className="absolute -top-1 -right-2 bg-red-600 text-white text-[10px] rounded-full px-1">
+                  <span className="absolute -top-1 -right-2 bg-red-600 text-white text-badge rounded-full px-1">
                     {overdueCount}
                   </span>
                 )}

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -214,7 +214,7 @@ export default function PlantCard({ plant }) {
           className="block mb-2"
         >
           <img src={plant.image} alt={plant.name} loading="lazy" className="plant-thumb" />
-          <h2 className="font-bold text-[1.1rem] font-headline mt-2">{plant.name}</h2>
+          <h2 className="font-bold text-heading font-headline mt-2">{plant.name}</h2>
         </Link>
         <p className="text-sm text-green-700 font-medium font-body">Next: {plant.nextWater}</p>
         <button

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -111,7 +111,7 @@ export default function TaskCard({
                 : task.type}
             </Badge>
             {daysSince != null && (
-              <span className="text-xs text-gray-400">
+              <span className="text-timestamp text-gray-400">
                 {daysSince} {daysSince === 1 ? 'day' : 'days'} since care
               </span>
             )}

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -16,7 +16,7 @@ export default function UnifiedTaskCard({ plant, urgent = false, overdue = false
 
   const lastText = lastCared ? formatDaysAgo(lastCared) : null
   const last = lastText ? (
-    <p className="text-xs text-gray-500">Last cared for {lastText}</p>
+    <p className="text-timestamp text-gray-500">Last cared for {lastText}</p>
   ) : null
 
   return (

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -55,7 +55,7 @@ test('renders task text', () => {
   expect(badge).toHaveClass('inline-flex')
   expect(badge).toHaveClass('bg-blue-100')
   expect(badge).toHaveClass('text-blue-800')
-  expect(badge).toHaveClass('text-xs')
+  expect(badge).toHaveClass('text-badge')
   expect(badge).toHaveClass('font-medium')
 })
 

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -189,7 +189,7 @@ exports[`matches snapshot in dark mode 1`] = `
         src="test.jpg"
       />
       <h2
-        class="font-bold text-[1.1rem] font-headline mt-2"
+        class="font-bold text-heading font-headline mt-2"
       >
         Aloe Vera
       </h2>

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`matches snapshot in dark mode 1`] = `
           class="flex items-center gap-2 mt-1"
         >
           <span
-            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-blue-100 text-blue-800"
+            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-badge font-medium bg-blue-100 text-blue-800"
           >
             <svg
               aria-hidden="true"
@@ -76,7 +76,7 @@ exports[`matches snapshot in dark mode 1`] = `
             To Water
           </span>
           <span
-            class="text-xs text-gray-400"
+            class="text-timestamp text-gray-400"
           >
             9
              

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -29,7 +29,7 @@ exports[`matches snapshot in dark mode 1`] = `
         class="flex items-center gap-2 mt-1"
       >
         <span
-          class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-xs font-medium bg-water-100/90 text-water-800"
+          class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-badge font-medium bg-water-100/90 text-water-800"
         >
           <svg
             aria-hidden="true"
@@ -66,7 +66,7 @@ exports[`matches snapshot in dark mode 1`] = `
         </span>
       </div>
       <p
-        class="text-xs text-gray-500"
+        class="text-timestamp text-gray-500"
       >
         Last cared for 
         3 days ago

--- a/src/index.css
+++ b/src/index.css
@@ -230,3 +230,18 @@ body {
 .plant-thumb {
   @apply w-full aspect-[3/4] object-cover rounded-xl;
 }
+
+@layer utilities {
+  .text-heading {
+    @apply text-2xl;
+  }
+  .text-body {
+    @apply text-base;
+  }
+  .text-badge {
+    @apply text-xs;
+  }
+  .text-timestamp {
+    @apply text-xs;
+  }
+}

--- a/src/pages/AddRoom.jsx
+++ b/src/pages/AddRoom.jsx
@@ -18,7 +18,7 @@ export default function AddRoom() {
   return (
     <PageContainer>
     <form onSubmit={handleSubmit} className="space-y-4">
-      <h1 className="text-2xl font-bold font-headline">Add Room</h1>
+      <h1 className="text-heading font-bold font-headline">Add Room</h1>
       <div className="grid gap-1">
         <label htmlFor="room-name" className="font-medium">Room Name</label>
         <input

--- a/src/pages/EditPlant.jsx
+++ b/src/pages/EditPlant.jsx
@@ -51,7 +51,7 @@ export default function EditPlant() {
   return (
     <PageContainer>
     <form onSubmit={handleSubmit} className="space-y-4">
-      <h1 className="text-2xl font-bold font-headline">Edit Plant</h1>
+      <h1 className="text-heading font-bold font-headline">Edit Plant</h1>
       <div className="grid gap-1">
         <label htmlFor="name" className="font-medium">Name</label>
         <input

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -4,7 +4,7 @@ import PageContainer from "../components/PageContainer.jsx"
 export default function Gallery() {
   return (
     <PageContainer>
-      <h2 className="text-2xl font-headline mb-4">Gallery</h2>
+      <h2 className="text-heading font-headline mb-4">Gallery</h2>
       <p className="text-gray-700 dark:text-gray-200">Coming soon...</p>
     </PageContainer>
   )

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -131,7 +131,7 @@ export default function MyPlants() {
                     <p className="text-sm text-gray-500 leading-none">{countPlants(room)} plants</p>
                   </div>
                 </div>
-                <div className="flex gap-1 text-[10px]">
+                <div className="flex gap-1 text-badge">
                   {wateredToday && (
                     <span role="img" aria-label="Watered today">💧</span>
                   )}
@@ -146,7 +146,7 @@ export default function MyPlants() {
                 {overdue > 0 && (
                   <Badge
                     variant="overdue"
-                    colorClass="slide-in animate-pulse rounded-full text-[11px]"
+                    colorClass="slide-in animate-pulse rounded-full text-badge"
                   >
                     ⚠️ {overdue} needs love
                   </Badge>

--- a/src/pages/NotFound.jsx
+++ b/src/pages/NotFound.jsx
@@ -4,7 +4,7 @@ import PageContainer from "../components/PageContainer.jsx"
 export default function NotFound() {
   return (
     <PageContainer className="text-center space-y-4">
-      <h1 className="text-2xl font-bold font-headline">Page Not Found</h1>
+      <h1 className="text-heading font-bold font-headline">Page Not Found</h1>
       <p className="text-gray-600">Sorry, we couldn\'t find that page.</p>
       <Link to="/" className="text-green-600 underline">
         Go to Today

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -193,7 +193,7 @@ export default function PlantDetail() {
           />
           <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent" aria-hidden="true"></div>
           <div className="absolute bottom-3 left-4 text-white drop-shadow">
-            <h2 className="text-2xl font-semibold font-headline">{plant.name}</h2>
+            <h2 className="text-heading font-semibold font-headline">{plant.name}</h2>
             {plant.nickname && (
               <p className="text-sm text-gray-200">{plant.nickname}</p>
             )}
@@ -227,7 +227,7 @@ export default function PlantDetail() {
             >
               <ProgressRing percent={progressPct} size={48} colorClass={ringClass} />
               <div
-                className={`absolute inset-1 rounded-full bg-white/80 flex items-center justify-center text-[10px] font-semibold ${ringClass}`}
+                className={`absolute inset-1 rounded-full bg-white/80 flex items-center justify-center text-badge font-semibold ${ringClass}`}
               >
                 {progressPct >= 1 ? 'Water Now' : `${Math.round(progressPct * 100)}%`}
               </div>
@@ -348,7 +348,7 @@ export default function PlantDetail() {
             const isCollapsed = collapsedMonths[monthKey]
             return (
               <div key={monthKey} className="mt-6 first:mt-0">
-                <h3 className="text-[0.7rem] uppercase tracking-wider text-gray-300 mb-2 flex items-center">
+                <h3 className="text-timestamp uppercase tracking-wider text-gray-300 mb-2 flex items-center">
                   <button
                     type="button"
                     aria-expanded={!isCollapsed}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -18,11 +18,11 @@ export default function Settings() {
 
   return (
     <PageContainer className="space-y-6 text-gray-700 dark:text-gray-200">
-      <h1 className="text-xl font-semibold font-headline">Settings</h1>
+      <h1 className="text-heading font-semibold font-headline">Settings</h1>
 
       <div className="space-y-4">
         <Panel>
-          <h2 className="flex items-center gap-2 mb-4 text-base font-medium font-headline">
+          <h2 className="flex items-center gap-2 mb-4 text-heading font-medium font-headline">
             <User className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
             Profile
           </h2>
@@ -51,7 +51,7 @@ export default function Settings() {
         </Panel>
 
         <Panel>
-          <h2 className="flex items-center gap-2 mb-4 text-base font-medium font-headline">
+          <h2 className="flex items-center gap-2 mb-4 text-heading font-medium font-headline">
             <MapPin className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
             Weather &amp; Location
           </h2>
@@ -82,7 +82,7 @@ export default function Settings() {
         </Panel>
 
         <Panel>
-          <h2 className="flex items-center gap-2 mb-4 text-base font-medium font-headline">
+          <h2 className="flex items-center gap-2 mb-4 text-heading font-medium font-headline">
             <Clock className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
             Preferences
           </h2>

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -351,7 +351,7 @@ export default function Tasks() {
             : dateKey
           return (
             <div key={dateKey}>
-              <h3 className="mt-4 text-sm font-semibold text-gray-500">{heading}</h3>
+              <h3 className="mt-4 text-heading font-semibold text-gray-500">{heading}</h3>
               <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-4'}>
                 {list.map((e, i) => {
                   const task = {

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -59,7 +59,7 @@ export default function Timeline() {
         <div className="relative">
           {groupedEvents.map(([monthKey, list]) => (
             <div key={monthKey} className="mt-6 first:mt-0">
-              <h3 className="sticky top-0 z-10 bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm px-1 text-[0.7rem] uppercase tracking-wider text-gray-500 mb-2">
+              <h3 className="sticky top-0 z-10 bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm px-1 text-timestamp uppercase tracking-wider text-gray-500 mb-2">
                 {formatMonth(monthKey)}
               </h3>
               <ul className="ml-3 border-l-2 border-gray-200 space-y-6 pl-5">

--- a/src/pages/add/ImageStep.jsx
+++ b/src/pages/add/ImageStep.jsx
@@ -15,7 +15,7 @@ export default function ImageStep({ image, dispatch, onNext, onBack }) {
   return (
     <PageContainer>
     <form onSubmit={e => {e.preventDefault(); onNext();}} className="space-y-4">
-      <h1 className="text-2xl font-bold font-headline">Add Plant</h1>
+      <h1 className="text-heading font-bold font-headline">Add Plant</h1>
       <div className="grid gap-1">
         <label htmlFor="image" className="font-medium">Image URL</label>
         <input

--- a/src/pages/add/NameStep.jsx
+++ b/src/pages/add/NameStep.jsx
@@ -10,7 +10,7 @@ export default function NameStep({ name, dispatch, onNext }) {
   return (
     <PageContainer>
     <form onSubmit={e => {e.preventDefault(); onNext();}} className="space-y-4">
-      <h1 className="text-2xl font-bold font-headline">Add Plant</h1>
+      <h1 className="text-heading font-bold font-headline">Add Plant</h1>
       <div className="grid gap-1">
         <label htmlFor="name" className="font-medium">Name</label>
         <input

--- a/src/pages/add/OptionalInfoStep.jsx
+++ b/src/pages/add/OptionalInfoStep.jsx
@@ -5,7 +5,7 @@ export default function OptionalInfoStep({ room, notes, careLevel, dispatch, onB
   return (
     <PageContainer>
     <form onSubmit={e => { e.preventDefault(); onSubmit(); }} className="space-y-4">
-      <h1 className="text-2xl font-bold font-headline">Add Plant</h1>
+      <h1 className="text-heading font-bold font-headline">Add Plant</h1>
       <div className="grid gap-1">
         <label htmlFor="room" className="font-medium">Room</label>
         <input

--- a/src/pages/add/ScheduleStep.jsx
+++ b/src/pages/add/ScheduleStep.jsx
@@ -3,7 +3,7 @@ export default function ScheduleStep({ lastWatered, nextWater, dispatch, onBack,
   return (
     <PageContainer>
     <form onSubmit={e => {e.preventDefault(); onSubmit();}} className="space-y-4">
-      <h1 className="text-2xl font-bold font-headline">Add Plant</h1>
+      <h1 className="text-heading font-bold font-headline">Add Plant</h1>
       <div className="grid gap-1">
         <label htmlFor="lastWatered" className="font-medium">Last Watered</label>
         <input


### PR DESCRIPTION
## Summary
- introduce text-heading, text-body, text-badge and text-timestamp utilities
- replace inline text sizing for headings, badges and timestamps
- update affected tests and snapshots

## Testing
- `npm test -- -u --watchAll=false`

------
https://chatgpt.com/codex/tasks/task_e_687a59239620832488e4ec0ed8bdd1e7