### PR TITLE
Simplify RoomList layout

### DIFF
--- a/src/pages/RoomList.jsx
+++ b/src/pages/RoomList.jsx
@@ -1,15 +1,11 @@
 import { useParams, Link } from 'react-router-dom'
 import { useState } from 'react'
-import { Drop, Sun, Gauge } from 'phosphor-react'
 import BalconyPlantCard from '../components/BalconyPlantCard.jsx'
 
 import { usePlants } from '../PlantContext.jsx'
-import { formatDaysAgo } from '../utils/dateFormat.js'
 import { createRipple } from '../utils/interactions.js'
 import PageHeader from '../components/PageHeader.jsx'
-import Badge from '../components/Badge.jsx'
 import PageContainer from "../components/PageContainer.jsx"
-import ImageCard from '../components/ImageCard.jsx'
 import FilterPills from '../components/FilterPills.jsx'
 
 export default function RoomList() {
@@ -49,7 +45,7 @@ export default function RoomList() {
       )}
       {list.length === 0 ? (
         <p>No plants in this room.</p>
-      ) : roomName === 'Balcony' ? (
+      ) : (
         <div className="space-y-6">
           {sorted.map(plant => (
             <Link
@@ -62,77 +58,6 @@ export default function RoomList() {
               <BalconyPlantCard plant={plant} />
             </Link>
           ))}
-        </div>
-      ) : (
-        <div
-          className="grid gap-2 gap-y-6"
-          style={{
-            gridTemplateColumns: 'repeat(auto-fill, minmax(160px,1fr))',
-            gridAutoRows: '1fr',
-          }}
-        >
-          {sorted.map(plant => {
-            const src =
-              typeof plant.image === 'string' && plant.image.trim() !== ''
-                ? plant.image
-                : plant.placeholderSrc
-            const daysUntil = plant.nextWater
-              ? Math.ceil((new Date(plant.nextWater) - today) / 86400000)
-              : null
-            const needsWater = daysUntil != null && daysUntil <= 0
-            const status = needsWater
-              ? 'Needs water'
-              : `Last watered ${formatDaysAgo(plant.lastWatered)}`
-            const colorClass = needsWater
-              ? 'bg-red-100 text-red-700'
-              : 'bg-black/40 text-white backdrop-blur-sm'
-            return (
-              <Link
-                key={plant.id}
-                to={`/room/${encodeURIComponent(roomName)}/plant/${plant.id}`}
-                className="block h-full transition-transform hover:-translate-y-1 active:shadow"
-                onMouseDown={createRipple}
-                onTouchStart={createRipple}
-              >
-                <ImageCard
-                  as="div"
-                  imgSrc={src}
-                  title={plant.name}
-                  badges={[
-                    <Badge
-                      key="status"
-                      Icon={Drop}
-                      size="sm"
-                      colorClass={`${colorClass} text-xs rounded-full`}
-                    >
-                      {status}
-                    </Badge>,
-                    plant.light && (
-                      <Badge
-                        key="light"
-                        Icon={Sun}
-                        size="sm"
-                        colorClass="bg-black/40 text-white backdrop-blur-sm"
-                      >
-                        {plant.light}
-                      </Badge>
-                    ),
-                    plant.difficulty && (
-                      <Badge
-                        key="diff"
-                        Icon={Gauge}
-                        size="sm"
-                        colorClass="bg-black/40 text-white backdrop-blur-sm"
-                      >
-                        {plant.difficulty}
-                      </Badge>
-                    ),
-                  ]}
-                  className="hover:shadow-lg h-full flex flex-col"
-                />
-              </Link>
-            )
-          })}
         </div>
       )}
     </PageContainer>


### PR DESCRIPTION
## Summary
- remove grid layout logic from RoomList
- show `BalconyPlantCard` for plants in any room
- drop unused imports

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b0b34a0488324a612ba62cf83f4bb