### PR TITLE
Add DetailTabs and refactor PlantDetail

### DIFF
--- a/src/components/DetailTabs.jsx
+++ b/src/components/DetailTabs.jsx
@@ -1,0 +1,38 @@
+import { useState } from 'react'
+
+export default function DetailTabs({ tabs = [], value, onChange }) {
+  const [internal, setInternal] = useState(value ?? tabs[0]?.id)
+  const active = value ?? internal
+
+  const handleClick = id => {
+    onChange?.(id)
+    if (value === undefined) {
+      setInternal(id)
+    }
+  }
+
+  const activeTab = tabs.find(t => t.id === active)
+
+  return (
+    <div>
+      <div role="tablist" className="flex justify-center gap-2 my-2">
+        {tabs.map(tab => (
+          <button
+            key={tab.id}
+            role="tab"
+            aria-selected={active === tab.id}
+            onClick={() => handleClick(tab.id)}
+            className={`px-3 py-1 rounded-full text-sm font-medium focus:outline-none ${
+              active === tab.id
+                ? 'bg-green-600 text-white'
+                : 'bg-gray-200 text-gray-700 dark:bg-gray-600 dark:text-gray-200'
+            }`}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+      <div className="mt-4">{activeTab?.content}</div>
+    </div>
+  )
+}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -2,7 +2,6 @@ import { useParams, useNavigate } from 'react-router-dom'
 import { useState, useRef, useMemo, useEffect } from 'react'
 
 import {
-  Clock,
   Sun,
   Drop,
   Gauge,
@@ -26,7 +25,7 @@ import ProgressRing from '../components/ProgressRing.jsx'
 import PageHeader from '../components/PageHeader.jsx'
 import PlantDetailFab from '../components/PlantDetailFab.jsx'
 import SectionCard from '../components/SectionCard.jsx'
-import AccordionGroup from '../components/AccordionGroup.jsx'
+import DetailTabs from '../components/DetailTabs.jsx'
 
 import useToast from "../hooks/useToast.jsx"
 import confetti from 'canvas-confetti'
@@ -166,15 +165,10 @@ export default function PlantDetail() {
     setShowNoteModal(false)
   }
 
-  const sections = [
+  const tabs = [
     {
       id: 'care',
-      title: (
-        <span className="flex items-center gap-2">
-          <Clock className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
-          Care Overview
-        </span>
-      ),
+      label: 'Care',
       content: (
         <SectionCard className="space-y-3">
           <div className="space-y-3">
@@ -215,37 +209,40 @@ export default function PlantDetail() {
                 </div>
               </div>
             )}
-            {(plant.light || plant.humidity || plant.difficulty) && (
-              <ul className="space-y-1 text-sm">
-                {plant.light && (
-                  <li className="flex items-center gap-2">
-                    <Sun className="w-4 h-4" aria-hidden="true" /> {plant.light}
-                  </li>
-                )}
-                {plant.humidity && (
-                  <li className="flex items-center gap-2">
-                    <Drop className="w-4 h-4" aria-hidden="true" /> {plant.humidity}
-                  </li>
-                )}
-                {plant.difficulty && (
-                  <li className="flex items-center gap-2">
-                    <Gauge className="w-4 h-4" aria-hidden="true" /> {plant.difficulty}
-                  </li>
-                )}
-              </ul>
-            )}
           </div>
         </SectionCard>
       ),
     },
     {
-      id: 'activity',
-      title: (
-        <span className="flex items-center gap-2">
-          <Note className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
-          Activity
-        </span>
+      id: 'overview',
+      label: 'Overview',
+      content: (
+        <SectionCard>
+          {(plant.light || plant.humidity || plant.difficulty) && (
+            <ul className="space-y-1 text-sm">
+              {plant.light && (
+                <li className="flex items-center gap-2">
+                  <Sun className="w-4 h-4" aria-hidden="true" /> {plant.light}
+                </li>
+              )}
+              {plant.humidity && (
+                <li className="flex items-center gap-2">
+                  <Drop className="w-4 h-4" aria-hidden="true" /> {plant.humidity}
+                </li>
+              )}
+              {plant.difficulty && (
+                <li className="flex items-center gap-2">
+                  <Gauge className="w-4 h-4" aria-hidden="true" /> {plant.difficulty}
+                </li>
+              )}
+            </ul>
+          )}
+        </SectionCard>
       ),
+    },
+    {
+      id: 'activity',
+      label: 'Activity',
       content: (
         <SectionCard className="space-y-4">
           <div className="flex justify-end">
@@ -308,12 +305,7 @@ export default function PlantDetail() {
     },
     {
       id: 'gallery',
-      title: (
-        <span className="flex items-center gap-2">
-          <Image className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
-          Gallery
-        </span>
-      ),
+      label: 'Gallery',
       content: (
         <SectionCard className="space-y-2">
           <div className="flex flex-nowrap gap-3 overflow-x-auto pb-1 sm:pb-2">
@@ -432,7 +424,7 @@ export default function PlantDetail() {
           />
         </div>
 
-        <AccordionGroup sections={sections} />
+        <DetailTabs tabs={tabs} />
       </div>
       <PlantDetailFab
         onAddPhoto={openFileInput}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -25,12 +25,7 @@ test('renders plant details without duplicates', () => {
   const images = screen.getAllByAltText(plant.name)
   expect(images).toHaveLength(1)
 
-  fireEvent.click(screen.getByRole('button', { name: /care overview/i }))
-
-  expect(screen.getByText(plant.light)).toBeInTheDocument()
-  expect(screen.getByText(plant.humidity)).toBeInTheDocument()
-  expect(screen.getByText(plant.difficulty)).toBeInTheDocument()
-
+  // Care tab is active by default
   const wateredLabels = screen.getAllByText(/Last watered/i)
   const wateredLabel = wateredLabels[wateredLabels.length - 1]
   expect(wateredLabel.textContent).toMatch(/Last watered:/i)
@@ -40,6 +35,12 @@ test('renders plant details without duplicates', () => {
   const fertLabel = screen.getAllByText(new RegExp(plant.nextFertilize))
   const fertText = fertLabel[fertLabel.length - 1]
   expect(fertText.textContent).toMatch(new RegExp(plant.nextFertilize))
+
+  fireEvent.click(screen.getByRole('tab', { name: /overview/i }))
+
+  expect(screen.getByText(plant.light)).toBeInTheDocument()
+  expect(screen.getByText(plant.humidity)).toBeInTheDocument()
+  expect(screen.getByText(plant.difficulty)).toBeInTheDocument()
 
   const subHeadings = screen.queryAllByRole('heading', { level: 4 })
   expect(subHeadings).toHaveLength(0)
@@ -60,9 +61,10 @@ test('displays all sections', () => {
     </MenuProvider>
   )
 
-  expect(screen.getByRole('button', { name: /care overview/i })).toBeInTheDocument()
-  expect(screen.getByRole('button', { name: /activity/i })).toBeInTheDocument()
-  expect(screen.getByRole('button', { name: /gallery/i })).toBeInTheDocument()
+  expect(screen.getByRole('tab', { name: /care/i })).toBeInTheDocument()
+  expect(screen.getByRole('tab', { name: /overview/i })).toBeInTheDocument()
+  expect(screen.getByRole('tab', { name: /activity/i })).toBeInTheDocument()
+  expect(screen.getByRole('tab', { name: /gallery/i })).toBeInTheDocument()
 })
 
 
@@ -83,7 +85,7 @@ test('opens lightbox from gallery', () => {
     </MenuProvider>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /gallery/i }))
+  fireEvent.click(screen.getByRole('tab', { name: /gallery/i }))
 
   // Captions are not displayed with thumbnails
   expect(screen.queryByText(plant.photos[0].caption)).toBeNull()
@@ -140,7 +142,7 @@ test('view all button opens the viewer from first image', () => {
     </MenuProvider>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /gallery/i }))
+  fireEvent.click(screen.getByRole('tab', { name: /gallery/i }))
 
   const viewAll = screen.getByRole('button', { name: /view all photos/i })
   fireEvent.click(viewAll)

--- a/src/pages/__tests__/PlantDetailActions.test.jsx
+++ b/src/pages/__tests__/PlantDetailActions.test.jsx
@@ -90,7 +90,7 @@ test('fab triggers file input click', () => {
     </MenuProvider>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /gallery/i }))
+  fireEvent.click(screen.getByRole('tab', { name: /gallery/i }))
 
   fireEvent.click(screen.getByRole('button', { name: /open create menu/i }))
   fireEvent.click(screen.getByRole('button', { name: /add photo/i }))

--- a/src/pages/__tests__/PlantDetailCareLog.test.jsx
+++ b/src/pages/__tests__/PlantDetailCareLog.test.jsx
@@ -37,7 +37,7 @@ test('shows notes from care log in timeline', () => {
     </MenuProvider>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /activity/i }))
+  fireEvent.click(screen.getByRole('tab', { name: /activity/i }))
 
   expect(screen.getByText('July 2, 2025')).toBeInTheDocument()
   expect(screen.getAllByText(/Watered/).length).toBeGreaterThan(0)
@@ -56,7 +56,7 @@ test('timeline bullet markup matches snapshot', () => {
     </MenuProvider>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /activity/i }))
+  fireEvent.click(screen.getByRole('tab', { name: /activity/i }))
 
   const list = container.querySelector('ul')
   expect(list).toMatchSnapshot()


### PR DESCRIPTION
## Summary
- add new `DetailTabs` component for dynamic tab content
- replace accordion in PlantDetail with new tabs
- move plant info into an Overview tab and rename Care Overview to Care
- update related tests for tab behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b224c8d8083249f6bc98413647a3c