### PR TITLE
Improve overdue task styling

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -10,7 +10,7 @@ export default function Badge({
   const variants = {
     info: 'bg-blue-100 text-blue-800',
     urgent: 'bg-yellow-100 text-yellow-700',
-    overdue: 'bg-red-100 text-red-600',
+    overdue: 'bg-red-50 text-red-500',
     complete: 'bg-green-100 text-green-800',
   }
 

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -57,7 +57,7 @@ export default function TaskCard({
       data-testid="task-card"
       tabIndex="0"
       aria-label={`Task card for ${task.plantName}`}
-      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow-sm border border-neutral-200 dark:border-gray-600 ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-neutral-50 dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
+      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-neutral-50 dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
       style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
       onPointerDown={start}
       onPointerMove={move}

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -1,6 +1,6 @@
 import React, { useState } from 'react'
 
-import { Drop, Sun, CheckCircle } from 'phosphor-react'
+import { Drop, Sun, CheckCircle, WarningCircle } from 'phosphor-react'
 import { formatDaysAgo } from '../utils/dateFormat.js'
 import { useNavigate } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
@@ -23,7 +23,7 @@ export default function UnifiedTaskCard({
   const { Snackbar, showSnackbar } = useSnackbar()
 
   const bgClass = overdue
-    ? 'bg-red-50 dark:bg-red-900'
+    ? 'bg-red-50 dark:bg-red-800'
     : urgent
     ? 'bg-yellow-50 dark:bg-yellow-900'
     : 'bg-gray-50 dark:bg-gray-800'
@@ -34,13 +34,13 @@ export default function UnifiedTaskCard({
   ) : null
 
   const waterColor = overdue
-    ? 'bg-red-100 text-red-600'
+    ? 'bg-red-50 text-red-500'
     : urgent
     ? 'bg-yellow-100 text-yellow-700'
     : 'bg-water-100/90 text-water-800'
 
   const fertColor = overdue
-    ? 'bg-red-100 text-red-600'
+    ? 'bg-red-50 text-red-500'
     : urgent
     ? 'bg-yellow-100 text-yellow-700'
     : 'bg-fertilize-100/90 text-fertilize-800'
@@ -80,7 +80,7 @@ export default function UnifiedTaskCard({
   return (
     <div
       data-testid="unified-task-card"
-      className={`relative rounded-2xl border border-neutral-200 dark:border-gray-600 shadow-sm overflow-hidden ${bgClass}`}
+      className={`relative rounded-2xl border border-neutral-200 dark:border-gray-600 shadow overflow-hidden ${bgClass}`}
       style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
       onPointerDown={start}
       onPointerMove={move}
@@ -97,7 +97,9 @@ export default function UnifiedTaskCard({
               {name}
             </p>
             {overdue ? (
-              <Badge variant="overdue" size="sm">Overdue</Badge>
+              <Badge variant="overdue" size="sm" Icon={WarningCircle}>
+                Overdue
+              </Badge>
             ) : urgent ? (
               <Badge variant="urgent" size="sm">Today</Badge>
             ) : null}

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -67,7 +67,7 @@ test('incomplete tasks show alert style', () => {
       </BaseCard>
     </MemoryRouter>
   )
-  const wrapper = container.querySelector('.shadow-sm')
+  const wrapper = container.querySelector('.shadow')
   expect(wrapper).toHaveClass('bg-neutral-50')
 })
 
@@ -79,7 +79,7 @@ test('applies highlight when urgent', () => {
       </BaseCard>
     </MemoryRouter>
   )
-  const wrapper = container.querySelector('.shadow-sm')
+  const wrapper = container.querySelector('.shadow')
   expect(wrapper).toHaveClass('ring-green-300')
   expect(wrapper).toHaveClass('dark:ring-green-400')
 })
@@ -93,7 +93,7 @@ test('shows completed state', () => {
       </BaseCard>
     </MemoryRouter>
   )
-  const wrapper = container.querySelector('.shadow-sm')
+  const wrapper = container.querySelector('.shadow')
   expect(wrapper).toHaveClass('opacity-50')
   expect(wrapper).toHaveClass('bg-gray-100')
   expect(container.querySelector('.check-pop')).toBeInTheDocument()

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`matches snapshot in dark mode 1`] = `
 >
   <div
     aria-label="Task card for Monstera"
-    class="relative flex items-center p-5 gap-4 rounded-2xl shadow-sm border border-neutral-200 dark:border-gray-600 bg-neutral-50 dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
+    class="relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 bg-neutral-50 dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
     data-testid="task-card"
     style="transform: translateX(0px); transition: transform 0.2s;"
     tabindex="0"

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`matches snapshot in dark mode 1`] = `
 <div
-  class="relative rounded-2xl border border-neutral-200 dark:border-gray-600 shadow-sm overflow-hidden bg-gray-50 dark:bg-gray-800"
+  class="relative rounded-2xl border border-neutral-200 dark:border-gray-600 shadow overflow-hidden bg-gray-50 dark:bg-gray-800"
   data-testid="unified-task-card"
   style="transform: translateX(0px); transition: transform 0.2s;"
 >


### PR DESCRIPTION
## Summary
- soften overdue badge color
- add warning icon to Overdue badge
- lighten overdue card background
- add subtle shadow to task cards
- update unit tests and snapshots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687af331c8988324b6923c6e3eb84cf9