### PR TITLE
Reverse timeline order

### DIFF
--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -36,10 +36,11 @@ export default function Timeline() {
     [plantEvents, noteEvents]
   )
 
-  const groupedEvents = useMemo(
-    () => groupEventsByMonth(events),
-    [events]
-  )
+  const groupedEvents = useMemo(() => {
+    return groupEventsByMonth(events)
+      .map(([month, list]) => [month, [...list].reverse()])
+      .reverse()
+  }, [events])
 
   const [selectedEvent, setSelectedEvent] = useState(null)
 

--- a/src/pages/__tests__/Timeline.test.jsx
+++ b/src/pages/__tests__/Timeline.test.jsx
@@ -33,10 +33,10 @@ test('ignores activities without valid dates when generating events', () => {
 
   const items = screen.getAllByRole('listitem')
   expect(items).toHaveLength(4)
-  expect(items[0]).toHaveTextContent('Fertilized Plant A')
-  expect(items[1]).toHaveTextContent('Plant B: Watered')
-  expect(items[2]).toHaveTextContent('Watered Plant B')
-  expect(items[3]).toHaveTextContent('Watered Plant A')
+  expect(items[0]).toHaveTextContent('Watered Plant A')
+  expect(items[1]).toHaveTextContent('Watered Plant B')
+  expect(items[2]).toHaveTextContent('Plant B: Watered')
+  expect(items[3]).toHaveTextContent('Fertilized Plant A')
 })
 
 test('renders care log notes', () => {
@@ -71,6 +71,6 @@ test('displays month headers when events span months', () => {
 
   const headings = screen.getAllByRole('heading', { level: 3 })
   expect(headings).toHaveLength(2)
-  expect(headings[0]).toHaveTextContent('July 2025')
-  expect(headings[1]).toHaveTextContent('August 2025')
+  expect(headings[0]).toHaveTextContent('August 2025')
+  expect(headings[1]).toHaveTextContent('July 2025')
 })


### PR DESCRIPTION
## Summary
- show most recent timeline events first
- adjust Timeline tests for reversed ordering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687af9c034608324a54cfdf765a84c6b