### PR TITLE
UI polish for plant care views

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,6 +1,9 @@
 export default function Card({ as: Component = 'div', className = '', children, ...props }) {
   return (
-    <Component className={`bg-white dark:bg-gray-700 rounded-2xl shadow-sm p-4 ${className}`} {...props}>
+    <Component
+      className={`bg-white dark:bg-gray-700 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-600 p-4 ${className}`}
+      {...props}
+    >
       {children}
     </Component>
   )

--- a/src/components/CreateFab.jsx
+++ b/src/components/CreateFab.jsx
@@ -28,14 +28,14 @@ export default function CreateFab() {
     <div className="fixed bottom-24 right-20 z-30">
       {open && (
         <div
-          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
+          className="fixed inset-0 bg-black/60 flex items-center justify-center z-30 backdrop-blur-sm"
           role="dialog"
           aria-modal="true"
           aria-label="Add menu"
           onClick={() => setOpen(false)}
         >
           <ul
-            className="relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
+            className="relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-4 animate-fade-in-up"
             onClick={e => e.stopPropagation()}
           >
             <button
@@ -52,7 +52,7 @@ export default function CreateFab() {
                   to={to}
                   onClick={() => setOpen(false)}
                   title={label}
-                  className="flex items-center gap-3 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
+                  className="flex items-center gap-3 w-full rounded-lg p-3 hover:bg-green-50 dark:hover:bg-gray-600 transition"
                 >
                   <span className={`p-2 rounded-full ${colorClasses[color].bg}`}>
                     <Icon className={`w-5 h-5 ${colorClasses[color].text}`} aria-hidden="true" />

--- a/src/components/PlantDetailFab.jsx
+++ b/src/components/PlantDetailFab.jsx
@@ -27,14 +27,14 @@ export default function PlantDetailFab({ onAddPhoto, onAddNote }) {
     <div className="absolute bottom-4 right-4 z-30">
       {open && (
         <div
-          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
+          className="fixed inset-0 bg-black/60 flex items-center justify-center z-30 backdrop-blur-sm"
           role="dialog"
           aria-modal="true"
           aria-label="Add menu"
           onClick={() => setOpen(false)}
         >
           <ul
-            className="relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
+            className="relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-4 animate-fade-in-up"
             onClick={e => e.stopPropagation()}
           >
             <button
@@ -54,7 +54,7 @@ export default function PlantDetailFab({ onAddPhoto, onAddNote }) {
                     action?.()
                   }}
                   title={label}
-                  className="flex items-center gap-3 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
+                  className="flex items-center gap-3 w-full rounded-lg p-3 hover:bg-green-50 dark:hover:bg-gray-600 transition"
                 >
                   <span className={`p-2 rounded-full ${colorClasses[color].bg}`}>
                     <Icon className={`w-5 h-5 ${colorClasses[color].text}`} aria-hidden="true" />

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -175,7 +175,7 @@ exports[`matches snapshot in dark mode 1`] = `
     </div>
   </div>
   <div
-    class="bg-white dark:bg-gray-700 rounded-2xl shadow-sm p-4 "
+    class="bg-white dark:bg-gray-700 rounded-2xl shadow-sm border border-gray-200 dark:border-gray-600 p-4 "
     style="transform: translateX(0px); transition: transform 0.2s;"
   >
     <a

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -76,7 +76,7 @@ export default function MyPlants() {
   return (
     <PageContainer>
       <PageHeader title="All Plants" />
-      <div className="flex items-center gap-4 mb-2">
+      <div className="flex items-center justify-between gap-4 mb-3">
         <label className="text-sm">
           Sort
           <select
@@ -124,7 +124,7 @@ export default function MyPlants() {
                     alt={`Photo of the ${room} room`}
                   />
                   <div
-                    className="absolute inset-0 rounded-md bg-gradient-to-t from-black/60 via-black/30 to-transparent"
+                    className="absolute inset-0 rounded-md bg-gradient-to-t from-black/70 via-black/40 to-transparent"
                     aria-hidden="true"
                   ></div>
                   <div className="absolute bottom-1 left-2 right-2 text-white drop-shadow space-y-0.5">
@@ -132,7 +132,7 @@ export default function MyPlants() {
                     <p className="text-sm text-gray-500 leading-none">{countPlants(room)} plants</p>
                   </div>
                 </div>
-                <div className="flex gap-1 text-badge">
+                <div className="flex gap-2 text-badge mt-1">
                   {wateredToday && (
                     <span role="img" aria-label="Watered today">💧</span>
                   )}
@@ -145,12 +145,14 @@ export default function MyPlants() {
                   {lastUpdated && <span>{formatDaysAgo(lastUpdated)}</span>}
                 </div>
                 {overdue > 0 && (
-                  <Badge
-                    variant="overdue"
-                    colorClass="slide-in animate-pulse rounded-full text-badge"
-                  >
-                    ⚠️ {overdue} needs love
-                  </Badge>
+                  <div className="mt-1">
+                    <Badge
+                      variant="overdue"
+                      colorClass="slide-in animate-pulse rounded-full text-badge"
+                    >
+                      ⚠️ {overdue} needs love
+                    </Badge>
+                  </div>
                 )}
               </Card>
             </Link>

--- a/src/pages/RoomList.jsx
+++ b/src/pages/RoomList.jsx
@@ -85,12 +85,12 @@ export default function RoomList() {
                     loading="lazy"
                     className="plant-thumb"
                   />
-                  <span className="absolute top-1 left-1 bg-black/60 text-white text-xs px-1 rounded">
+                  <span className="absolute top-1 left-1 bg-black/70 text-white text-xs px-1 rounded">
                     {plant.name}
                   </span>
                   <Badge
                     Icon={Drop}
-                    colorClass={`absolute bottom-1 left-1 text-xs ${colorClass}`}
+                    colorClass={`absolute bottom-1 left-1 text-xs whitespace-nowrap ${colorClass}`}
                   >
                     {status}
                   </Badge>


### PR DESCRIPTION
## Summary
- add subtle border to Card component for depth
- tweak layout on All Plants page and improve overlays
- adjust spacing in room cards
- improve FAB backdrop and touch targets
- ensure plant status labels don't wrap

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687ac1f976ac8324b6ee724fe886e0ab