### PR TITLE
Remove swipe from FeaturedCard

### DIFF
--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -4,7 +4,6 @@ import { useWeather } from '../WeatherContext.jsx'
 import { formatCareSummary } from '../utils/date.js'
 
 
-import useSwipe from '../hooks/useSwipe.js'
 import useINatPhoto from '../hooks/useINatPhoto.js'
 import { createRipple } from '../utils/interactions.js'
 
@@ -28,10 +27,6 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
   }
   const suggestion = forecast ? weatherEmojis[forecast.condition] || '☀️' : null
 
-  const { dx: deltaX, start, move, end } = useSwipe(diff => {
-    if (diff > 50) setIndex(i => (i - 1 + items.length) % items.length)
-    else if (diff < -50) setIndex(i => (i + 1) % items.length)
-  })
 
   const handleKeyDown = e => {
     if (e.key === 'ArrowRight') {
@@ -62,14 +57,10 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
       onKeyDown={handleKeyDown}
 
 
-      onPointerDown={e => { createRipple(e); start(e) }}
-      onPointerMove={move}
-      onPointerUp={end}
-      onPointerCancel={end}
+      onPointerDown={createRipple}
 
 
       className="relative block overflow-hidden rounded-3xl shadow bg-sage dark:bg-gray-700 focus:outline-none focus-visible:ring-2 focus-visible:ring-offset-2 focus-visible:ring-blue-500"
-      style={{ transform: `translateX(${deltaX}px)`, transition: deltaX === 0 ? 'transform 0.2s' : 'none' }}
     >
       <img
         src={imageSrc}

--- a/src/components/__tests__/FeaturedCard.test.jsx
+++ b/src/components/__tests__/FeaturedCard.test.jsx
@@ -26,20 +26,15 @@ test('shows featured label and care summary', () => {
   expect(screen.getByText('Last watered 3 days ago \u00B7 Needs water today')).toBeInTheDocument()
 })
 
-test('swipe changes plant', () => {
-  render(
+test('pointer down creates ripple', () => {
+  const { container } = render(
     <MemoryRouter>
       <FeaturedCard plants={plants} />
     </MemoryRouter>
   )
   const card = screen.getByTestId('featured-card')
-  fireEvent.pointerDown(card, { clientX: 80 })
-  expect(card.querySelector('.ripple-effect')).toBeInTheDocument()
-  card.querySelector('.ripple-effect')?.remove()
-  fireEvent.pointerDown(card, { clientX: 100 })
-  fireEvent.pointerMove(card, { clientX: 20 })
-  fireEvent.pointerUp(card, { clientX: 20 })
-  expect(screen.getByText('Pothos')).toBeInTheDocument()
+  fireEvent.pointerDown(card)
+  expect(container.querySelector('.ripple-effect')).toBeInTheDocument()
 })
 
 test('arrow keys change plant', () => {


### PR DESCRIPTION
## Summary
- remove useSwipe logic from `FeaturedCard`
- keep ripple effect on pointer down
- update tests accordingly

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b04ee3ea483248436a6790f44feb2