### PR TITLE
Fix event dates for notes

### DIFF
--- a/src/utils/__tests__/events.test.js
+++ b/src/utils/__tests__/events.test.js
@@ -70,3 +70,24 @@ test('groupEventsByMonth sorts months chronologically', () => {
     ['2099-12', [events[0]]],
   ])
 })
+
+test('timeline events never have dates in the future', () => {
+  const plant = {
+    notes: 'keep soil moist',
+    advancedCare: 'requires misting',
+  }
+
+  const events = buildEvents(plant)
+  const today = new Date().toISOString().slice(0, 10)
+  const now = new Date()
+
+  const noteEvent = events.find(e => e.type === 'noteText')
+  const advEvent = events.find(e => e.type === 'advanced')
+
+  expect(noteEvent.date).toBe(today)
+  expect(advEvent.date).toBe(today)
+
+  events.forEach(e => {
+    expect(new Date(e.date).getTime()).toBeLessThanOrEqual(now.getTime())
+  })
+})

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -2,6 +2,7 @@ export function buildEvents(source, { includePlantName = false } = {}) {
   const plants = Array.isArray(source) ? source : [source].filter(Boolean)
   const events = []
   const added = new Set()
+  const today = new Date().toISOString().slice(0, 10)
 
   const addEvent = (e) => {
     const key = `${e.type}-${e.date}`
@@ -69,7 +70,7 @@ export function buildEvents(source, { includePlantName = false } = {}) {
 
     if (p.notes) {
       addEvent({
-        date: '2100-01-01',
+        date: today,
         label: includePlantName ? `${p.name} note` : 'Note',
         note: p.notes,
         type: 'noteText',
@@ -78,7 +79,7 @@ export function buildEvents(source, { includePlantName = false } = {}) {
 
     if (p.advancedCare) {
       addEvent({
-        date: '2100-01-01',
+        date: today,
         label: includePlantName ? `${p.name} care tip` : 'Advanced care',
         note: p.advancedCare,
         type: 'advanced',


### PR DESCRIPTION
## Summary
- ensure note and advanced care timeline events never use future dates
- verify events are not dated beyond today

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687ac224f0748324b410b6903f2c1186