### PR TITLE
Fix localStorage parse in happy plant hook

### DIFF
--- a/src/hooks/useHappyPlant.js
+++ b/src/hooks/useHappyPlant.js
@@ -14,7 +14,14 @@ export default function useHappyPlant() {
 
     if (typeof localStorage !== 'undefined') {
       const storedRaw = localStorage.getItem('happyPlant')
-      const stored = storedRaw ? JSON.parse(storedRaw) : {}
+      let stored = {}
+      if (storedRaw) {
+        try {
+          stored = JSON.parse(storedRaw)
+        } catch {
+          // ignore
+        }
+      }
       if (stored.date === today && images[stored.index]) {
         return images[stored.index]
       }


### PR DESCRIPTION
## Summary
- handle invalid JSON when reading stored happy plant data

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b23c5837083248c78703aa5a0586a