### PR TITLE
Improve All Plants grid styling

### DIFF
--- a/src/components/Card.jsx
+++ b/src/components/Card.jsx
@@ -1,6 +1,6 @@
 export default function Card({ as: Component = 'div', className = '', children, ...props }) {
   return (
-    <Component className={`bg-white dark:bg-gray-700 rounded-2xl shadow-sm p-4 ${className}`} {...props}>
+    <Component className={`bg-white dark:bg-gray-700 rounded-2xl shadow p-4 ${className}`} {...props}>
       {children}
     </Component>
   )

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -175,7 +175,7 @@ exports[`matches snapshot in dark mode 1`] = `
     </div>
   </div>
   <div
-    class="bg-white dark:bg-gray-700 rounded-2xl shadow-sm p-4 "
+    class="bg-white dark:bg-gray-700 rounded-2xl shadow p-4 "
     style="transform: translateX(0px); transition: transform 0.2s;"
   >
     <a

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Plus } from 'phosphor-react'
+import { Plus, Drop, Sun, Bug, WarningCircle } from 'phosphor-react'
 import { getNextWateringDate } from '../utils/watering.js'
 
 import Badge from '../components/Badge.jsx'
@@ -134,13 +134,13 @@ export default function MyPlants() {
                 </div>
                 <div className="flex gap-1 text-badge">
                   {wateredToday && (
-                    <span role="img" aria-label="Watered today">💧</span>
+                    <Drop className="w-4 h-4" aria-hidden="true" />
                   )}
                   {lowLight && (
-                    <span role="img" aria-label="Low light">☀️</span>
+                    <Sun className="w-4 h-4" aria-hidden="true" />
                   )}
                   {pestAlert && (
-                    <span role="img" aria-label="Pest alert">🐛</span>
+                    <Bug className="w-4 h-4" aria-hidden="true" />
                   )}
                   {lastUpdated && <span>{formatDaysAgo(lastUpdated)}</span>}
                 </div>
@@ -148,8 +148,9 @@ export default function MyPlants() {
                   <Badge
                     variant="overdue"
                     colorClass="slide-in animate-pulse rounded-full text-badge"
+                    Icon={WarningCircle}
                   >
-                    ⚠️ {overdue} needs love
+                    {overdue} needs love
                   </Badge>
                 )}
               </Card>

--- a/src/pages/__tests__/MyPlants.test.jsx
+++ b/src/pages/__tests__/MyPlants.test.jsx
@@ -64,7 +64,7 @@ test('shows overdue badge for rooms with tasks', () => {
   const badge = screen
     .getAllByText(/needs love/i)
     .find(el => el.tagName === 'SPAN')
-  expect(badge).toHaveTextContent('⚠️ 2 needs love')
+  expect(badge).toHaveTextContent('2 needs love')
 
   jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- add more pronounced shadow to `Card`
- replace emoji in room grid with Phosphor icons
- update snapshot and test expectations

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_687af28c6ce083249f5013513a92180d