### PR TITLE
Add plant health status badges

### DIFF
--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -1,6 +1,7 @@
 import { Link, useNavigate } from 'react-router-dom'
 import { useState, useRef } from 'react'
 import { Drop, PencilSimpleLine, Trash } from 'phosphor-react'
+import Badge from './Badge.jsx'
 
 import { createRipple } from '../utils/interactions.js'
 import useSwipe from '../hooks/useSwipe.js'
@@ -11,6 +12,7 @@ import useSnackbar from '../hooks/useSnackbar.jsx'
 import NoteModal from './NoteModal.jsx'
 import ConfirmModal from './ConfirmModal.jsx'
 import ImageCard from './ImageCard.jsx'
+import { getWaterStatus } from '../utils/watering.js'
 
 export default function PlantCard({ plant }) {
   const navigate = useNavigate()
@@ -21,6 +23,10 @@ export default function PlantCard({ plant }) {
   const [showNote, setShowNote] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
   const [showDeletePrompt, setShowDeletePrompt] = useState(false)
+
+  const { thirsty, overdue } = getWaterStatus(plant.nextWater)
+  const statusVariant = thirsty ? 'overdue' : 'complete'
+  const statusLabel = thirsty ? 'Thirsty' : 'Healthy'
 
   const LONG_PRESS_MS = 600
   const EDIT_THRESHOLD = 100
@@ -202,8 +208,14 @@ export default function PlantCard({ plant }) {
           )}
         </div>
       )}
+      <div className="absolute top-2 right-2 pointer-events-none">
+        <Badge variant={statusVariant} size="sm">
+          {statusLabel}
+        </Badge>
+      </div>
       <ImageCard
         style={{ transform: `translateX(${deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
+        className={overdue ? 'ring-2 ring-yellow-300' : ''}
         imgSrc={plant.image}
         title={
           <Link

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -175,7 +175,16 @@ exports[`matches snapshot in dark mode 1`] = `
     </div>
   </div>
   <div
-    class="bg-white dark:bg-gray-700 rounded-2xl shadow p-4 p-0 overflow-hidden relative "
+    class="absolute top-2 right-2 pointer-events-none"
+  >
+    <span
+      class="inline-flex items-center gap-1 rounded-full font-medium px-1.5 py-0 text-[10px] bg-red-50 text-red-500"
+    >
+      Thirsty
+    </span>
+  </div>
+  <div
+    class="bg-white dark:bg-gray-700 rounded-2xl shadow p-4 p-0 overflow-hidden relative ring-2 ring-yellow-300"
     style="transform: translateX(0px); transition: transform 0.2s;"
   >
     <div

--- a/src/utils/watering.js
+++ b/src/utils/watering.js
@@ -39,3 +39,17 @@ export function getWateringProgress(lastWatered, nextWater, today = new Date()) 
   const elapsed = Math.min(Math.max((today - last) / 86400000, 0), total);
   return elapsed / total;
 }
+
+export function getWaterStatus(nextWater, today = new Date()) {
+  if (!nextWater) return { thirsty: false, overdue: false };
+  const next = new Date(nextWater);
+  if (isNaN(next)) return { thirsty: false, overdue: false };
+  const todayDate = new Date(
+    today.getFullYear(),
+    today.getMonth(),
+    today.getDate()
+  );
+  const thirsty = next <= todayDate;
+  const overdue = next < todayDate;
+  return { thirsty, overdue };
+}


### PR DESCRIPTION
## Summary
- compute plant watering status with `getWaterStatus`
- display `Thirsty` or `Healthy` badge on plant cards
- highlight overdue plants with a warm ring

## Testing
- `npm test -- -u`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b01d3dd648324b5cf347cc5bc7dc8