### PR TITLE
Update task card styles

### DIFF
--- a/src/components/TasksContainer.jsx
+++ b/src/components/TasksContainer.jsx
@@ -6,7 +6,7 @@ export default function TasksContainer({ visibleTasks = [], happyPlant }) {
   return (
     <div
       data-testid="tasks-container"
-      className="mt-4 border-t border-neutral-200 dark:border-gray-600 bg-sage dark:bg-gray-700 rounded-xl p-4"
+      className="mt-4 border-t border-neutral-200 dark:border-gray-600 p-4"
     >
       <section className="space-y-2">
         <div className="flex items-center justify-between">

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -31,9 +31,9 @@ export default function UnifiedTaskCard({
   const { Snackbar, showSnackbar } = useSnackbar()
 
   const bgClass = overdue
-    ? 'bg-red-50 dark:bg-red-800'
+    ? 'bg-pink-50 dark:bg-red-800'
     : urgent
-    ? 'bg-sage dark:bg-gray-700'
+    ? 'bg-yellow-50 dark:bg-gray-700'
     : 'bg-gray-50 dark:bg-gray-800'
 
   const lastText = lastCared ? formatDaysAgo(lastCared) : null
@@ -182,16 +182,16 @@ export default function UnifiedTaskCard({
               </Badge>
             ) : null}
           </div>
-          <div className="flex items-center gap-4 mt-1 font-semibold text-gray-700 dark:text-gray-200">
+          <div className="flex items-center gap-4 mt-1 font-semibold">
             {dueWater && (
-              <span className="inline-flex items-center gap-1">
-                <Drop className="w-4 h-4 text-water-600" aria-hidden="true" />
+              <span className="inline-flex items-center gap-1 text-amber-600">
+                <Drop className="w-4 h-4" aria-hidden="true" />
                 Water
               </span>
             )}
             {dueFertilize && (
-              <span className="inline-flex items-center gap-1">
-                <Sun className="w-4 h-4 text-fertilize-600" aria-hidden="true" />
+              <span className="inline-flex items-center gap-1 text-red-600">
+                <Sun className="w-4 h-4" aria-hidden="true" />
                 Fertilize
               </span>
             )}

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -66,7 +66,7 @@ test('applies urgent style', () => {
     </MemoryRouter>
   )
   const wrapper = container.querySelector('[data-testid="unified-task-card"]')
-  expect(wrapper).toHaveClass('bg-sage')
+  expect(wrapper).toHaveClass('bg-yellow-50')
 })
 
 test('applies overdue style', () => {
@@ -76,7 +76,7 @@ test('applies overdue style', () => {
     </MemoryRouter>
   )
   const wrapper = container.querySelector('[data-testid="unified-task-card"]')
-  expect(wrapper).toHaveClass('bg-red-50')
+  expect(wrapper).toHaveClass('bg-pink-50')
 })
 
 test('matches snapshot in dark mode', () => {

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -220,14 +220,14 @@ exports[`matches snapshot in dark mode 1`] = `
         </p>
       </div>
       <div
-        class="flex items-center gap-4 mt-1 font-semibold text-gray-700 dark:text-gray-200"
+        class="flex items-center gap-4 mt-1 font-semibold"
       >
         <span
-          class="inline-flex items-center gap-1"
+          class="inline-flex items-center gap-1 text-amber-600"
         >
           <svg
             aria-hidden="true"
-            class="w-4 h-4 text-water-600"
+            class="w-4 h-4"
             fill="currentColor"
             height="1em"
             viewBox="0 0 256 256"

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -118,7 +118,7 @@ test('tasks container renders with background', () => {
     </MemoryRouter>
   )
 
-  expect(screen.getByTestId('tasks-container')).toHaveClass('bg-sage')
+  expect(screen.getByTestId('tasks-container')).not.toHaveClass('bg-sage')
 })
 
 
@@ -140,7 +140,7 @@ test('featured section provides extra spacing', () => {
 
   const container = screen.getByTestId('tasks-container')
   expect(container).toBeInTheDocument()
-  expect(container).toHaveClass('bg-sage')
+  expect(container).not.toHaveClass('bg-sage')
 
 
   const section = screen.getByTestId('featured-card').closest('section')


### PR DESCRIPTION
## Summary
- adjust `TasksContainer` to remove green background wrapper
- color code task cards for watering and fertilizing
- update tests and snapshots for new styles

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687b1004c908832498eb08885952db6f