### PR TITLE
Implement redirect and toast for plant addition

### DIFF
--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -2,6 +2,7 @@ import { useReducer, useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePlants, addBase } from '../PlantContext.jsx'
 import useINatPhoto from '../hooks/useINatPhoto.js'
+import useToast from '../hooks/useToast.jsx'
 import NameStep from './add/NameStep.jsx'
 import ImageStep from './add/ImageStep.jsx'
 import ScheduleStep from './add/ScheduleStep.jsx'
@@ -69,6 +70,7 @@ export default function Add() {
   const [state, dispatch] = useReducer(reducer, initialState)
   const [step, setStep] = useState(1)
   const placeholder = useINatPhoto(state.name)
+  const { Toast, showToast } = useToast()
 
   const next = () => setStep(s => s + 1)
   const back = () => setStep(s => s - 1)
@@ -85,11 +87,13 @@ export default function Add() {
       ...(state.notes && { notes: state.notes }),
       ...(state.careLevel && { careLevel: state.careLevel }),
     })
-    navigate('/myplants')
+    showToast('Added')
+    setTimeout(() => navigate('/'), 800)
   }
 
   return (
     <>
+      <Toast />
       <StepIndicator step={step} />
       {step === 1 && (
         <NameStep name={state.name} dispatch={dispatch} onNext={next} />

--- a/src/pages/__tests__/Add.test.jsx
+++ b/src/pages/__tests__/Add.test.jsx
@@ -1,18 +1,27 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import Add from '../Add.jsx'
-import MyPlants from '../MyPlants.jsx'
+import Home from '../Home.jsx'
 import { PlantProvider } from '../../PlantContext.jsx'
 import { RoomProvider } from '../../RoomContext.jsx'
 
+jest.mock('../../WeatherContext.jsx', () => ({
+  useWeather: () => ({ forecast: { rainfall: 0 } }),
+}))
+
+jest.mock('../../UserContext.jsx', () => ({
+  useUser: () => ({ username: 'Jon', timeZone: 'UTC' }),
+}))
+
 test('user can complete steps and add a plant', () => {
+  jest.useFakeTimers()
   render(
     <PlantProvider>
       <RoomProvider>
         <MemoryRouter initialEntries={['/add']}>
           <Routes>
             <Route path="/add" element={<Add />} />
-            <Route path="/myplants" element={<MyPlants />} />
+            <Route path="/" element={<Home />} />
           </Routes>
         </MemoryRouter>
       </RoomProvider>
@@ -43,7 +52,9 @@ test('user can complete steps and add a plant', () => {
   fireEvent.change(screen.getByLabelText(/notes/i), { target: { value: 'Thrives' } })
   fireEvent.change(screen.getByLabelText(/care level/i), { target: { value: 'easy' } })
   fireEvent.click(screen.getByRole('button', { name: /add plant/i }))
+  act(() => {
+    jest.runAllTimers()
+  })
 
-  expect(screen.getByRole('heading', { name: /all plants/i })).toBeInTheDocument()
-  expect(screen.getByText('Desk')).toBeInTheDocument()
+  expect(screen.getByTestId('tasks-container')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- redirect to Today page after adding a plant
- show a short toast confirming the add
- update `Add.test` for new navigation and asynchronous redirect

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b05d69de48324a4a9d6d8f4f8d017