### PR TITLE
Add ImageCard component and refactor plant views

### DIFF
--- a/src/components/ImageCard.jsx
+++ b/src/components/ImageCard.jsx
@@ -1,0 +1,32 @@
+import Card from './Card.jsx'
+
+export default function ImageCard({
+  as: Component = 'div',
+  imgSrc,
+  title,
+  badges,
+  children,
+  className = '',
+  ...props
+}) {
+  return (
+    <Card as={Component} className={`p-0 overflow-hidden relative ${className}`} {...props}>
+      <div className="relative">
+        <img src={imgSrc} alt={typeof title === 'string' ? title : ''} loading="lazy" className="plant-thumb" />
+        <div
+          className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent"
+          aria-hidden="true"
+        ></div>
+        {(title || badges) && (
+          <div className="absolute bottom-1 left-2 right-2 drop-shadow text-white space-y-0.5">
+            {title && (
+              <div className="font-bold text-lg font-headline leading-none">{title}</div>
+            )}
+            {badges && <div className="flex flex-wrap gap-1">{badges}</div>}
+          </div>
+        )}
+      </div>
+      {children && <div className="p-4">{children}</div>}
+    </Card>
+  )
+}

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -10,7 +10,7 @@ import { usePlants } from '../PlantContext.jsx'
 import useSnackbar from '../hooks/useSnackbar.jsx'
 import NoteModal from './NoteModal.jsx'
 import ConfirmModal from './ConfirmModal.jsx'
-import Card from './Card.jsx'
+import ImageCard from './ImageCard.jsx'
 
 export default function PlantCard({ plant }) {
   const navigate = useNavigate()
@@ -202,20 +202,22 @@ export default function PlantCard({ plant }) {
           )}
         </div>
       )}
