### PR TITLE
Align PlantDetail timeline with global style

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -358,7 +358,7 @@ export default function PlantDetail() {
             const isCollapsed = collapsedMonths[monthKey]
             return (
               <div key={monthKey} className="mt-6 first:mt-0">
-                <h3 className="text-timestamp uppercase tracking-wider text-gray-300 mb-2 flex items-center">
+                <h3 className="sticky top-0 z-10 bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm px-1 text-timestamp uppercase tracking-wider text-gray-300 mb-2 flex items-center">
                   <button
                     type="button"
                     aria-expanded={!isCollapsed}
@@ -381,7 +381,7 @@ export default function PlantDetail() {
                 <ul
                   className={`${
                     isCollapsed ? 'hidden' : ''
-                  } ml-3 border-l-2 border-gray-200 space-y-6 pl-5`}
+                  } relative ml-3 space-y-6 pl-5 before:absolute before:inset-y-0 before:left-2 before:w-px before:bg-gray-200`}
                 >
                   {list.map((e, i) => {
                     const Icon = actionIcons[e.type]

--- a/src/pages/__tests__/PlantDetailCareLog.test.jsx
+++ b/src/pages/__tests__/PlantDetailCareLog.test.jsx
@@ -42,3 +42,18 @@ test('shows notes from care log in timeline', () => {
   expect(screen.getByText('deep soak')).toBeInTheDocument()
 
 })
+
+test('timeline bullet markup matches snapshot', () => {
+  const { container } = render(
+    <MenuProvider>
+      <MemoryRouter initialEntries={['/plant/1']}>
+        <Routes>
+          <Route path="/plant/:id" element={<PlantDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </MenuProvider>
+  )
+
+  const list = container.querySelector('ul')
+  expect(list).toMatchSnapshot()
+})

--- a/src/pages/__tests__/__snapshots__/PlantDetailCareLog.test.jsx.snap
+++ b/src/pages/__tests__/__snapshots__/PlantDetailCareLog.test.jsx.snap
@@ -1,0 +1,94 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`timeline bullet markup matches snapshot 1`] = `
+<ul
+  class=" relative ml-3 space-y-6 pl-5 before:absolute before:inset-y-0 before:left-2 before:w-px before:bg-gray-200"
+>
+  <li
+    class="relative text-xs sm:text-sm"
+  >
+    <div
+      class="absolute -left-5 top-[0.25rem] w-4 h-4 flex items-center justify-center rounded-full bg-green-500 z-10"
+    >
+      <svg
+        aria-hidden="true"
+        class="w-3 h-3 text-white"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 256 256"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect
+          fill="none"
+          height="256"
+          width="256"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="112"
+          x2="176"
+          y1="112"
+          y2="112"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="112"
+          x2="176"
+          y1="144"
+          y2="144"
+        />
+        <rect
+          fill="none"
+          height="176"
+          rx="8"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          width="176"
+          x="40"
+          y="40"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="80"
+          x2="80"
+          y1="40"
+          y2="216"
+        />
+      </svg>
+    </div>
+    <div
+      class="flex items-start bg-gray-50 dark:bg-gray-700 rounded-xl p-3 shadow-sm"
+    >
+      <div>
+        <span
+          class="font-medium"
+        >
+          July 2, 2025
+        </span>
+         — 
+        Watered
+        <div
+          class="text-xs italic text-green-700 mt-1"
+        >
+          deep soak
+        </div>
+      </div>
+    </div>
+  </li>
+</ul>
+`;


### PR DESCRIPTION
## Summary
- update `PlantDetail` timeline heading to use sticky positioning
- switch timeline `<ul>` to pseudo-element border for parity with `Timeline`
- add snapshot test verifying bullet markup

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687ac518f9888324b3d7e95a6d6b1b23