### PR TITLE
Add modal overlay utility classes

### DIFF
--- a/src/components/AddMenu.jsx
+++ b/src/components/AddMenu.jsx
@@ -10,14 +10,14 @@ export default function AddMenu({ open = false, onClose = () => {} }) {
   ]
   return (
     <div
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
+      className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
       role="dialog"
       aria-modal="true"
       aria-label="Add menu"
       onClick={onClose}
     >
       <ul
-        className="relative bg-white dark:bg-gray-700 rounded-lg shadow-lg p-6 space-y-4 bloom-pop text-lg"
+        className="modal-box relative p-6 space-y-4 bloom-pop text-lg"
         onClick={e => e.stopPropagation()}
       >
         <button

--- a/src/components/CareSummaryModal.jsx
+++ b/src/components/CareSummaryModal.jsx
@@ -18,9 +18,9 @@ export default function CareSummaryModal({ tasks = [], onClose }) {
       role="dialog"
       aria-modal="true"
       aria-label="Care summary"
-      className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50"
+      className="modal-overlay bg-black bg-opacity-70 z-50"
     >
-      <div className="relative bg-white dark:bg-gray-700 rounded-lg shadow-lg p-4 w-72 max-w-full">
+      <div className="modal-box relative p-4 w-72 max-w-full">
         <button
           aria-label="Close"
           onClick={onClose}

--- a/src/components/ConfirmModal.jsx
+++ b/src/components/ConfirmModal.jsx
@@ -19,9 +19,9 @@ export default function ConfirmModal({ label = 'Are you sure?', onConfirm, onCan
       role="dialog"
       aria-modal="true"
       aria-label={label}
-      className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50"
+      className="modal-overlay bg-black bg-opacity-70 z-50"
     >
-      <div className="bg-white dark:bg-gray-700 rounded-lg shadow-lg p-4 w-72 max-w-full text-center">
+      <div className="modal-box p-4 w-72 max-w-full text-center">
         <p className="mb-4 font-body">{label}</p>
         <div className="flex justify-end gap-2">
           <button

--- a/src/components/CreateFab.jsx
+++ b/src/components/CreateFab.jsx
@@ -28,14 +28,14 @@ export default function CreateFab() {
     <div className="fixed bottom-24 right-20 z-30">
       {open && (
         <div
-          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
+          className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
           role="dialog"
           aria-modal="true"
           aria-label="Add menu"
           onClick={() => setOpen(false)}
         >
           <ul
-            className="relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
+            className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
             onClick={e => e.stopPropagation()}
           >
             <button

--- a/src/components/LegendModal.jsx
+++ b/src/components/LegendModal.jsx
@@ -6,9 +6,9 @@ export default function LegendModal({ onClose }) {
       role="dialog"
       aria-modal="true"
       aria-label="Legend"
-      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50"
+      className="modal-overlay bg-black/70 z-50"
     >
-      <div className="bg-white dark:bg-gray-700 rounded-lg shadow-lg p-4 w-72 max-w-full">
+      <div className="modal-box p-4 w-72 max-w-full">
         <h3 className="font-headline mb-2">Legend</h3>
         <ul className="space-y-2 text-sm">
           <li className="flex items-center gap-2">

--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -32,7 +32,7 @@ export default function Lightbox({ images, startIndex = 0, onClose, label = 'Ima
       role="dialog"
       aria-modal="true"
       aria-label={label}
-      className="fixed inset-0 bg-black bg-opacity-80 flex items-center justify-center z-50"
+      className="modal-overlay bg-black bg-opacity-80 z-50"
     >
       <button
         ref={closeBtnRef}

--- a/src/components/LogDetailsModal.jsx
+++ b/src/components/LogDetailsModal.jsx
@@ -9,9 +9,9 @@ export default function LogDetailsModal({ event, onClose }) {
       role="dialog"
       aria-modal="true"
       aria-label="Log details"
-      className="fixed inset-0 bg-black/70 flex items-center justify-center z-50"
+      className="modal-overlay bg-black/70 z-50"
     >
-      <div className="bg-white dark:bg-gray-700 rounded-lg shadow-lg p-4 w-72 max-w-full">
+      <div className="modal-box p-4 w-72 max-w-full">
         <div className="flex items-center gap-2 mb-2">
           {Icon && <Icon className="w-5 h-5" aria-hidden="true" />}
           <h3 className="font-headline text-heading">{event.label}</h3>

--- a/src/components/NoteFab.jsx
+++ b/src/components/NoteFab.jsx
@@ -17,14 +17,14 @@ export default function NoteFab({ onAddNote }) {
     <div className="absolute bottom-4 right-4 z-30">
       {open && (
         <div
-          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
+          className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
           role="dialog"
           aria-modal="true"
           aria-label="Add menu"
           onClick={() => setOpen(false)}
         >
           <ul
-            className="relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
+            className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
             onClick={e => e.stopPropagation()}
           >
             <button

--- a/src/components/NoteModal.jsx
+++ b/src/components/NoteModal.jsx
@@ -20,9 +20,9 @@ export default function NoteModal({ label = 'Add Note', onSave, onCancel }) {
       role="dialog"
       aria-modal="true"
       aria-label={label}
-      className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-50"
+      className="modal-overlay bg-black bg-opacity-70 z-50"
     >
-      <div className="bg-white dark:bg-gray-700 rounded-lg shadow-lg p-4 w-72 max-w-full">
+      <div className="modal-box p-4 w-72 max-w-full">
         <label className="block mb-2 font-headline" htmlFor="note-input">
           {label}
         </label>

--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -66,14 +66,14 @@ export default function PersistentBottomNav() {
       </ul>
       {open && moreItems.length > 0 && (
         <div
-          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
+          className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
           role="dialog"
           aria-modal="true"
           aria-label="Navigation menu"
           onClick={() => setOpen(false)}
         >
           <ul
-            className="relative bg-white dark:bg-gray-700 rounded-lg shadow-lg p-6 space-y-4 bloom-pop text-lg"
+            className="modal-box relative p-6 space-y-4 bloom-pop text-lg"
             onClick={e => e.stopPropagation()}
           >
             <button

--- a/src/components/PlantDetailFab.jsx
+++ b/src/components/PlantDetailFab.jsx
@@ -27,14 +27,14 @@ export default function PlantDetailFab({ onAddPhoto, onAddNote }) {
     <div className="absolute bottom-4 right-4 z-30">
       {open && (
         <div
-          className="fixed inset-0 bg-black/50 flex items-center justify-center z-30 backdrop-blur-sm"
+          className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
           role="dialog"
           aria-modal="true"
           aria-label="Add menu"
           onClick={() => setOpen(false)}
         >
           <ul
-            className="relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
+            className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
             onClick={e => e.stopPropagation()}
           >
             <button

--- a/src/index.css
+++ b/src/index.css
@@ -267,3 +267,12 @@ body {
 .task-action {
   @apply px-2 py-1 rounded text-xs flex items-center gap-1 font-body transition;
 }
+
+/* Reusable modal styling */
+.modal-overlay {
+  @apply fixed inset-0 flex items-center justify-center;
+}
+
+.modal-box {
+  @apply bg-white dark:bg-gray-700 rounded-lg shadow-lg;
+}


### PR DESCRIPTION
## Summary
- add `.modal-overlay` and `.modal-box` utilities
- refactor all modal components to use the new classes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b15f41c60832485ac0ce104471a08