### PR TITLE
Add progress ring indicator to PlantDetail hero

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -401,7 +401,12 @@ export default function PlantDetail() {
           <div className="img-gradient-overlay" aria-hidden="true"></div>
           <div className="absolute bottom-2 left-3 right-3 flex flex-col sm:flex-row justify-between text-white drop-shadow space-y-1 sm:space-y-0">
             <div>
-              <h2 className="text-heading font-semibold font-headline">{plant.name}</h2>
+              <div className="flex items-center gap-2">
+                <h2 className="text-heading font-semibold font-headline">{plant.name}</h2>
+                <div className="relative" style={{ width: 24, height: 24 }} aria-label="Watering progress">
+                  <ProgressRing percent={progressPct} size={24} colorClass={ringClass} />
+                </div>
+              </div>
               {plant.nickname && <p className="text-sm text-gray-200">{plant.nickname}</p>}
             </div>
             {/* brief care stats moved to Care tab */}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -46,6 +46,23 @@ test('renders plant details without duplicates', () => {
   expect(subHeadings).toHaveLength(0)
 })
 
+test('shows watering progress indicator', () => {
+  const plant = plants[0]
+  render(
+    <MenuProvider>
+      <PlantProvider>
+        <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+          <Routes>
+            <Route path="/plant/:id" element={<PlantDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </PlantProvider>
+    </MenuProvider>
+  )
+
+  expect(screen.getByLabelText(/watering progress/i)).toBeInTheDocument()
+})
+
 
 test('displays all sections', () => {
   const plant = plants[0]


### PR DESCRIPTION
## Summary
- show watering progress ring on the Plant detail hero image
- test that progress ring is visible via accessible label

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687b28c1e87083249c71b94375ba244f