### PR TITLE
Update room list styles

### DIFF
--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -4,7 +4,7 @@ export default function PageHeader({ title, breadcrumb }) {
   return (
     <header className="mb-4 space-y-1 text-left">
       {breadcrumb && <Breadcrumb {...breadcrumb} />}
-      <h1 className="text-heading font-bold font-headline">{title}</h1>
+      <h1 className="text-2xl tracking-wide font-bold font-headline">{title}</h1>
     </header>
   )
 }

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -91,7 +91,7 @@ export default function MyPlants() {
         ]}
       />
       <div
-        className="grid gap-2"
+        className="grid gap-2 gap-y-6"
         style={{
           gridTemplateColumns: 'repeat(auto-fill, minmax(160px,1fr))',
           gridAutoRows: '1fr',
@@ -121,7 +121,7 @@ export default function MyPlants() {
                 title={
                   <>
                     <p className="font-bold text-lg font-headline leading-none">{room}</p>
-                    <p className="text-sm text-gray-500 leading-none">{countPlants(room)} plants</p>
+                    <p className="text-xs text-gray-500 leading-none">{countPlants(room)} plants</p>
                   </>
                 }
                 className="space-y-2 hover:shadow-lg h-full flex flex-col"

--- a/src/pages/RoomList.jsx
+++ b/src/pages/RoomList.jsx
@@ -50,7 +50,7 @@ export default function RoomList() {
         <p>No plants in this room.</p>
       ) : (
         <div
-          className="grid gap-2"
+          className="grid gap-2 gap-y-6"
           style={{
             gridTemplateColumns: 'repeat(auto-fill, minmax(160px,1fr))',
             gridAutoRows: '1fr',


### PR DESCRIPTION
## Summary
- enlarge page titles with slight letter-spacing
- show room plant counts with smaller text
- add vertical spacing to plant grids

## Testing
- `npm test` *(fails: npm not found)*

------
https://chatgpt.com/codex/tasks/task_e_687b043579f48324b78adaf51ead0d66