### PR TITLE
Improve home view layout and remove water button

### DIFF
--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -92,15 +92,7 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
             )}
           </div>
         )}
-        <div className="flex gap-2">
-          <button
-            type="button"
-            aria-label={`Mark ${name} as watered`}
-            className="px-4 py-2 bg-gradient-to-b from-blue-500 to-blue-600 text-white rounded-full shadow-md shadow-blue-600/30 text-sm animate-bounce-once"
-          >
-            Water Now
-          </button>
-        </div>
+        {/* Action buttons were removed to keep the card minimal */}
 
       </div>
     </Link>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -229,9 +229,13 @@ export default function Home() {
       </header>
       )}
     {plants.length > 0 && (
-      <section className="mb-4">
+      <section className="mb-4 space-y-2">
         <h2 className="sr-only">Featured Plant</h2>
         <FeaturedCard plants={plants} startIndex={featuredIndex} />
+        <hr
+          className="mx-auto w-16 border-t border-dashed border-neutral-300 dark:border-gray-600"
+          aria-hidden="true"
+        />
       </section>
     )}
     <CareStats


### PR DESCRIPTION
## Summary
- remove 'Water Now' button from the featured card so it doesn't dominate
- add a dashed divider under the featured plant to connect it with today's tasks

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687af1fb00248324b6e9077375d9c596