### PR TITLE
Redesigned task cards

### DIFF
--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -33,7 +33,7 @@ export default function UnifiedTaskCard({
   const bgClass = overdue
     ? 'bg-red-50 dark:bg-red-800'
     : urgent
-    ? 'bg-yellow-50 dark:bg-yellow-900'
+    ? 'bg-sage dark:bg-gray-700'
     : 'bg-gray-50 dark:bg-gray-800'
 
   const lastText = lastCared ? formatDaysAgo(lastCared) : null
@@ -41,17 +41,27 @@ export default function UnifiedTaskCard({
     <p className="text-timestamp text-gray-500">Last cared for {lastText}</p>
   ) : null
 
-  const waterColor = overdue
-    ? 'bg-red-50 text-red-500'
-    : urgent
-    ? 'bg-yellow-100 text-yellow-700'
-    : 'bg-water-100/90 text-water-800'
+  let intervalDays = null
+  if (dueWater && plant.lastWatered && plant.nextWater) {
+    const last = new Date(plant.lastWatered)
+    const next = new Date(plant.nextWater)
+    if (!isNaN(last) && !isNaN(next)) {
+      intervalDays = Math.round((next - last) / 86400000)
+    }
+  } else if (dueFertilize && plant.lastFertilized && plant.nextFertilize) {
+    const last = new Date(plant.lastFertilized)
+    const next = new Date(plant.nextFertilize)
+    if (!isNaN(last) && !isNaN(next)) {
+      intervalDays = Math.round((next - last) / 86400000)
+    }
+  }
 
-  const fertColor = overdue
-    ? 'bg-red-50 text-red-500'
-    : urgent
-    ? 'bg-yellow-100 text-yellow-700'
-    : 'bg-fertilize-100/90 text-fertilize-800'
+  const needsText = intervalDays
+    ? `Needs ${dueWater ? 'water' : 'fertilizer'} every ${intervalDays} day${
+        intervalDays === 1 ? '' : 's'
+      }`
+    : null
+
 
   const goToDetail = () => {
     const room = plant.room ? encodeURIComponent(plant.room) : null
@@ -167,18 +177,38 @@ export default function UnifiedTaskCard({
                 Overdue
               </Badge>
             ) : urgent ? (
-              <Badge variant="urgent" size="sm">Today</Badge>
+              <Badge variant="urgent" size="sm" Icon={CheckCircle}>
+                Today
+              </Badge>
             ) : null}
           </div>
-          <div className="flex items-center gap-2 mt-1">
+          <div className="flex items-center gap-4 mt-1 font-semibold text-gray-700 dark:text-gray-200">
             {dueWater && (
-              <Badge Icon={Drop} colorClass={waterColor}>Water</Badge>
+              <span className="inline-flex items-center gap-1">
+                <Drop className="w-4 h-4 text-water-600" aria-hidden="true" />
+                Water
+              </span>
             )}
             {dueFertilize && (
-              <Badge Icon={Sun} colorClass={fertColor}>Fertilize</Badge>
+              <span className="inline-flex items-center gap-1">
+                <Sun className="w-4 h-4 text-fertilize-600" aria-hidden="true" />
+                Fertilize
+              </span>
             )}
           </div>
           {last}
+          {needsText && (
+            <p
+              className={`text-timestamp mt-0.5 flex items-center gap-1 ${
+                overdue ? 'text-red-600' : 'text-gray-500'
+              }`}
+            >
+              {overdue && (
+                <WarningCircle className="w-3 h-3" aria-hidden="true" />
+              )}
+              {needsText}
+            </p>
+          )}
         </div>
       </div>
       {completed && (

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -53,7 +53,7 @@ test('renders plant info and badges', () => {
   expect(screen.getByText('Fern')).toBeInTheDocument()
   const waterBadge = screen.getByText('Water')
   expect(waterBadge).toBeInTheDocument()
-  expect(waterBadge).toHaveClass('bg-water-100/90')
+  expect(waterBadge).toHaveClass('inline-flex')
   expect(screen.queryByText('Fertilize')).toBeNull()
   expect(screen.getByText('Last cared for 3 days ago')).toBeInTheDocument()
   expect(screen.queryByRole('button', { name: /mark as done/i })).toBeNull()
@@ -66,7 +66,7 @@ test('applies urgent style', () => {
     </MemoryRouter>
   )
   const wrapper = container.querySelector('[data-testid="unified-task-card"]')
-  expect(wrapper).toHaveClass('bg-yellow-50')
+  expect(wrapper).toHaveClass('bg-sage')
 })
 
 test('applies overdue style', () => {

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -220,14 +220,14 @@ exports[`matches snapshot in dark mode 1`] = `
         </p>
       </div>
       <div
-        class="flex items-center gap-2 mt-1"
+        class="flex items-center gap-4 mt-1 font-semibold text-gray-700 dark:text-gray-200"
       >
         <span
-          class="inline-flex items-center gap-1 rounded-full font-medium px-2 py-0.5 text-badge bg-water-100/90 text-water-800"
+          class="inline-flex items-center gap-1"
         >
           <svg
             aria-hidden="true"
-            class="w-3 h-3"
+            class="w-4 h-4 text-water-600"
             fill="currentColor"
             height="1em"
             viewBox="0 0 256 256"


### PR DESCRIPTION
## Summary
- restyle UnifiedTaskCard for mint/today and use new icons
- show watering/fertilizing frequency text when available
- update tests and snapshots

## Testing
- `npm test -- -u`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b08d467d48324b3b75a4f4e5d4e6c