### PR TITLE
Improve plant detail tags and CTA

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -5,6 +5,7 @@ export default function Badge({
   Icon,
   variant,
   colorClass,
+  size = 'base',
 }) {
   const variants = {
     info: 'bg-blue-100 text-blue-800',
@@ -14,9 +15,16 @@ export default function Badge({
 
   const cls = colorClass || variants[variant] || 'bg-gray-200 text-gray-800'
 
+  const sizeClasses = {
+    base: 'px-2 py-0.5 text-badge',
+    sm: 'px-1.5 py-0 text-[10px]',
+  }
+
+  const sizeClass = sizeClasses[size] || sizeClasses.base
+
   return (
     <span
-      className={`inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-badge font-medium ${cls}`}
+      className={`inline-flex items-center gap-1 rounded-full font-medium ${sizeClass} ${cls}`}
     >
       {Icon && <Icon className="w-3 h-3" aria-hidden="true" />}
       {children}

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -40,7 +40,7 @@ exports[`matches snapshot in dark mode 1`] = `
           class="flex items-center gap-2 mt-1"
         >
           <span
-            class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-badge font-medium bg-blue-100 text-blue-800"
+            class="inline-flex items-center gap-1 rounded-full font-medium px-2 py-0.5 text-badge bg-blue-100 text-blue-800"
           >
             <svg
               aria-hidden="true"

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -29,7 +29,7 @@ exports[`matches snapshot in dark mode 1`] = `
         class="flex items-center gap-2 mt-1"
       >
         <span
-          class="inline-flex items-center gap-1 px-2 py-0.5 rounded-full text-badge font-medium bg-water-100/90 text-water-800"
+          class="inline-flex items-center gap-1 rounded-full font-medium px-2 py-0.5 text-badge bg-water-100/90 text-water-800"
         >
           <svg
             aria-hidden="true"

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -199,26 +199,36 @@ export default function PlantDetail() {
             )}
           </div>
           <div
-            className="absolute top-2 right-2 z-10 flex flex-wrap gap-4"
+            className="absolute top-2 right-2 z-10 flex flex-wrap gap-2"
             aria-label="Care tags"
           >
             {plant.light && (
-              <Badge Icon={Sun} variant="info">
+              <Badge Icon={Sun} variant="info" size="sm">
                 {plant.light}
               </Badge>
             )}
             {plant.humidity && (
-              <Badge Icon={Drop} variant="info">
+              <Badge Icon={Drop} variant="info" size="sm">
                 {plant.humidity}
               </Badge>
             )}
             {plant.difficulty && (
-              <Badge Icon={Gauge} variant="info">
+              <Badge Icon={Gauge} variant="info" size="sm">
                 {plant.difficulty}
               </Badge>
             )}
           </div>
-          <div className="absolute bottom-2 right-2 flex gap-4" data-testid="progress-rings">
+          <div className="absolute bottom-2 right-2 flex items-center gap-2" data-testid="progress-rings">
+            {progressPct >= 1 && (
+              <button
+                type="button"
+                onClick={handleWatered}
+                aria-label={`Mark ${plant.name} as watered`}
+                className="px-3 py-1 bg-blue-600 text-white rounded-full shadow text-sm"
+              >
+                Water Now
+              </button>
+            )}
             <div
               className="relative"
               style={{ width: 48, height: 48 }}

--- a/src/pages/__tests__/PlantDetailActions.test.jsx
+++ b/src/pages/__tests__/PlantDetailActions.test.jsx
@@ -51,7 +51,7 @@ test('quick stats action buttons trigger handlers', () => {
   )
 
   fireEvent.click(
-    screen.getByRole('button', { name: /mark plant a as watered/i })
+    screen.getAllByRole('button', { name: /mark plant a as watered/i })[0]
   )
   expect(markWatered).toHaveBeenCalledWith(1, '')
 


### PR DESCRIPTION
## Summary
- allow smaller badges with new `size` prop
- shrink plant detail care tags and place them closer together
- add prominent **Water Now** button next to watering ring
- update tests and snapshots for new UI

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ac15156788324b07c6fad3475f554