### PR TITLE
Extend timeline bullet colors

### DIFF
--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -50,6 +50,8 @@ export default function Timeline() {
     fertilize: 'bg-yellow-500',
     note: 'bg-gray-400',
     log: 'bg-green-500',
+    advanced: 'bg-purple-500',
+    noteText: 'bg-gray-400',
   }
 
   return (


### PR DESCRIPTION
## Summary
- add `advanced` and `noteText` bullet colors to the timeline page

## Testing
- `npx jest --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_687ac60158688324b2e0146928387943