### PR TITLE
Add SnackbarProvider context

### DIFF
--- a/src/__tests__/FabVisibility.test.jsx
+++ b/src/__tests__/FabVisibility.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import App from '../App.jsx'
+import SnackbarProvider, { Snackbar } from '../hooks/SnackbarProvider.jsx'
 
 jest.mock('../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: [] }),
@@ -25,9 +26,12 @@ jest.mock('../RoomContext.jsx', () => ({
 describe('floating action button visibility', () => {
   test('shows fab on All Plants page', () => {
     render(
-      <MemoryRouter initialEntries={[ '/myplants' ]}>
-        <App />
-      </MemoryRouter>
+      <SnackbarProvider>
+        <MemoryRouter initialEntries={[ '/myplants' ]}>
+          <App />
+        </MemoryRouter>
+        <Snackbar />
+      </SnackbarProvider>
     )
 
     const button = screen.getByRole('button', { name: /open create menu/i })
@@ -39,9 +43,12 @@ describe('floating action button visibility', () => {
 
   test('fab hidden on Profile page', () => {
     render(
-      <MemoryRouter initialEntries={[ '/profile' ]}>
-        <App />
-      </MemoryRouter>
+      <SnackbarProvider>
+        <MemoryRouter initialEntries={[ '/profile' ]}>
+          <App />
+        </MemoryRouter>
+        <Snackbar />
+      </SnackbarProvider>
     )
 
     expect(screen.queryByRole('button', { name: /open create menu/i })).toBeNull()

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -18,7 +18,7 @@ export default function PlantCard({ plant }) {
   const navigate = useNavigate()
   const { plants, markWatered, removePlant, updatePlant, restorePlant } =
     usePlants()
-  const { Snackbar, showSnackbar } = useSnackbar()
+  const { showSnackbar } = useSnackbar()
   const [showActions, setShowActions] = useState(false)
   const [showNote, setShowNote] = useState(false)
   const [showConfirm, setShowConfirm] = useState(false)
@@ -252,7 +252,6 @@ export default function PlantCard({ plant }) {
         onCancel={cancelDelete}
       />
     )}
-    <Snackbar />
     </>
   )
 }

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -16,7 +16,7 @@ export default function TaskCard({
   const { daysSince, eto } = getWateringInfo(task.lastWatered, { eto: task.eto })
   const navigate = useNavigate()
   const { plants, markWatered, markFertilized, updatePlant } = usePlants()
-  const { Snackbar, showSnackbar } = useSnackbar()
+  const { showSnackbar } = useSnackbar()
 
   const goToDetail = e => {
     e.stopPropagation()
@@ -212,7 +212,6 @@ export default function TaskCard({
             </div>
           )}
         </div>
-      <Snackbar />
     </>
   )
 }

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -28,7 +28,7 @@ export default function UnifiedTaskCard({
   const [completed, setCompleted] = useState(false)
   const navigate = useNavigate()
   const { plants, markWatered, markFertilized, updatePlant } = usePlants()
-  const { Snackbar, showSnackbar } = useSnackbar()
+  const { showSnackbar } = useSnackbar()
 
   const bgClass = overdue
     ? 'bg-pink-50 dark:bg-red-800'
@@ -226,7 +226,6 @@ export default function UnifiedTaskCard({
           </svg>
         </div>
       )}
-      <Snackbar />
     </div>
   )
 }

--- a/src/components/__tests__/PlantCard.test.jsx
+++ b/src/components/__tests__/PlantCard.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, act } from '@testing-library/react'
 import userEvent from '@testing-library/user-event'
 import PlantCard from '../PlantCard.jsx'
 import { MemoryRouter, useNavigate } from 'react-router-dom'
+import SnackbarProvider, { Snackbar } from '../../hooks/SnackbarProvider.jsx'
 import { usePlants } from '../../PlantContext.jsx'
 
 beforeAll(() => {
@@ -24,6 +25,17 @@ jest.mock('../../PlantContext.jsx', () => ({
 }))
 
 const usePlantsMock = usePlants
+
+function renderWithSnackbar(ui) {
+  return render(
+    <SnackbarProvider>
+      <MemoryRouter>
+        {ui}
+      </MemoryRouter>
+      <Snackbar />
+    </SnackbarProvider>
+  )
+}
 
 beforeEach(() => {
   navigateMock.mockClear()
@@ -50,19 +62,15 @@ const plant = {
 }
 
 test('renders plant name', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   expect(screen.getByText('Aloe Vera')).toBeInTheDocument()
 })
 
 test('water button triggers watering with note', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   fireEvent.click(screen.getByText('Water'))
   const dialog = screen.getByRole('dialog', { name: /optional note/i })
@@ -72,20 +80,16 @@ test('water button triggers watering with note', () => {
 })
 
 test('edit button navigates to edit page', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   fireEvent.click(screen.getByText('Edit'))
   expect(navigateMock).toHaveBeenCalledWith('/plant/1/edit')
 })
 
 test('delete button shows confirm modal before removing plant', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   fireEvent.click(screen.getByText('Delete'))
   const dialog = screen.getByRole('dialog', { name: /delete this plant/i })
@@ -95,10 +99,8 @@ test('delete button shows confirm modal before removing plant', () => {
 })
 
 test('delete cancelled does not remove plant', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   fireEvent.click(screen.getByText('Delete'))
   fireEvent.click(screen.getByText('Cancel'))
@@ -106,10 +108,8 @@ test('delete cancelled does not remove plant', () => {
 })
 
 test('clicking card adds ripple effect', () => {
-  const { container } = render(
-    <MemoryRouter>
+  const { container } = renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   const wrapper = screen.getByTestId('card-wrapper')
   fireEvent.mouseDown(wrapper)
@@ -117,10 +117,8 @@ test('clicking card adds ripple effect', () => {
 })
 
 test('arrow right opens watering note modal', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   const wrapper = screen.getByTestId('card-wrapper')
   wrapper.focus()
@@ -129,10 +127,8 @@ test('arrow right opens watering note modal', () => {
 })
 
 test('arrow left navigates to edit page', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   const wrapper = screen.getByTestId('card-wrapper')
   wrapper.focus()
@@ -143,10 +139,8 @@ test('arrow left navigates to edit page', () => {
 
 test('delete key confirms before removing plant', () => {
 
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   const wrapper = screen.getByTestId('card-wrapper')
   wrapper.focus()
@@ -158,10 +152,8 @@ test('delete key confirms before removing plant', () => {
 })
 
 test('backspace key confirms before removing plant', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   const wrapper = screen.getByTestId('card-wrapper')
   wrapper.focus()
@@ -173,10 +165,8 @@ test('backspace key confirms before removing plant', () => {
 })
 
 test('swipe right waters plant', async () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   const wrapper = screen.getByTestId('card-wrapper')
 
@@ -195,10 +185,8 @@ test('swipe right waters plant', async () => {
 })
 
 test('swipe left navigates to edit page', async () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   const wrapper = screen.getByTestId('card-wrapper')
   const user = userEvent.setup()
@@ -216,10 +204,8 @@ test('swipe left navigates to edit page', async () => {
 })
 
 test('swipe far left shows confirm modal and removes plant', async () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   const wrapper = screen.getByTestId('card-wrapper')
   const user = userEvent.setup()
@@ -241,10 +227,8 @@ test('swipe far left shows confirm modal and removes plant', async () => {
 
 test('matches snapshot in dark mode', () => {
   document.documentElement.classList.add('dark')
-  const { container } = render(
-    <MemoryRouter>
+  const { container } = renderWithSnackbar(
       <PlantCard plant={plant} />
-    </MemoryRouter>
   )
   expect(container.firstChild).toMatchSnapshot()
   document.documentElement.classList.remove('dark')

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, useNavigate } from 'react-router-dom'
+import SnackbarProvider, { Snackbar } from '../../hooks/SnackbarProvider.jsx'
 import TaskCard from '../TaskCard.jsx'
 import BaseCard from '../BaseCard.jsx'
 import { usePlants } from '../../PlantContext.jsx'
@@ -19,6 +20,17 @@ jest.mock('../../PlantContext.jsx', () => ({
 }))
 
 const usePlantsMock = usePlants
+
+function renderWithSnackbar(ui) {
+  return render(
+    <SnackbarProvider>
+      <MemoryRouter>
+        {ui}
+      </MemoryRouter>
+      <Snackbar />
+    </SnackbarProvider>
+  )
+}
 
 beforeEach(() => {
   navigateMock.mockClear()
@@ -44,12 +56,10 @@ const task = {
 }
 
 test('renders task text', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <BaseCard variant="task">
         <TaskCard task={task} />
       </BaseCard>
-    </MemoryRouter>
   )
   expect(screen.getByText('Monstera')).toBeInTheDocument()
   const badge = screen.getByText('To Water')
@@ -62,24 +72,20 @@ test('renders task text', () => {
 })
 
 test('incomplete tasks show alert style', () => {
-  const { container } = render(
-    <MemoryRouter>
+  const { container } = renderWithSnackbar(
       <BaseCard variant="task">
         <TaskCard task={task} />
       </BaseCard>
-    </MemoryRouter>
   )
   const wrapper = container.querySelector('.shadow')
   expect(wrapper).toHaveClass('bg-neutral-50')
 })
 
 test('applies highlight when urgent', () => {
-  const { container } = render(
-    <MemoryRouter>
+  const { container } = renderWithSnackbar(
       <BaseCard variant="task">
         <TaskCard task={task} urgent />
       </BaseCard>
-    </MemoryRouter>
   )
   const wrapper = container.querySelector('.shadow')
   expect(wrapper).toHaveClass('ring-green-300')
@@ -88,12 +94,10 @@ test('applies highlight when urgent', () => {
 
 
 test('shows completed state', () => {
-  const { container } = render(
-    <MemoryRouter>
+  const { container } = renderWithSnackbar(
       <BaseCard variant="task">
         <TaskCard task={task} completed />
       </BaseCard>
-    </MemoryRouter>
   )
   const wrapper = container.querySelector('.shadow')
   expect(wrapper).toHaveClass('opacity-50')
@@ -102,12 +106,10 @@ test('shows completed state', () => {
 })
 
 test('renders badge icon', () => {
-  const { container } = render(
-    <MemoryRouter>
+  const { container } = renderWithSnackbar(
       <BaseCard variant="task">
         <TaskCard task={task} />
       </BaseCard>
-    </MemoryRouter>
   )
   const svg = container.querySelector('svg')
   expect(svg).toBeInTheDocument()
@@ -115,12 +117,10 @@ test('renders badge icon', () => {
 
 test('shows info chip with accessibility label', () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <BaseCard variant="task">
         <TaskCard task={task} />
       </BaseCard>
-    </MemoryRouter>
   )
   const chip = screen.getByText(/Evapotranspiration/i)
   expect(chip).toHaveAttribute(
@@ -132,24 +132,20 @@ test('shows info chip with accessibility label', () => {
 
 test('compact mode hides reason and evapotranspiration info', () => {
   const compactTask = { ...task, reason: 'Needs water' }
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <BaseCard variant="task">
         <TaskCard task={compactTask} compact />
       </BaseCard>
-    </MemoryRouter>
   )
   expect(screen.queryByText('Needs water')).not.toBeInTheDocument()
   expect(screen.queryByText(/Evapotranspiration/)).not.toBeInTheDocument()
 })
 
 test('partial left swipe reveals actions', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <BaseCard variant="task">
         <TaskCard task={task} />
       </BaseCard>
-    </MemoryRouter>
   )
   const wrapper = screen.getByTestId('task-card')
   fireEvent.pointerDown(wrapper, { clientX: 100, buttons: 1 })
@@ -168,12 +164,10 @@ test('partial left swipe reveals actions', () => {
 test('matches snapshot in dark mode', () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-16'))
   document.documentElement.classList.add('dark')
-  const { container } = render(
-    <MemoryRouter>
+  const { container } = renderWithSnackbar(
       <BaseCard variant="task">
         <TaskCard task={task} urgent />
       </BaseCard>
-    </MemoryRouter>
   )
   expect(container.firstChild).toMatchSnapshot()
   document.documentElement.classList.remove('dark')

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, useNavigate } from 'react-router-dom'
 import UnifiedTaskCard from '../UnifiedTaskCard.jsx'
 import { usePlants } from '../../PlantContext.jsx'
+import SnackbarProvider, { Snackbar } from '../../hooks/SnackbarProvider.jsx'
 
 const navigateMock = jest.fn()
 const markWatered = jest.fn()
@@ -20,6 +21,17 @@ jest.mock('../../PlantContext.jsx', () => ({
 }))
 
 const usePlantsMock = usePlants
+
+function renderWithSnackbar(ui) {
+  return render(
+    <SnackbarProvider>
+      <MemoryRouter>
+        {ui}
+      </MemoryRouter>
+      <Snackbar />
+    </SnackbarProvider>
+  )
+}
 
 const plant = {
   id: 1,
@@ -45,10 +57,8 @@ beforeEach(() => {
 })
 
 test('renders plant info and badges', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <UnifiedTaskCard plant={plant} />
-    </MemoryRouter>
   )
   expect(screen.getByText('Fern')).toBeInTheDocument()
   const waterBadge = screen.getByText('Water')
@@ -60,20 +70,16 @@ test('renders plant info and badges', () => {
 })
 
 test('applies urgent style', () => {
-  const { container } = render(
-    <MemoryRouter>
+  const { container } = renderWithSnackbar(
       <UnifiedTaskCard plant={plant} urgent />
-    </MemoryRouter>
   )
   const wrapper = container.querySelector('[data-testid="unified-task-card"]')
   expect(wrapper).toHaveClass('bg-yellow-50')
 })
 
 test('applies overdue style', () => {
-  const { container } = render(
-    <MemoryRouter>
+  const { container } = renderWithSnackbar(
       <UnifiedTaskCard plant={plant} overdue />
-    </MemoryRouter>
   )
   const wrapper = container.querySelector('[data-testid="unified-task-card"]')
   expect(wrapper).toHaveClass('bg-pink-50')
@@ -81,29 +87,23 @@ test('applies overdue style', () => {
 
 test('matches snapshot in dark mode', () => {
   document.documentElement.classList.add('dark')
-  const { container } = render(
-    <MemoryRouter>
+  const { container } = renderWithSnackbar(
       <UnifiedTaskCard plant={plant} />
-    </MemoryRouter>
   )
   expect(container.firstChild).toMatchSnapshot()
   document.documentElement.classList.remove('dark')
 })
 
 test('does not render a completion button', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <UnifiedTaskCard plant={plant} />
-    </MemoryRouter>
   )
   expect(screen.queryByRole('button', { name: /mark as done/i })).toBeNull()
 })
 
 test('partial left swipe reveals actions', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <UnifiedTaskCard plant={plant} />
-    </MemoryRouter>
   )
   const wrapper = screen.getByTestId('unified-task-card')
   fireEvent.pointerDown(wrapper, { clientX: 100, buttons: 1 })

--- a/src/hooks/SnackbarProvider.jsx
+++ b/src/hooks/SnackbarProvider.jsx
@@ -1,0 +1,55 @@
+import { createContext, useContext, useState, useRef, useCallback } from 'react'
+
+const SnackbarContext = createContext()
+
+export function SnackbarProvider({ children, timeout = 5000 }) {
+  const [snack, setSnack] = useState(null)
+  const timer = useRef()
+
+  const showSnackbar = useCallback((message, undoFn) => {
+    clearTimeout(timer.current)
+    setSnack({ message, undoFn })
+    timer.current = setTimeout(() => setSnack(null), timeout)
+  }, [timeout])
+
+  const hideSnackbar = useCallback(() => {
+    clearTimeout(timer.current)
+    setSnack(null)
+  }, [])
+
+  return (
+    <SnackbarContext.Provider value={{ snack, showSnackbar, hideSnackbar }}>
+      {children}
+    </SnackbarContext.Provider>
+  )
+}
+
+export const useSnackbarContext = () => useContext(SnackbarContext)
+
+export function Snackbar() {
+  const { snack, hideSnackbar } = useSnackbarContext()
+
+  const handleUndo = () => {
+    if (snack?.undoFn) snack.undoFn()
+    hideSnackbar()
+  }
+
+  return snack ? (
+    <div className="fixed inset-x-0 bottom-0 pb-safe flex justify-center pointer-events-none">
+      <div
+        className="m-4 bg-gray-800 text-white px-4 py-2 rounded shadow pointer-events-auto flex items-center gap-4"
+        role="status"
+      >
+        <span>{snack.message}</span>
+        {snack.undoFn && (
+          <button onClick={handleUndo} className="underline text-sm">
+            Undo
+          </button>
+        )}
+      </div>
+      <div aria-live="polite" className="sr-only">{snack.message}</div>
+    </div>
+  ) : null
+}
+
+export default SnackbarProvider

--- a/src/hooks/useSnackbar.jsx
+++ b/src/hooks/useSnackbar.jsx
@@ -1,42 +1,5 @@
-import { useCallback, useRef, useState } from 'react'
+import { useSnackbarContext } from './SnackbarProvider.jsx'
 
-export default function useSnackbar(timeout = 5000) {
-  const [snack, setSnack] = useState(null)
-  const timer = useRef()
-
-  const showSnackbar = useCallback((message, undoFn) => {
-    clearTimeout(timer.current)
-    setSnack({ message, undoFn })
-    timer.current = setTimeout(() => setSnack(null), timeout)
-  }, [timeout])
-
-  const hideSnackbar = useCallback(() => {
-    clearTimeout(timer.current)
-    setSnack(null)
-  }, [])
-
-  const handleUndo = useCallback(() => {
-    if (snack?.undoFn) snack.undoFn()
-    hideSnackbar()
-  }, [snack, hideSnackbar])
-
-  const Snackbar = () =>
-    snack ? (
-      <div className="fixed inset-x-0 bottom-0 pb-safe flex justify-center pointer-events-none">
-        <div
-          className="m-4 bg-gray-800 text-white px-4 py-2 rounded shadow pointer-events-auto flex items-center gap-4"
-          role="status"
-        >
-          <span>{snack.message}</span>
-          {snack.undoFn && (
-            <button onClick={handleUndo} className="underline text-sm">
-              Undo
-            </button>
-          )}
-        </div>
-        <div aria-live="polite" className="sr-only">{snack.message}</div>
-      </div>
-    ) : null
-
-  return { Snackbar, showSnackbar, hideSnackbar }
+export default function useSnackbar() {
+  return useSnackbarContext()
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,23 +7,27 @@ import { RoomProvider } from './RoomContext.jsx'
 import { ThemeProvider } from './ThemeContext.jsx'
 import { WeatherProvider } from './WeatherContext.jsx'
 import { UserProvider } from './UserContext.jsx'
+import SnackbarProvider, { Snackbar } from './hooks/SnackbarProvider.jsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <UserProvider>
-      <ThemeProvider>
-        <WeatherProvider>
-          <PlantProvider>
-            <RoomProvider>
-              <BrowserRouter basename={import.meta.env.VITE_BASE_PATH}>
-                <App />
-              </BrowserRouter>
-            </RoomProvider>
-          </PlantProvider>
-        </WeatherProvider>
-      </ThemeProvider>
-    </UserProvider>
+    <SnackbarProvider>
+      <UserProvider>
+        <ThemeProvider>
+          <WeatherProvider>
+            <PlantProvider>
+              <RoomProvider>
+                <BrowserRouter basename={import.meta.env.VITE_BASE_PATH}>
+                  <App />
+                </BrowserRouter>
+              </RoomProvider>
+            </PlantProvider>
+            <Snackbar />
+          </WeatherProvider>
+        </ThemeProvider>
+      </UserProvider>
+    </SnackbarProvider>
   </React.StrictMode>
 )
 

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -7,14 +7,12 @@ import Panel from '../components/Panel.jsx'
 import ToggleSwitch from '../components/ToggleSwitch.jsx'
 import PageContainer from "../components/PageContainer.jsx"
 
-import useSnackbar from '../hooks/useSnackbar.jsx'
 
 
 export default function Settings() {
   const { theme, toggleTheme } = useTheme()
   const { location, setLocation, units, setUnits } = useWeather()
   const { username, setUsername, timeZone, setTimeZone } = useUser()
-  const { Snackbar, showSnackbar } = useSnackbar()
 
   return (
     <PageContainer className="space-y-6 text-gray-700 dark:text-gray-200">
@@ -96,7 +94,6 @@ export default function Settings() {
         </Panel>
       </div>
 
-      <Snackbar />
     </PageContainer>
   )
 }

--- a/src/pages/__tests__/Add.test.jsx
+++ b/src/pages/__tests__/Add.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, act } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import Add from '../Add.jsx'
 import Home from '../Home.jsx'
+import SnackbarProvider, { Snackbar } from '../../hooks/SnackbarProvider.jsx'
 import { PlantProvider } from '../../PlantContext.jsx'
 import { RoomProvider } from '../../RoomContext.jsx'
 
@@ -13,9 +14,18 @@ jest.mock('../../UserContext.jsx', () => ({
   useUser: () => ({ username: 'Jon', timeZone: 'UTC' }),
 }))
 
+function renderWithSnackbar(ui) {
+  return render(
+    <SnackbarProvider>
+      {ui}
+      <Snackbar />
+    </SnackbarProvider>
+  )
+}
+
 test('user can complete steps and add a plant', () => {
   jest.useFakeTimers()
-  render(
+  renderWithSnackbar(
     <PlantProvider>
       <RoomProvider>
         <MemoryRouter initialEntries={['/add']}>

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -1,6 +1,7 @@
 import { render, screen } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Home from '../Home.jsx'
+import SnackbarProvider, { Snackbar } from '../../hooks/SnackbarProvider.jsx'
 
 jest.mock('../../WeatherContext.jsx', () => ({
   useWeather: () => ({ forecast: { rainfall: 0 } }),
@@ -16,15 +17,22 @@ jest.mock('../../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: mockPlants }),
 }))
 
+function renderWithSnackbar(ui) {
+  return render(
+    <SnackbarProvider>
+      <MemoryRouter>{ui}</MemoryRouter>
+      <Snackbar />
+    </SnackbarProvider>
+  )
+}
+
 afterEach(() => {
   jest.useRealTimers()
 })
 
 test('shows upbeat message when there are no tasks', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Home />
-    </MemoryRouter>
   )
   expect(screen.getByText(/all plants are happy/i)).toBeInTheDocument()
   expect(screen.getByTestId('care-stats')).toBeInTheDocument()
@@ -44,10 +52,8 @@ test('care stats render when tasks exist', () => {
     nextFertilize: '2025-07-10',
   })
 
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Home />
-    </MemoryRouter>
   )
 
   const stats = screen.getByTestId('care-stats')
@@ -67,10 +73,8 @@ test('featured card appears before care stats', () => {
     nextFertilize: '2025-07-10',
   })
 
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Home />
-    </MemoryRouter>
   )
 
   const featured = screen.getByTestId('featured-card')
@@ -97,10 +101,8 @@ test('earliest due task appears first', () => {
     }
   )
 
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Home />
-    </MemoryRouter>
   )
 
   const tasks = screen.getAllByTestId('unified-task-card')
@@ -112,10 +114,8 @@ test('earliest due task appears first', () => {
 
 
 test('tasks container renders with background', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Home />
-    </MemoryRouter>
   )
 
   expect(screen.getByTestId('tasks-container')).not.toHaveClass('bg-sage')
@@ -132,10 +132,8 @@ test('featured section provides extra spacing', () => {
     nextFertilize: '2025-07-10',
   })
 
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Home />
-    </MemoryRouter>
   )
 
   const container = screen.getByTestId('tasks-container')

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -2,6 +2,7 @@ import { render, screen, fireEvent, within, cleanup } from '@testing-library/rea
 
 import { MemoryRouter } from 'react-router-dom'
 import userEvent from '@testing-library/user-event'
+import SnackbarProvider, { Snackbar } from '../../hooks/SnackbarProvider.jsx'
 
 
 import Tasks from '../Tasks.jsx'
@@ -31,6 +32,15 @@ jest.mock('../../WeatherContext.jsx', () => ({
   useWeather: () => ({ forecast: { rainfall: 0 } }),
 }))
 
+function renderWithSnackbar(ui) {
+  return render(
+    <SnackbarProvider>
+      <MemoryRouter>{ui}</MemoryRouter>
+      <Snackbar />
+    </SnackbarProvider>
+  )
+}
+
 beforeEach(() => {
   mockPlants = samplePlants
   localStorage.clear()
@@ -38,10 +48,8 @@ beforeEach(() => {
 
 test('ignores activities without valid dates when generating events', () => {
   jest.useFakeTimers().setSystemTime(new Date("2025-07-16"))
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Tasks />
-    </MemoryRouter>
   )
 
   expect(screen.queryByText(/Repotted/)).toBeNull()
@@ -61,10 +69,8 @@ test('ignores activities without valid dates when generating events', () => {
 
 test('shows friendly message when there are no tasks', () => {
   mockPlants = []
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Tasks />
-    </MemoryRouter>
   )
 
   expect(screen.getByText(/All caught up/i)).toBeInTheDocument()
@@ -74,10 +80,8 @@ test('shows friendly message when there are no tasks', () => {
 
 test('filters by type', () => {
   jest.useFakeTimers().setSystemTime(new Date("2025-07-16"))
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Tasks />
-    </MemoryRouter>
   )
 
   const selects = screen.getAllByRole('combobox')
@@ -91,10 +95,8 @@ test('filters by type', () => {
 })
 
 test('sorts by plant name', () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Tasks />
-    </MemoryRouter>
   )
 
   const selects = screen.getAllByRole('combobox')
@@ -107,10 +109,8 @@ test('sorts by plant name', () => {
 
 
 test('switching to Past tab shows past events', async () => {
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Tasks />
-    </MemoryRouter>
   )
 
   const pastTab = screen.getByRole('tab', { name: /Past/i })
@@ -135,10 +135,8 @@ test('completed tasks are styled', () => {
       lastFertilized: today,
     },
   ]
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Tasks />
-    </MemoryRouter>
   )
   const cards = screen.getAllByTestId('task-card')
   expect(cards[0]).toHaveClass('opacity-50')
@@ -151,10 +149,8 @@ test('completed tasks are styled', () => {
 test('future watering date does not show Water badge', async () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
 
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Tasks />
-    </MemoryRouter>
   )
 
   const tab = screen.getByRole('tab', { name: /By Plant/i })
@@ -169,10 +165,8 @@ test('future watering date does not show Water badge', async () => {
 
   cleanup()
 
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Tasks />
-    </MemoryRouter>
   )
 
 
@@ -205,10 +199,8 @@ test('by plant view shows due and future tasks correctly', async () => {
     },
   ]
 
-  render(
-    <MemoryRouter>
+  renderWithSnackbar(
       <Tasks />
-    </MemoryRouter>
   )
 
   const byPlantTab = screen.getByRole('tab', { name: /By Plant/i })


### PR DESCRIPTION
## Summary
- add global `SnackbarProvider` with `Snackbar` component
- wrap application in the provider
- update components to use shared snackbar
- adjust pages and tests for the provider

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687b19345000832480b28a31a9b828b8