### PR TITLE
Fix hero image padding

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -394,7 +394,7 @@ export default function PlantDetail() {
 
   return (
     <>
-      <div className="full-bleed relative mb-4">
+      <div className="full-bleed relative mb-4 -mt-8">
         <div className="hidden lg:block absolute inset-0 overflow-hidden -z-10">
           <img
             src={plant.image}


### PR DESCRIPTION
## Summary
- remove extra top padding above plant details hero image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b2db613b883248285a3fd24803cac