### PR TITLE
Add event order toggle in PlantDetail

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -11,6 +11,8 @@ import {
   Info,
   CaretDown,
   CaretRight,
+  SortAscending,
+  SortDescending,
 } from 'phosphor-react'
 
 import Lightbox from '../components/Lightbox.jsx'
@@ -63,6 +65,7 @@ export default function PlantDetail() {
   const [lightboxIndex, setLightboxIndex] = useState(null)
   const [showLegend, setShowLegend] = useState(false)
   const [collapsedMonths, setCollapsedMonths] = useState({})
+  const [latestFirst, setLatestFirst] = useState(true)
 
   const ringClass = ringColors[plant?.urgency] || 'text-green-600'
   const progressPct = getWateringProgress(plant?.lastWatered, plant?.nextWater)
@@ -91,10 +94,15 @@ export default function PlantDetail() {
     overdueFertDays > 0 ? 'border-red-500' : 'border-green-500'
 
   const events = useMemo(() => buildEvents(plant), [plant])
-  const groupedEvents = useMemo(
-    () => groupEventsByMonth(events),
-    [events]
-  )
+  const groupedEvents = useMemo(() => {
+    const grouped = groupEventsByMonth(events)
+    if (latestFirst) {
+      return grouped
+        .map(([month, list]) => [month, [...list].reverse()])
+        .reverse()
+    }
+    return grouped
+  }, [events, latestFirst])
 
 
   const handleFiles = e => {
@@ -245,7 +253,21 @@ export default function PlantDetail() {
       label: 'Activity',
       content: (
         <SectionCard className="space-y-4">
-          <div className="flex justify-end">
+          <div className="flex justify-end gap-2">
+            <button
+              type="button"
+              onClick={() => setLatestFirst(l => !l)}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            >
+              {latestFirst ? (
+                <SortDescending className="w-4 h-4" aria-hidden="true" />
+              ) : (
+                <SortAscending className="w-4 h-4" aria-hidden="true" />
+              )}
+              <span className="sr-only">
+                {latestFirst ? 'Show oldest first' : 'Show newest first'}
+              </span>
+            </button>
             <button type="button" onClick={() => setShowLegend(true)} className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300">
               <Info className="w-4 h-4" aria-hidden="true" />
               <span className="sr-only">Legend</span>

--- a/src/pages/__tests__/PlantDetailCareLog.test.jsx
+++ b/src/pages/__tests__/PlantDetailCareLog.test.jsx
@@ -61,3 +61,38 @@ test('timeline bullet markup matches snapshot', () => {
   const list = container.querySelector('ul')
   expect(list).toMatchSnapshot()
 })
+
+test('toggle reverses month ordering', () => {
+  mockPlants = [
+    {
+      id: 1,
+      name: 'Plant A',
+      image: 'a.jpg',
+      careLog: [
+        { date: '2025-07-02', type: 'Watered' },
+        { date: '2025-06-01', type: 'Watered' },
+      ],
+      photos: [],
+    },
+  ]
+
+  render(
+    <MenuProvider>
+      <MemoryRouter initialEntries={['/plant/1']}>
+        <Routes>
+          <Route path="/plant/:id" element={<PlantDetail />} />
+        </Routes>
+      </MemoryRouter>
+    </MenuProvider>
+  )
+
+  fireEvent.click(screen.getByRole('tab', { name: /activity/i }))
+
+  let headings = screen.getAllByRole('heading', { level: 3 })
+  expect(headings[0]).toHaveTextContent('July 2025')
+
+  fireEvent.click(screen.getByRole('button', { name: /show oldest first/i }))
+
+  headings = screen.getAllByRole('heading', { level: 3 })
+  expect(headings[0]).toHaveTextContent('June 2025')
+})


### PR DESCRIPTION
## Summary
- show newest care events first in PlantDetail
- add sort toggle button near the legend
- test event ordering toggle

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b2a10cfa88324b9e7e16526ace0c4