-      <Card
+      <ImageCard
         style={{ transform: `translateX(${deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
+        imgSrc={plant.image}
+        title={
+          <Link
+            to={
+              plant.room
+                ? `/room/${encodeURIComponent(plant.room)}/plant/${plant.id}`
+                : `/plant/${plant.id}`
+            }
+            className="focus:outline-none"
+          >
+            {plant.name}
+          </Link>
+        }
       >
-        <Link
-          to={
-            plant.room
-              ? `/room/${encodeURIComponent(plant.room)}/plant/${plant.id}`
-              : `/plant/${plant.id}`
-          }
-          className="block mb-2"
-        >
-          <img src={plant.image} alt={plant.name} loading="lazy" className="plant-thumb" />
-          <h2 className="font-bold text-heading font-headline mt-2">{plant.name}</h2>
-        </Link>
         <p className="text-sm text-green-700 font-medium font-body">Next: {plant.nextWater}</p>
         <button
           onMouseDown={createRipple}
@@ -226,7 +228,7 @@ export default function PlantCard({ plant }) {
           <Drop className="w-4 h-4" aria-hidden="true" />
           Watered
         </button>
-      </Card>
+      </ImageCard>
     </div>
     {showNote && (
       <NoteModal label="Optional note" onSave={handleSaveNote} onCancel={handleCancelNote} />

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -175,67 +175,83 @@ exports[`matches snapshot in dark mode 1`] = `
     </div>
   </div>
   <div
-    class="bg-white dark:bg-gray-700 rounded-2xl shadow p-4 "
+    class="bg-white dark:bg-gray-700 rounded-2xl shadow p-4 p-0 overflow-hidden relative "
     style="transform: translateX(0px); transition: transform 0.2s;"
   >
-    <a
-      class="block mb-2"
-      href="/plant/1"
+    <div
+      class="relative"
     >
       <img
-        alt="Aloe Vera"
+        alt=""
         class="plant-thumb"
         loading="lazy"
         src="test.jpg"
       />
-      <h2
-        class="font-bold text-heading font-headline mt-2"
-      >
-        Aloe Vera
-      </h2>
-    </a>
-    <p
-      class="text-sm text-green-700 font-medium font-body"
-    >
-      Next: 
-      2024-05-07
-    </p>
-    <button
-      class="mt-2 px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 transition relative overflow-hidden font-body text-sm flex items-center gap-1"
-    >
-      <svg
+      <div
         aria-hidden="true"
-        class="w-4 h-4"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 256 256"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
+        class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent"
+      />
+      <div
+        class="absolute bottom-1 left-2 right-2 drop-shadow text-white space-y-0.5"
       >
-        <rect
-          fill="none"
-          height="256"
-          width="256"
-        />
-        <path
-          d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-        <path
-          d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-      </svg>
-      Watered
-    </button>
+        <div
+          class="font-bold text-lg font-headline leading-none"
+        >
+          <a
+            class="focus:outline-none"
+            href="/plant/1"
+          >
+            Aloe Vera
+          </a>
+        </div>
+      </div>
+    </div>
+    <div
+      class="p-4"
+    >
+      <p
+        class="text-sm text-green-700 font-medium font-body"
+      >
+        Next: 
+        2024-05-07
+      </p>
+      <button
+        class="mt-2 px-3 py-1 bg-green-100 text-green-700 rounded hover:bg-green-200 transition relative overflow-hidden font-body text-sm flex items-center gap-1"
+      >
+        <svg
+          aria-hidden="true"
+          class="w-4 h-4"
+          fill="currentColor"
+          height="1em"
+          viewBox="0 0 256 256"
+          width="1em"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <rect
+            fill="none"
+            height="256"
+            width="256"
+          />
+          <path
+            d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+          <path
+            d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
+            fill="none"
+            stroke="currentColor"
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="16"
+          />
+        </svg>
+        Watered
+      </button>
+    </div>
   </div>
 </div>
 `;

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -13,7 +13,7 @@ import { createRipple } from '../utils/interactions.js'
 import CreateFab from '../components/CreateFab.jsx'
 import PageContainer from "../components/PageContainer.jsx"
 import PageHeader from "../components/PageHeader.jsx"
-import Card from '../components/Card.jsx'
+import ImageCard from '../components/ImageCard.jsx'
 
 export default function MyPlants() {
   const { rooms } = useRooms()
@@ -116,32 +116,21 @@ export default function MyPlants() {
               onMouseDown={createRipple}
               onTouchStart={createRipple}
             >
-              <Card className="space-y-2 hover:shadow-lg">
-                <div className="relative">
-                  <img
-                    src={thumbnail}
-                    className="w-full h-24 object-cover rounded-md"
-                    alt={`Photo of the ${room} room`}
-                  />
-                  <div
-                    className="absolute inset-0 rounded-md bg-gradient-to-t from-black/60 via-black/30 to-transparent"
-                    aria-hidden="true"
-                  ></div>
-                  <div className="absolute bottom-1 left-2 right-2 text-white drop-shadow space-y-0.5">
+              <ImageCard
+                as="div"
+                imgSrc={thumbnail}
+                title={
+                  <>
                     <p className="font-bold text-lg font-headline leading-none">{room}</p>
                     <p className="text-sm text-gray-500 leading-none">{countPlants(room)} plants</p>
-                  </div>
-                </div>
+                  </>
+                }
+                className="space-y-2 hover:shadow-lg"
+              >
                 <div className="flex gap-1 text-badge">
-                  {wateredToday && (
-                    <Drop className="w-4 h-4" aria-hidden="true" />
-                  )}
-                  {lowLight && (
-                    <Sun className="w-4 h-4" aria-hidden="true" />
-                  )}
-                  {pestAlert && (
-                    <Bug className="w-4 h-4" aria-hidden="true" />
-                  )}
+                  {wateredToday && <Drop className="w-4 h-4" aria-hidden="true" />}
+                  {lowLight && <Sun className="w-4 h-4" aria-hidden="true" />}
+                  {pestAlert && <Bug className="w-4 h-4" aria-hidden="true" />}
                   {lastUpdated && <span>{formatDaysAgo(lastUpdated)}</span>}
                 </div>
                 {overdue > 0 && (
@@ -153,7 +142,7 @@ export default function MyPlants() {
                     {overdue} needs love
                   </Badge>
                 )}
-              </Card>
+              </ImageCard>
             </Link>
           )
         })}

--- a/src/pages/RoomList.jsx
+++ b/src/pages/RoomList.jsx
@@ -8,7 +8,7 @@ import { createRipple } from '../utils/interactions.js'
 import PageHeader from '../components/PageHeader.jsx'
 import Badge from '../components/Badge.jsx'
 import PageContainer from "../components/PageContainer.jsx"
-import Card from '../components/Card.jsx'
+import ImageCard from '../components/ImageCard.jsx'
 
 export default function RoomList() {
   const { roomName } = useParams()
@@ -78,48 +78,42 @@ export default function RoomList() {
                 onMouseDown={createRipple}
                 onTouchStart={createRipple}
               >
-                <Card className="relative overflow-hidden hover:shadow-lg">
-                  <img
-                    src={src}
-                    alt={plant.name}
-                    loading="lazy"
-                    className="plant-thumb"
-                  />
-                  <div
-                    className="absolute inset-0 bg-gradient-to-t from-black/50 via-black/20 to-transparent"
-                    aria-hidden="true"
-                  ></div>
-                  <span className="absolute top-1 left-1 bg-black/40 text-white text-xs px-1 rounded">
-                    {plant.name}
-                  </span>
-                  <div className="absolute bottom-1 left-1 flex flex-wrap gap-1">
+                <ImageCard
+                  as="div"
+                  imgSrc={src}
+                  title={plant.name}
+                  badges={[
                     <Badge
+                      key="status"
                       Icon={Drop}
                       size="sm"
                       colorClass={`${colorClass} text-xs rounded-full`}
                     >
                       {status}
-                    </Badge>
-                    {plant.light && (
+                    </Badge>,
+                    plant.light && (
                       <Badge
+                        key="light"
                         Icon={Sun}
                         size="sm"
                         colorClass="bg-black/40 text-white backdrop-blur-sm"
                       >
                         {plant.light}
                       </Badge>
-                    )}
-                    {plant.difficulty && (
+                    ),
+                    plant.difficulty && (
                       <Badge
+                        key="diff"
                         Icon={Gauge}
                         size="sm"
                         colorClass="bg-black/40 text-white backdrop-blur-sm"
                       >
                         {plant.difficulty}
                       </Badge>
-                    )}
-                  </div>
-                </Card>
+                    ),
+                  ]}
+                  className="hover:shadow-lg"
+                />
               </Link>
             )
           })}


### PR DESCRIPTION
## Summary
- create `ImageCard` for shared image cards
- update PlantCard to use ImageCard with gradient overlay
- refactor RoomList and MyPlants to reuse ImageCard
- update PlantCard snapshot

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687aff2656a883249b34f0d8521f1a01