### PR TITLE
Remove progress rings from plant details

### DIFF
--- a/src/components/PlantDetailFab.jsx
+++ b/src/components/PlantDetailFab.jsx
@@ -1,7 +1,12 @@
 import { useState, useEffect } from 'react'
-import { Plus, Image as ImageIcon, Note } from 'phosphor-react'
+import { Plus, Image as ImageIcon, Note, Drop, Flower } from 'phosphor-react'
 
-export default function PlantDetailFab({ onAddPhoto, onAddNote }) {
+export default function PlantDetailFab({
+  onAddPhoto,
+  onAddNote,
+  onWater,
+  onFertilize,
+}) {
   const [open, setOpen] = useState(false)
 
   useEffect(() => {
@@ -14,11 +19,20 @@ export default function PlantDetailFab({ onAddPhoto, onAddNote }) {
   }, [open])
 
   const items = [
+    { label: 'Mark Watered', Icon: Drop, action: onWater, color: 'blue' },
+    {
+      label: 'Mark Fertilized',
+      Icon: Flower,
+      action: onFertilize,
+      color: 'yellow',
+    },
     { label: 'Add Photo', Icon: ImageIcon, action: onAddPhoto, color: 'green' },
     { label: 'Add Note', Icon: Note, action: onAddNote, color: 'violet' },
   ]
 
   const colorClasses = {
+    blue: { bg: 'bg-blue-100', text: 'text-blue-600' },
+    yellow: { bg: 'bg-yellow-100', text: 'text-yellow-600' },
     green: { bg: 'bg-green-100', text: 'text-green-600' },
     violet: { bg: 'bg-violet-100', text: 'text-violet-600' },
   }

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -187,19 +187,9 @@ export default function PlantDetail() {
                 Watering
               </div>
               <div className="mt-2 space-y-1 text-sm">
-                <div>
-                  <span className="text-gray-500">Last watered:</span>{' '}
-                  <span className="text-gray-900 dark:text-gray-100">
-                    {formatDaysAgo(plant.lastWatered)}
-                    {formatTimeOfDay(plant.lastWatered) ? ` \u00B7 ${formatTimeOfDay(plant.lastWatered)}` : ''} (
-                    <span>{plant.lastWatered}</span>
-                    )
-                  </span>
-                </div>
-                <div>
-                  <span className="text-gray-500">Next due:</span>{' '}
-                  <span className="text-gray-900 dark:text-gray-100">{plant.nextWater}</span>
-                </div>
+                <p>
+                  Last watered: {formatDaysAgo(plant.lastWatered)} · Next: {plant.nextWater}
+                </p>
                 {overdueWaterDays > 0 && (
                   <div className="flex items-center text-red-600 dark:text-red-400">
                     <span className="mr-1" role="img" aria-label="Overdue">❗</span>
@@ -207,15 +197,6 @@ export default function PlantDetail() {
                   </div>
                 )}
               </div>
-              <button
-                type="button"
-                onClick={handleWatered}
-                aria-label={`Mark ${plant.name} as watered`}
-                className="absolute bottom-3 right-3 px-2 py-1 border border-water-600 text-water-600 rounded text-xs flex items-center gap-1 group"
-              >
-                <Drop className="w-3 h-3 group-active:drip-pulse" aria-hidden="true" />
-                Mark Watered
-              </button>
             </div>
             {plant.nextFertilize && (
               <div className={`relative rounded-lg p-3 border-l-4 ${fertBorderClass} bg-fertilize-50 dark:bg-fertilize-900/30`}>
@@ -224,21 +205,10 @@ export default function PlantDetail() {
                   Fertilizing
                 </div>
                 <div className="mt-2 space-y-1 text-sm">
-                  {plant.lastFertilized && (
-                    <div>
-                      <span className="text-gray-500">Last fertilized:</span>{' '}
-                      <span className="text-gray-900 dark:text-gray-100">
-                        {formatDaysAgo(plant.lastFertilized)}
-                        {formatTimeOfDay(plant.lastFertilized) ? ` \u00B7 ${formatTimeOfDay(plant.lastFertilized)}` : ''} (
-                        <span>{plant.lastFertilized}</span>
-                        )
-                      </span>
-                    </div>
-                  )}
-                  <div>
-                    <span className="text-gray-500">Next due:</span>{' '}
-                    <span className="text-gray-900 dark:text-gray-100">{plant.nextFertilize}</span>
-                  </div>
+                  <p>
+                    Last fertilized:{' '}
+                    {plant.lastFertilized ? formatDaysAgo(plant.lastFertilized) : 'Never'} · Next: {plant.nextFertilize}
+                  </p>
                   {overdueFertDays > 0 && (
                     <div className="flex items-center text-red-600 dark:text-red-400">
                       <span className="mr-1" role="img" aria-label="Overdue">❗</span>
@@ -246,14 +216,6 @@ export default function PlantDetail() {
                     </div>
                   )}
                 </div>
-                <button
-                  type="button"
-                  onClick={handleFertilized}
-                  aria-label={`Mark ${plant.name} as fertilized`}
-                  className="absolute bottom-3 right-3 px-2 py-1 border border-fertilize-600 text-fertilize-600 rounded text-xs flex items-center gap-1"
-                >
-                  <Flower className="w-3 h-3" aria-hidden="true" /> Mark Fertilized
-                </button>
               </div>
             )}
           </div>
@@ -435,39 +397,16 @@ export default function PlantDetail() {
               <p className="text-sm text-gray-200">{plant.nickname}</p>
             )}
           </div>
-          <div className="absolute bottom-2 right-2 flex items-center gap-2" data-testid="progress-rings">
-            {progressPct >= 1 && (
-              <button
-                type="button"
-                onClick={handleWatered}
-                aria-label={`Mark ${plant.name} as watered`}
-                className="px-3 py-1 bg-blue-600 text-white rounded-full shadow text-sm"
-              >
-                Water Now
-              </button>
-            )}
-            <div
-              className="relative"
-              style={{ width: 48, height: 48 }}
-              data-testid="watering-ring"
-              aria-label={`Watering progress ${Math.round(progressPct * 100)}%`}
-            >
-              <ProgressRing percent={progressPct} size={48} colorClass={ringClass} />
-              <div
-                className={`absolute inset-1 rounded-full bg-white/80 flex items-center justify-center text-badge font-semibold ${ringClass}`}
-              >
-                {progressPct >= 1 ? 'Water Now' : `${Math.round(progressPct * 100)}%`}
-              </div>
-            </div>
-            {plant.nextFertilize && plant.lastFertilized && (
-              <div className="relative" style={{ width: 40, height: 40 }} data-testid="fertilizing-ring">
-                <ProgressRing
-                  percent={fertProgressPct}
-                  size={40}
-                  strokeWidth={4}
-                  colorClass="text-yellow-600"
-                />
-              </div>
+          <div className="absolute bottom-2 right-2 text-xs text-white drop-shadow" data-testid="brief-care">
+            <p>
+              Last watered: {formatDaysAgo(plant.lastWatered)} · Next: {plant.nextWater}
+            </p>
+            {plant.nextFertilize && (
+              <p>
+                Last fertilized:{' '}
+                {plant.lastFertilized ? formatDaysAgo(plant.lastFertilized) : 'Never'} · Next:{' '}
+                {plant.nextFertilize}
+              </p>
             )}
           </div>
         </div>
@@ -489,7 +428,12 @@ export default function PlantDetail() {
 
         <AccordionGroup sections={sections} />
       </div>
-      <PlantDetailFab onAddPhoto={openFileInput} onAddNote={handleLogEvent} />
+      <PlantDetailFab
+        onAddPhoto={openFileInput}
+        onAddNote={handleLogEvent}
+        onWater={handleWatered}
+        onFertilize={handleFertilized}
+      />
       {showNoteModal && (
         <NoteModal label="Note" onSave={saveNote} onCancel={cancelNote} />
       )}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent, within } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import PlantDetail from '../PlantDetail.jsx'
 import plants from '../../plants.json'
@@ -33,33 +33,15 @@ test('renders plant details without duplicates', () => {
 
   fireEvent.click(screen.getByRole('button', { name: /care overview/i }))
 
-  const wateredLabel = screen.getByText(/Last watered/i)
-  expect(
-    within(wateredLabel.parentElement).getByText(new RegExp(plant.lastWatered))
-  ).toBeInTheDocument()
-
-  const waterHeading = screen.getByText('Watering')
-  const nextLabels = screen.getAllByText(/Next due:/i)
-  expect(screen.getByText(new RegExp(plant.nextWater))).toBeInTheDocument()
-  expect(
-    screen.getByRole('button', {
-      name: `Mark ${plant.name} as watered`,
-    })
-  ).toBeInTheDocument()
+  const wateredLabels = screen.getAllByText(/Last watered/i)
+  const wateredLabel = wateredLabels[wateredLabels.length - 1]
+  expect(wateredLabel.textContent).toMatch(/Last watered:/i)
+  expect(wateredLabel.textContent).toMatch(new RegExp(plant.nextWater))
 
   const fertHeading = screen.getByText('Fertilizing')
-  const nextFertLabel = nextLabels.find(label => label !== nextLabels[0])
-  expect(screen.getAllByText(new RegExp(plant.nextFertilize)).length).toBeGreaterThan(0)
-  expect(
-    screen.getByRole('button', {
-      name: `Mark ${plant.name} as fertilized`,
-    })
-  ).toBeInTheDocument()
-
-  const fertLabel = screen.getByText(/Last fertilized/i)
-  expect(
-    within(fertLabel.parentElement).getByText(new RegExp(plant.lastFertilized))
-  ).toBeInTheDocument()
+  const fertLabel = screen.getAllByText(new RegExp(plant.nextFertilize))
+  const fertText = fertLabel[fertLabel.length - 1]
+  expect(fertText.textContent).toMatch(new RegExp(plant.nextFertilize))
 
   const subHeadings = screen.queryAllByRole('heading', { level: 4 })
   expect(subHeadings).toHaveLength(0)
@@ -85,59 +67,7 @@ test('displays all sections', () => {
   expect(screen.getByRole('button', { name: /gallery/i })).toBeInTheDocument()
 })
 
-test('shows watering progress ring', () => {
-  const plant = plants[0]
-  render(
-    <MenuProvider>
-      <PlantProvider>
-        <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
-          <Routes>
-            <Route path="/plant/:id" element={<PlantDetail />} />
-          </Routes>
-        </MemoryRouter>
-      </PlantProvider>
-    </MenuProvider>
-  )
 
-  expect(screen.getByTestId('watering-ring')).toBeInTheDocument()
-})
-
-test('fertilizing ring is displayed', () => {
-  const plant = plants[0]
-  render(
-    <MenuProvider>
-      <PlantProvider>
-        <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
-          <Routes>
-            <Route path="/plant/:id" element={<PlantDetail />} />
-          </Routes>
-        </MemoryRouter>
-      </PlantProvider>
-    </MenuProvider>
-  )
-
-  const rings = screen.getByTestId('progress-rings')
-  expect(rings.querySelectorAll('svg')).toHaveLength(2)
-})
-
-test('percent text adopts urgency color', () => {
-  const plant = plants[0]
-  render(
-    <MenuProvider>
-      <PlantProvider>
-        <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
-          <Routes>
-            <Route path="/plant/:id" element={<PlantDetail />} />
-          </Routes>
-        </MemoryRouter>
-      </PlantProvider>
-    </MenuProvider>
-  )
-
-  const ring = screen.getByTestId('watering-ring')
-  const pctText = within(ring).getByText(/%|Water Now/i)
-  expect(pctText.className).toMatch(/text-red-600/)
-})
 
 
 test('opens lightbox from gallery', () => {

--- a/src/pages/__tests__/PlantDetailActions.test.jsx
+++ b/src/pages/__tests__/PlantDetailActions.test.jsx
@@ -50,16 +50,12 @@ test('quick stats action buttons trigger handlers', () => {
     </MenuProvider>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /care overview/i }))
-
-  fireEvent.click(
-    screen.getAllByRole('button', { name: /mark plant a as watered/i })[0]
-  )
+  fireEvent.click(screen.getByRole('button', { name: /open create menu/i }))
+  fireEvent.click(screen.getByRole('button', { name: /mark watered/i }))
   expect(markWatered).toHaveBeenCalledWith(1, '')
 
-  fireEvent.click(
-    screen.getByRole('button', { name: /mark plant a as fertilized/i })
-  )
+  fireEvent.click(screen.getByRole('button', { name: /open create menu/i }))
+  fireEvent.click(screen.getByRole('button', { name: /mark fertilized/i }))
   expect(markFertilized).toHaveBeenCalledWith(1, '')
 })
 


### PR DESCRIPTION
## Summary
- streamline care overview without progress rings
- move watering and fertilizing actions into PlantDetailFab menu
- adjust PlantDetail tests for updated UI
- update PlantDetailActions tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b1d8296108324b5cfe4538b8ce8bf