### PR TITLE
Add swipe action bar to TaskCards

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,4 +1,4 @@
-import { Drop, Sun } from 'phosphor-react'
+import { Drop, Sun, PencilSimpleLine, ClockCounterClockwise, Trash } from 'phosphor-react'
 import { useNavigate } from 'react-router-dom'
 import { getWateringInfo } from '../utils/watering.js'
 import { usePlants } from '../PlantContext.jsx'
@@ -35,6 +35,35 @@ export default function TaskCard({
     }
   }
 
+  const handleEdit = () => {
+    const room = task.room ? encodeURIComponent(task.room) : null
+    navigate(
+      room ? `/room/${room}/plant/${task.plantId}/edit` : `/plant/${task.plantId}/edit`
+    )
+  }
+
+  const handleReschedule = () => {
+    const prev = plants.find(p => p.id === task.plantId)
+    const next = new Date(task.date || new Date())
+    next.setDate(next.getDate() + 1)
+    const updates =
+      task.type === 'Water'
+        ? { nextWater: next.toISOString().slice(0, 10) }
+        : { nextFertilize: next.toISOString().slice(0, 10) }
+    updatePlant(task.plantId, updates)
+    showSnackbar('Rescheduled', () => updatePlant(task.plantId, prev))
+  }
+
+  const handleDelete = () => {
+    const prev = plants.find(p => p.id === task.plantId)
+    const updates =
+      task.type === 'Water'
+        ? { nextWater: null }
+        : { nextFertilize: null }
+    updatePlant(task.plantId, updates)
+    showSnackbar('Deleted', () => updatePlant(task.plantId, prev))
+  }
+
   const { dx, start, move, end } = useSwipe(
     diff => {
       if (!swipeable) return
@@ -51,6 +80,8 @@ export default function TaskCard({
     { threshold: 30 }
   )
 
+  const showActionBar = dx < 0 && dx > -60
+
   return (
     <>
     <div
@@ -64,6 +95,39 @@ export default function TaskCard({
       onPointerUp={end}
       onPointerCancel={end}
     >
+      <div
+        className={`task-action-bar ${showActionBar ? 'show' : ''}`}
+        role="group"
+        aria-label="Task actions"
+      >
+        <button
+          type="button"
+          aria-label="Edit task"
+          onClick={handleEdit}
+          className="task-action bg-blue-600 text-white"
+        >
+          <PencilSimpleLine className="w-4 h-4" aria-hidden="true" />
+          Edit
+        </button>
+        <button
+          type="button"
+          aria-label="Reschedule task"
+          onClick={handleReschedule}
+          className="task-action bg-yellow-600 text-white"
+        >
+          <ClockCounterClockwise className="w-4 h-4" aria-hidden="true" />
+          Reschedule
+        </button>
+        <button
+          type="button"
+          aria-label="Delete task"
+          onClick={handleDelete}
+          className="task-action bg-red-600 text-white"
+        >
+          <Trash className="w-4 h-4" aria-hidden="true" />
+          Delete
+        </button>
+      </div>
       <div className="flex items-center flex-1 gap-4">
       <button
         type="button"

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -1,6 +1,14 @@
 import React, { useState } from 'react'
 
-import { Drop, Sun, CheckCircle, WarningCircle } from 'phosphor-react'
+import {
+  Drop,
+  Sun,
+  CheckCircle,
+  WarningCircle,
+  PencilSimpleLine,
+  ClockCounterClockwise,
+  Trash,
+} from 'phosphor-react'
 import { formatDaysAgo } from '../utils/dateFormat.js'
 import { useNavigate } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
@@ -64,6 +72,29 @@ export default function UnifiedTaskCard({
     }
   }
 
+  const handleEdit = () => {
+    const room = plant.room ? encodeURIComponent(plant.room) : null
+    navigate(room ? `/room/${room}/plant/${plant.id}/edit` : `/plant/${plant.id}/edit`)
+  }
+
+  const handleReschedule = () => {
+    const prev = plants.find(p => p.id === plant.id)
+    const next = new Date(plant.nextWater || plant.nextFertilize || new Date())
+    next.setDate(next.getDate() + 1)
+    const updates = dueWater
+      ? { nextWater: next.toISOString().slice(0, 10) }
+      : { nextFertilize: next.toISOString().slice(0, 10) }
+    updatePlant(plant.id, updates)
+    showSnackbar('Rescheduled', () => updatePlant(plant.id, prev))
+  }
+
+  const handleDelete = () => {
+    const prev = plants.find(p => p.id === plant.id)
+    const updates = dueWater ? { nextWater: null } : { nextFertilize: null }
+    updatePlant(plant.id, updates)
+    showSnackbar('Deleted', () => updatePlant(plant.id, prev))
+  }
+
   const { dx, start, move, end } = useSwipe(
     diff => {
       if (!swipeable) return
@@ -77,6 +108,8 @@ export default function UnifiedTaskCard({
     { threshold: 30 }
   )
 
+  const showActionBar = dx < 0 && dx > -60
+
   return (
     <div
       data-testid="unified-task-card"
@@ -87,6 +120,39 @@ export default function UnifiedTaskCard({
       onPointerUp={end}
       onPointerCancel={end}
     >
+      <div
+        className={`task-action-bar ${showActionBar ? 'show' : ''}`}
+        role="group"
+        aria-label="Task actions"
+      >
+        <button
+          type="button"
+          aria-label="Edit task"
+          onClick={handleEdit}
+          className="task-action bg-blue-600 text-white"
+        >
+          <PencilSimpleLine className="w-4 h-4" aria-hidden="true" />
+          Edit
+        </button>
+        <button
+          type="button"
+          aria-label="Reschedule task"
+          onClick={handleReschedule}
+          className="task-action bg-yellow-600 text-white"
+        >
+          <ClockCounterClockwise className="w-4 h-4" aria-hidden="true" />
+          Reschedule
+        </button>
+        <button
+          type="button"
+          aria-label="Delete task"
+          onClick={handleDelete}
+          className="task-action bg-red-600 text-white"
+        >
+          <Trash className="w-4 h-4" aria-hidden="true" />
+          Delete
+        </button>
+      </div>
       <div className="flex items-center gap-4 p-4">
         <div className="w-14 h-14 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-700">
           <img src={image} alt={name} className="w-12 h-12 rounded-full object-cover" />

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, useNavigate } from 'react-router-dom'
 import TaskCard from '../TaskCard.jsx'
 import BaseCard from '../BaseCard.jsx'
@@ -7,6 +7,7 @@ import { usePlants } from '../../PlantContext.jsx'
 const navigateMock = jest.fn()
 const markWatered = jest.fn()
 const markFertilized = jest.fn()
+const updatePlant = jest.fn()
 
 jest.mock('react-router-dom', () => {
   const actual = jest.requireActual('react-router-dom')
@@ -28,6 +29,7 @@ beforeEach(() => {
     plants: [],
     markWatered,
     markFertilized,
+    updatePlant,
   })
 })
 
@@ -139,6 +141,26 @@ test('compact mode hides reason and evapotranspiration info', () => {
   )
   expect(screen.queryByText('Needs water')).not.toBeInTheDocument()
   expect(screen.queryByText(/Evapotranspiration/)).not.toBeInTheDocument()
+})
+
+test('partial left swipe reveals actions', () => {
+  render(
+    <MemoryRouter>
+      <BaseCard variant="task">
+        <TaskCard task={task} />
+      </BaseCard>
+    </MemoryRouter>
+  )
+  const wrapper = screen.getByTestId('task-card')
+  fireEvent.pointerDown(wrapper, { clientX: 100, buttons: 1 })
+  fireEvent.pointerMove(wrapper, { clientX: 70, buttons: 1 })
+  expect(screen.getByRole('button', { name: /edit task/i })).toBeInTheDocument()
+  fireEvent.click(screen.getByRole('button', { name: /edit task/i }))
+  expect(navigateMock).toHaveBeenCalledWith('/plant/1/edit')
+  fireEvent.click(screen.getByRole('button', { name: /reschedule task/i }))
+  expect(updatePlant).toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button', { name: /delete task/i }))
+  expect(updatePlant).toHaveBeenCalledTimes(2)
 })
 
 

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -12,6 +12,195 @@ exports[`matches snapshot in dark mode 1`] = `
     tabindex="0"
   >
     <div
+      aria-label="Task actions"
+      class="task-action-bar "
+      role="group"
+    >
+      <button
+        aria-label="Edit task"
+        class="task-action bg-blue-600 text-white"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 256 256"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            fill="none"
+            height="256"
+            width="256"
+          />
+          <path
+            d="M96,216H48a8,8,0,0,1-8-8V163.3a7.9,7.9,0,0,1,2.3-5.6l120-120a8,8,0,0,1,11.4,0l44.6,44.6a8,8,0,0,1,0,11.4Z"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+          <line
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+            x1="216"
+            x2="96"
+            y1="216"
+            y2="216"
+          />
+          <line
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+            x1="136"
+            x2="192"
+            y1="64"
+            y2="120"
+          />
+        </svg>
+        Edit
+      </button>
+      <button
+        aria-label="Reschedule task"
+        class="task-action bg-yellow-600 text-white"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 256 256"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            fill="none"
+            height="256"
+            width="256"
+          />
+          <line
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+            x1="128"
+            x2="128"
+            y1="80"
+            y2="128"
+          />
+          <line
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+            x1="169.6"
+            x2="128"
+            y1="152"
+            y2="128"
+          />
+          <polyline
+            fill="none"
+            points="71.8 99.7 31.8 99.7 31.8 59.7"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+          <path
+            d="M65.8,190.2a88,88,0,1,0,0-124.4l-34,33.9"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+        </svg>
+        Reschedule
+      </button>
+      <button
+        aria-label="Delete task"
+        class="task-action bg-red-600 text-white"
+        type="button"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 256 256"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            fill="none"
+            height="256"
+            width="256"
+          />
+          <line
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+            x1="216"
+            x2="40"
+            y1="56"
+            y2="56"
+          />
+          <line
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+            x1="104"
+            x2="104"
+            y1="104"
+            y2="168"
+          />
+          <line
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+            x1="152"
+            x2="152"
+            y1="104"
+            y2="168"
+          />
+          <path
+            d="M200,56V208a8,8,0,0,1-8,8H64a8,8,0,0,1-8-8V56"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+          <path
+            d="M168,56V40a16,16,0,0,0-16-16H104A16,16,0,0,0,88,40V56"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+        </svg>
+        Delete
+      </button>
+    </div>
+    <div
       class="flex items-center flex-1 gap-4"
     >
       <button

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -7,6 +7,195 @@ exports[`matches snapshot in dark mode 1`] = `
   style="transform: translateX(0px); transition: transform 0.2s;"
 >
   <div
+    aria-label="Task actions"
+    class="task-action-bar "
+    role="group"
+  >
+    <button
+      aria-label="Edit task"
+      class="task-action bg-blue-600 text-white"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="w-4 h-4"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 256 256"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect
+          fill="none"
+          height="256"
+          width="256"
+        />
+        <path
+          d="M96,216H48a8,8,0,0,1-8-8V163.3a7.9,7.9,0,0,1,2.3-5.6l120-120a8,8,0,0,1,11.4,0l44.6,44.6a8,8,0,0,1,0,11.4Z"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="216"
+          x2="96"
+          y1="216"
+          y2="216"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="136"
+          x2="192"
+          y1="64"
+          y2="120"
+        />
+      </svg>
+      Edit
+    </button>
+    <button
+      aria-label="Reschedule task"
+      class="task-action bg-yellow-600 text-white"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="w-4 h-4"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 256 256"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect
+          fill="none"
+          height="256"
+          width="256"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="128"
+          x2="128"
+          y1="80"
+          y2="128"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="169.6"
+          x2="128"
+          y1="152"
+          y2="128"
+        />
+        <polyline
+          fill="none"
+          points="71.8 99.7 31.8 99.7 31.8 59.7"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+        />
+        <path
+          d="M65.8,190.2a88,88,0,1,0,0-124.4l-34,33.9"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+        />
+      </svg>
+      Reschedule
+    </button>
+    <button
+      aria-label="Delete task"
+      class="task-action bg-red-600 text-white"
+      type="button"
+    >
+      <svg
+        aria-hidden="true"
+        class="w-4 h-4"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 256 256"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect
+          fill="none"
+          height="256"
+          width="256"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="216"
+          x2="40"
+          y1="56"
+          y2="56"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="104"
+          x2="104"
+          y1="104"
+          y2="168"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="152"
+          x2="152"
+          y1="104"
+          y2="168"
+        />
+        <path
+          d="M200,56V208a8,8,0,0,1-8,8H64a8,8,0,0,1-8-8V56"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+        />
+        <path
+          d="M168,56V40a16,16,0,0,0-16-16H104A16,16,0,0,0,88,40V56"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+        />
+      </svg>
+      Delete
+    </button>
+  </div>
+  <div
     class="flex items-center gap-4 p-4"
   >
     <div

--- a/src/index.css
+++ b/src/index.css
@@ -245,3 +245,20 @@ body {
     @apply text-xs;
   }
 }
+
+.task-action-bar {
+  @apply absolute inset-y-0 right-2 flex items-center gap-2 pointer-events-none;
+  opacity: 0;
+  transform: translateX(20px);
+  transition: opacity 0.2s ease, transform 0.2s ease;
+}
+
+.task-action-bar.show {
+  opacity: 1;
+  transform: translateX(0);
+  pointer-events: auto;
+}
+
+.task-action {
+  @apply px-2 py-1 rounded text-xs flex items-center gap-1 font-body transition;
+}


### PR DESCRIPTION
## Summary
- show edit/reschedule/delete action bar when partially swiping left on task cards
- support same action bar on unified task cards
- animate bar reveal with new CSS utilities
- test new behaviour and update snapshots

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687af9247fa08324a2086e2e72ca0519