### PR TITLE
Switch to single controlled accordion on PlantDetail

### DIFF
--- a/src/components/AccordionGroup.jsx
+++ b/src/components/AccordionGroup.jsx
@@ -1,0 +1,26 @@
+import { useState } from 'react'
+
+export default function AccordionGroup({ sections = [] }) {
+  const [active, setActive] = useState(null)
+
+  return (
+    <div className="space-y-4">
+      {sections.map(({ id, title, content }) => (
+        <div key={id} className="border rounded-xl divide-y">
+          <button
+            type="button"
+            onClick={() => setActive(active === id ? null : id)}
+            aria-expanded={active === id}
+            className="w-full flex justify-between items-center px-4 py-2 font-semibold text-left"
+          >
+            <span>{title}</span>
+            <span className="text-sm text-green-600">
+              {active === id ? 'Hide Details' : 'Show Details'}
+            </span>
+          </button>
+          {active === id && <div className="p-4">{content}</div>}
+        </div>
+      ))}
+    </div>
+  )
+}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -31,6 +31,8 @@ test('renders plant details without duplicates', () => {
   expect(screen.getByText(plant.humidity)).toBeInTheDocument()
   expect(screen.getByText(plant.difficulty)).toBeInTheDocument()
 
+  fireEvent.click(screen.getByRole('button', { name: /care overview/i }))
+
   const wateredLabel = screen.getByText(/Last watered/i)
   expect(
     within(wateredLabel.parentElement).getByText(new RegExp(plant.lastWatered))
@@ -78,8 +80,8 @@ test('displays all sections', () => {
     </MenuProvider>
   )
 
-  expect(screen.getByRole('button', { name: /care details/i })).toBeInTheDocument()
-  expect(screen.getByRole('button', { name: /activity & notes/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /care overview/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /activity/i })).toBeInTheDocument()
   expect(screen.getByRole('button', { name: /gallery/i })).toBeInTheDocument()
 })
 

--- a/src/pages/__tests__/PlantDetailActions.test.jsx
+++ b/src/pages/__tests__/PlantDetailActions.test.jsx
@@ -50,6 +50,8 @@ test('quick stats action buttons trigger handlers', () => {
     </MenuProvider>
   )
 
+  fireEvent.click(screen.getByRole('button', { name: /care overview/i }))
+
   fireEvent.click(
     screen.getAllByRole('button', { name: /mark plant a as watered/i })[0]
   )

--- a/src/pages/__tests__/PlantDetailCareLog.test.jsx
+++ b/src/pages/__tests__/PlantDetailCareLog.test.jsx
@@ -37,7 +37,7 @@ test('shows notes from care log in timeline', () => {
     </MenuProvider>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /activity & notes/i }))
+  fireEvent.click(screen.getByRole('button', { name: /activity/i }))
 
   expect(screen.getByText('July 2, 2025')).toBeInTheDocument()
   expect(screen.getAllByText(/Watered/).length).toBeGreaterThan(0)
@@ -56,7 +56,7 @@ test('timeline bullet markup matches snapshot', () => {
     </MenuProvider>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /activity & notes/i }))
+  fireEvent.click(screen.getByRole('button', { name: /activity/i }))
 
   const list = container.querySelector('ul')
   expect(list).toMatchSnapshot()


### PR DESCRIPTION
## Summary
- introduce `AccordionGroup` component to manage a single open section
- use `AccordionGroup` in `PlantDetail` and define sections for Care Overview, Activity, and Gallery
- update tests to open new sections by name

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b1b8e3c4c8324861dbe21d5bd1ec5