### PR TITLE
Fix nav list key

### DIFF
--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -29,7 +29,7 @@ export default function PersistentBottomNav() {
         {mainLinks.map(({ to, label, Icon: LinkIcon }) => {
           const showBadge = label === 'All Plants' && overdueCount > 0
           return (
-            <li key={label} className="relative">
+            <li key={to ?? label} className="relative">
               <NavLink
                 to={to}
                 title={label}
@@ -85,7 +85,7 @@ export default function PersistentBottomNav() {
               &times;
             </button>
             {moreItems.map(({ to, onClick, label, Icon: ItemIcon }) => (
-              <li key={label}>
+              <li key={to ?? label}>
                 {to ? (
                   <NavLink
                     to={to}

--- a/src/components/__tests__/PersistentBottomNav.test.jsx
+++ b/src/components/__tests__/PersistentBottomNav.test.jsx
@@ -13,7 +13,7 @@ const customMenu = {
   ...defaultMenu,
   items: [
     ...defaultMenu.items,
-    { to: '/profile', label: 'Profile', Icon: Gear },
+    { to: '/settings', label: 'Profile', Icon: Gear },
     { to: '/extra', label: 'Extra', Icon: Gear },
   ],
 }


### PR DESCRIPTION
## Summary
- use route as React key for `PersistentBottomNav` links
- adjust test menu to keep routes unique

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b11b109a08324b682cb5511d7ca00