### PR TITLE
Replace emojis with icons

### DIFF
--- a/src/components/CareRings.jsx
+++ b/src/components/CareRings.jsx
@@ -1,4 +1,5 @@
 import React from 'react'
+import { CheckCircle } from 'phosphor-react'
 
 export default function CareRings({
   waterCompleted = 0,
@@ -33,10 +34,15 @@ export default function CareRings({
   const rotate = `rotate(-90 ${center} ${center})`
 
   const allComplete = totalTasks > 0 && totalCompleted === totalTasks
-  const progressText = noTasks
+  const progressDisplay = noTasks
     ? 'Rest Day'
     : allComplete
-    ? '🎉 All done!'
+    ? (
+        <>
+          <CheckCircle className="inline w-3 h-3 mr-1" aria-hidden="true" />
+          All done!
+        </>
+      )
     : `${totalCompleted} / ${totalTasks} tasks done`
 
   const displaySize = size
@@ -90,7 +96,7 @@ export default function CareRings({
           />
         </svg>
         <div className="absolute inset-0 flex items-center justify-center text-xs font-body font-semibold drop-shadow pointer-events-none">
-          {progressText}
+          {progressDisplay}
         </div>
       </div>
     </div>

--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -2,6 +2,15 @@ import { Link } from 'react-router-dom'
 import { useState } from 'react'
 import { useWeather } from '../WeatherContext.jsx'
 import { formatCareSummary } from '../utils/date.js'
+import {
+  Flower,
+  Sun,
+  Cloud,
+  CloudRain,
+  CloudLightning,
+  CloudSnow,
+  CloudFog,
+} from 'phosphor-react'
 
 
 import useINatPhoto from '../hooks/useINatPhoto.js'
@@ -15,17 +24,19 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
 
   const [index, setIndex] = useState(startIndex)
   const { forecast } = useWeather() || {}
-  const weatherEmojis = {
-    Clear: '☀️',
-    Clouds: '☁️',
-    Rain: '🌧️',
-    Drizzle: '🌦️',
-    Thunderstorm: '⛈️',
-    Snow: '❄️',
-    Mist: '🌫️',
-    Fog: '🌫️',
+  const weatherIcons = {
+    Clear: Sun,
+    Clouds: Cloud,
+    Rain: CloudRain,
+    Drizzle: CloudRain,
+    Thunderstorm: CloudLightning,
+    Snow: CloudSnow,
+    Mist: CloudFog,
+    Fog: CloudFog,
   }
-  const suggestion = forecast ? weatherEmojis[forecast.condition] || '☀️' : null
+  const WeatherIcon = forecast
+    ? weatherIcons[forecast.condition] || Sun
+    : null
 
 
   const handleKeyDown = e => {
@@ -72,14 +83,20 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
         aria-hidden="true"
       ></div>
       <div className="absolute bottom-3 left-4 right-4 text-white space-y-1 drop-shadow">
-        <span className="text-xs uppercase tracking-wide opacity-90">🌿 Featured Plant of the Day</span>
+        <span className="text-xs uppercase tracking-wide opacity-90 flex items-center gap-1">
+          <Flower className="w-3 h-3" aria-hidden="true" />
+          Featured Plant of the Day
+        </span>
 
         <h2 className="font-display text-heading font-semibold">{name}</h2>
         {preview && (
           <div className="flex items-center gap-1">
             <p className="text-sm opacity-90">{preview}</p>
-            {suggestion && (
-              <span aria-label={`Weather: ${forecast?.condition}`}>{suggestion}</span>
+            {WeatherIcon && (
+              <WeatherIcon
+                aria-label={`Weather: ${forecast?.condition}`}
+                className="w-4 h-4"
+              />
             )}
           </div>
         )}

--- a/src/components/WaterProgress.jsx
+++ b/src/components/WaterProgress.jsx
@@ -1,4 +1,4 @@
-import { Drop } from 'phosphor-react'
+import { Drop, Flower } from 'phosphor-react'
 import useRipple from '../utils/useRipple.js'
 
 export default function WaterProgress({ completed = 0, total = 0 }) {
@@ -23,7 +23,7 @@ export default function WaterProgress({ completed = 0, total = 0 }) {
         </span>
       ))}
       {total > 0 && completed === total && (
-        <span role="img" aria-label="Bloom" className="bloom-pop">🌱</span>
+        <Flower role="img" aria-label="Bloom" className="w-5 h-5 text-green-600 bloom-pop" />
       )}
     </div>
   )

--- a/src/components/__tests__/CareRings.test.jsx
+++ b/src/components/__tests__/CareRings.test.jsx
@@ -39,7 +39,7 @@ test('shows progress text and swirl when complete', () => {
   const { container } = render(
     <CareRings waterCompleted={2} waterTotal={2} fertCompleted={1} fertTotal={1} />
   )
-  expect(screen.getByText('🎉 All done!')).toBeInTheDocument()
+  expect(screen.getByText('All done!')).toBeInTheDocument()
   const svg = container.querySelector('svg')
   expect(svg.getAttribute('class')).toMatch(/swirl-once/)
 })

--- a/src/components/__tests__/FeaturedCard.test.jsx
+++ b/src/components/__tests__/FeaturedCard.test.jsx
@@ -21,7 +21,7 @@ test('shows featured label and care summary', () => {
       <FeaturedCard plants={plants} />
     </MemoryRouter>
   )
-  expect(screen.getByText('🌿 Featured Plant of the Day')).toBeInTheDocument()
+  expect(screen.getByText('Featured Plant of the Day')).toBeInTheDocument()
   expect(screen.getByText('Aloe')).toBeInTheDocument()
   expect(screen.getByText('Last watered 3 days ago \u00B7 Needs water today')).toBeInTheDocument()
 })

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -8,7 +8,7 @@ import UnifiedTaskCard from '../components/UnifiedTaskCard.jsx'
 import BaseCard from '../components/BaseCard.jsx'
 import TaskTabs from '../components/TaskTabs.jsx'
 import CareRings from '../components/CareRings.jsx'
-import { ListBullets, SquaresFour } from 'phosphor-react'
+import { ListBullets, SquaresFour, Sun } from 'phosphor-react'
 import useTaskLayout from '../hooks/useTaskLayout.js'
 
 
@@ -285,9 +285,14 @@ export default function Tasks() {
       {viewMode === 'By Plant' ? (
         eventsByPlant.length === 0 ? (
           <p className="text-center text-gray-500">
-            {noUpcomingTasks
-              ? 'All caught up! Your plants are feeling great 🌞'
-              : 'No tasks coming up.'}
+            {noUpcomingTasks ? (
+              <>
+                All caught up! Your plants are feeling great{' '}
+                <Sun className="inline w-3 h-3" aria-hidden="true" />
+              </>
+            ) : (
+              'No tasks coming up.'
+            )}
           </p>
         ) : (
           <div className={layout === 'grid' ? 'grid grid-cols-2 gap-4' : 'space-y-4'}>
@@ -333,9 +338,14 @@ export default function Tasks() {
         )
       ) : groupedEvents.length === 0 ? (
         <p className="text-center text-gray-500">
-          {noUpcomingTasks
-            ? 'All caught up! Your plants are feeling great 🌞'
-            : 'No tasks coming up.'}
+          {noUpcomingTasks ? (
+            <>
+              All caught up! Your plants are feeling great{' '}
+              <Sun className="inline w-3 h-3" aria-hidden="true" />
+            </>
+          ) : (
+            'No tasks coming up.'
+          )}
         </p>
       ) : (
         groupedEvents.map(([dateKey, list]) => {


### PR DESCRIPTION
## Summary
- remove decorative emoji usage
- add matching Phosphor icons in components
- update relevant unit tests to expect icon-based text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b0a4acf0083248515f81e2ef01ce6