### PR TITLE
Fix PlantDetail header duplication

### DIFF
--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -4,7 +4,9 @@ export default function PageHeader({ title, breadcrumb }) {
   return (
     <header className="mb-4 space-y-1 text-left">
       {breadcrumb && <Breadcrumb {...breadcrumb} />}
-      <h1 className="text-2xl tracking-wide font-bold font-headline">{title}</h1>
+      {title && (
+        <h1 className="text-2xl tracking-wide font-bold font-headline">{title}</h1>
+      )}
     </header>
   )
 }

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -409,10 +409,7 @@ export default function PlantDetail() {
         </div>
         </div>
         <div className="flex items-start justify-between">
-          <PageHeader
-            title={plant.name}
-            breadcrumb={{ room: plant.room, plant: plant.name }}
-          />
+          <PageHeader breadcrumb={{ room: plant.room, plant: plant.name }} />
         </div>
 
         <DetailTabs tabs={tabs} />

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -20,7 +20,7 @@ test('renders plant details without duplicates', () => {
   )
 
   const headings = screen.getAllByRole('heading', { name: plant.name })
-  expect(headings).toHaveLength(2)
+  expect(headings).toHaveLength(1)
 
   const images = screen.getAllByAltText(plant.name)
   expect(images).toHaveLength(1)


### PR DESCRIPTION
## Summary
- don't render a PageHeader title unless provided
- drop the title prop from PlantDetail's PageHeader
- update PlantDetail test to expect only one heading with the plant name

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b2876d9a88324aee23148429bd75f