### PR TITLE
Add gradient overlay class

### DIFF
--- a/src/components/ImageCard.jsx
+++ b/src/components/ImageCard.jsx
@@ -13,10 +13,7 @@ export default function ImageCard({
     <Card as={Component} className={`p-0 overflow-hidden relative ${className}`} {...props}>
       <div className="relative">
         <img src={imgSrc} alt={typeof title === 'string' ? title : ''} loading="lazy" className="plant-thumb" />
-        <div
-          className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent"
-          aria-hidden="true"
-        ></div>
+        <div className="img-gradient-overlay" aria-hidden="true"></div>
         {(title || badges) && (
           <div className="absolute bottom-1 left-2 right-2 drop-shadow text-white space-y-0.5">
             {title && (

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -198,7 +198,7 @@ exports[`matches snapshot in dark mode 1`] = `
       />
       <div
         aria-hidden="true"
-        class="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent"
+        class="img-gradient-overlay"
       />
       <div
         class="absolute bottom-1 left-2 right-2 drop-shadow text-white space-y-0.5"

--- a/src/index.css
+++ b/src/index.css
@@ -231,6 +231,11 @@ body {
   @apply w-full aspect-[3/4] object-cover rounded-xl;
 }
 
+/* Image gradient overlay */
+.img-gradient-overlay {
+  @apply absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent;
+}
+
 @layer utilities {
   .text-heading {
     @apply text-2xl;

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -137,10 +137,7 @@ export default function MyPlants() {
                 className="absolute inset-0 w-full h-full object-cover"
                 loading="lazy"
               />
-              <div
-                className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent"
-                aria-hidden="true"
-              ></div>
+              <div className="img-gradient-overlay" aria-hidden="true"></div>
               {overdue > 0 && (
                 <Badge
                   variant="overdue"

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -192,7 +192,7 @@ export default function PlantDetail() {
             loading="lazy"
             className="w-full h-64 object-cover"
           />
-          <div className="absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent" aria-hidden="true"></div>
+          <div className="img-gradient-overlay" aria-hidden="true"></div>
           <div className="absolute bottom-3 left-4 text-white drop-shadow">
             <h2 className="text-heading font-semibold font-headline">{plant.name}</h2>
             {plant.nickname && (


### PR DESCRIPTION
## Summary
- centralize gradient overlay style in index.css
- update ImageCard, MyPlants and PlantDetail components to use the new class
- update snapshot for PlantCard

## Testing
- `npm test --silent`


------
https://chatgpt.com/codex/tasks/task_e_687b1433e9308324a6b0e04c4703d0b8