### PR TITLE
Add gallery placeholder

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,11 +1,26 @@
 import React from 'react'
+import { Link } from 'react-router-dom'
 import PageContainer from "../components/PageContainer.jsx"
+import { addBase } from '../PlantContext.jsx'
 
 export default function Gallery() {
   return (
-    <PageContainer>
-      <h2 className="text-heading font-headline mb-4">Gallery</h2>
-      <p className="text-gray-700 dark:text-gray-200">Coming soon...</p>
+    <PageContainer className="text-center space-y-4">
+      <h2 className="text-heading font-headline">Gallery</h2>
+      <img
+        src={addBase('/happy-plant.svg')}
+        alt="Empty gallery"
+        className="w-32 h-32 mx-auto"
+      />
+      <p className="text-gray-700 dark:text-gray-200">
+        Gallery will unlock once you add photos.
+      </p>
+      <Link
+        to="/add"
+        className="inline-block px-4 py-2 bg-green-600 text-white rounded"
+      >
+        Add a plant
+      </Link>
     </PageContainer>
   )
 }


### PR DESCRIPTION
## Summary
- show an empty state illustration in Gallery
- add a button to add a plant from the Gallery

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b03edde208324beb738bc9d521ec6