### PR TITLE
Add delay for unified task completion

### DIFF
--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -70,15 +70,17 @@ export default function UnifiedTaskCard({
 
   const handleComplete = () => {
     const prev = plants.find(p => p.id === plant.id)
-    if (dueWater) {
-      markWatered(plant.id, '')
-    }
-    if (dueFertilize) {
-      markFertilized(plant.id, '')
-    }
     if (dueWater || dueFertilize) {
-      showSnackbar('Done', () => updatePlant(plant.id, prev))
       setCompleted(true)
+      setTimeout(() => {
+        if (dueWater) {
+          markWatered(plant.id, '')
+        }
+        if (dueFertilize) {
+          markFertilized(plant.id, '')
+        }
+        showSnackbar('Done', () => updatePlant(plant.id, prev))
+      }, 400)
     }
   }
 


### PR DESCRIPTION
## Summary
- ensure UnifiedTaskCard waits ~400ms before updating plant data

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b192b83308324b2c6297e62f09c85