### PR TITLE
Align timeline icons over line

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -379,7 +379,7 @@ export default function PlantDetail() {
                       <li key={`${e.date}-${i}`} className="relative text-xs sm:text-sm">
                         {Icon && (
                           <div
-                            className={`absolute -left-5 top-[0.25rem] w-4 h-4 flex items-center justify-center rounded-full ${bulletColors[e.type]}`}
+                            className={`absolute -left-2 top-[0.25rem] w-4 h-4 flex items-center justify-center rounded-full ${bulletColors[e.type]} z-10`}
                           >
                             <Icon className="w-3 h-3 text-white" aria-hidden="true" />
                           </div>

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -74,7 +74,7 @@ export default function Timeline() {
                     >
                       {Icon && (
                         <div
-                          className={`absolute -left-5 top-[0.25rem] w-4 h-4 flex items-center justify-center rounded-full ${bulletColors[e.type]}`}
+                          className={`absolute -left-2 top-[0.25rem] w-4 h-4 flex items-center justify-center rounded-full ${bulletColors[e.type]} z-10`}
                         >
                           <Icon className="w-3 h-3 text-white" aria-hidden="true" />
                         </div>


### PR DESCRIPTION
## Summary
- align timeline icons so the vertical line runs behind them

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687a6915a6108324815c6a792c0e5808