### PR TITLE
Add sorting toggle to timeline

### DIFF
--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -1,5 +1,6 @@
 import { usePlants } from '../PlantContext.jsx'
 import { useMemo, useState } from 'react'
+import { SortAscending, SortDescending } from 'phosphor-react'
 
 import { motion } from 'framer-motion'
 
@@ -14,6 +15,7 @@ import SectionCard from '../components/SectionCard.jsx'
 export default function Timeline() {
   const { plants, timelineNotes = [], addTimelineNote = () => {} } = usePlants()
   const [showNoteModal, setShowNoteModal] = useState(false)
+  const [latestFirst, setLatestFirst] = useState(true)
 
   const plantEvents = useMemo(
     () => buildEvents(plants, { includePlantName: true }),
@@ -37,10 +39,14 @@ export default function Timeline() {
   )
 
   const groupedEvents = useMemo(() => {
-    return groupEventsByMonth(events)
-      .map(([month, list]) => [month, [...list].reverse()])
-      .reverse()
-  }, [events])
+    const grouped = groupEventsByMonth(events)
+    if (latestFirst) {
+      return grouped
+        .map(([month, list]) => [month, [...list].reverse()])
+        .reverse()
+    }
+    return grouped
+  }, [events, latestFirst])
 
   const [selectedEvent, setSelectedEvent] = useState(null)
 
@@ -58,7 +64,22 @@ export default function Timeline() {
   return (
     <div className="relative overflow-y-auto max-h-full max-w-md mx-auto space-y-8 py-4 px-4 text-gray-700 dark:text-gray-200">
       <SectionCard className="border border-gray-100">
-
+        <div className="flex justify-end px-1">
+          <button
+            type="button"
+            onClick={() => setLatestFirst(l => !l)}
+            className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+          >
+            {latestFirst ? (
+              <SortDescending className="w-4 h-4" aria-hidden="true" />
+            ) : (
+              <SortAscending className="w-4 h-4" aria-hidden="true" />
+            )}
+            <span className="sr-only">
+              {latestFirst ? 'Show oldest first' : 'Show newest first'}
+            </span>
+          </button>
+        </div>
         <div className="relative">
           {groupedEvents.map(([monthKey, list]) => (
             <div key={monthKey} className="mt-6 first:mt-0">

--- a/src/pages/__tests__/Timeline.test.jsx
+++ b/src/pages/__tests__/Timeline.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, fireEvent } from '@testing-library/react'
 import Timeline from '../Timeline.jsx'
 
 const samplePlants = [
@@ -26,7 +26,7 @@ beforeEach(() => {
   mockPlants = samplePlants
 })
 
-test('ignores activities without valid dates when generating events', () => {
+test('ignores activities without valid dates and shows newest first', () => {
   render(<Timeline />)
 
   expect(screen.queryByText(/Repotted/)).toBeNull()
@@ -73,4 +73,18 @@ test('displays month headers when events span months', () => {
   expect(headings).toHaveLength(2)
   expect(headings[0]).toHaveTextContent('August 2025')
   expect(headings[1]).toHaveTextContent('July 2025')
+})
+
+test('toggle reverses the order of events', () => {
+  render(<Timeline />)
+
+  const items = screen.getAllByRole('listitem')
+  expect(items[0]).toHaveTextContent('Watered Plant A')
+
+  const toggle = screen.getByRole('button', { name: /show oldest first/i })
+  fireEvent.click(toggle)
+
+  const reversed = screen.getAllByRole('listitem')
+  expect(reversed[0]).toHaveTextContent('Fertilized Plant A')
+  expect(toggle).toHaveAccessibleName('Show newest first')
 })


### PR DESCRIPTION
## Summary
- add latest-first toggle to timeline page
- include sort controls for newest/oldest first
- test newest-first default and toggle behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b2debb8048324a494009047f48308