### PR TITLE
Add reusable modal-close class

### DIFF
--- a/src/components/AddMenu.jsx
+++ b/src/components/AddMenu.jsx
@@ -24,7 +24,7 @@ export default function AddMenu({ open = false, onClose = () => {} }) {
           type="button"
           aria-label="Close menu"
           onClick={onClose}
-          className="absolute top-2 right-2 text-gray-500"
+          className="modal-close"
         >
           &times;
         </button>

--- a/src/components/CareSummaryModal.jsx
+++ b/src/components/CareSummaryModal.jsx
@@ -24,7 +24,7 @@ export default function CareSummaryModal({ tasks = [], onClose }) {
         <button
           aria-label="Close"
           onClick={onClose}
-          className="absolute top-2 right-2 text-gray-500"
+          className="modal-close"
         >
           &times;
         </button>

--- a/src/index.css
+++ b/src/index.css
@@ -267,3 +267,8 @@ body {
 .task-action {
   @apply px-2 py-1 rounded text-xs flex items-center gap-1 font-body transition;
 }
+
+/* Standard close button for modals and menus */
+.modal-close {
+  @apply absolute top-2 right-2 text-gray-500;
+}


### PR DESCRIPTION
## Summary
- add `modal-close` class for consistent styling
- use `modal-close` in AddMenu and CareSummaryModal

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b16e06ecc832499ab9da0f4eb470f