### PR TITLE
Update DetailTabs styling with icons

### DIFF
--- a/src/components/DetailTabs.jsx
+++ b/src/components/DetailTabs.jsx
@@ -15,22 +15,27 @@ export default function DetailTabs({ tabs = [], value, onChange }) {
 
   return (
     <div>
-      <div role="tablist" className="flex justify-center gap-2 my-2">
-        {tabs.map(tab => (
-          <button
-            key={tab.id}
-            role="tab"
-            aria-selected={active === tab.id}
-            onClick={() => handleClick(tab.id)}
-            className={`px-3 py-1 rounded-full text-sm font-medium focus:outline-none ${
-              active === tab.id
-                ? 'bg-green-600 text-white'
-                : 'bg-gray-200 text-gray-700 dark:bg-gray-600 dark:text-gray-200'
-            }`}
-          >
-            {tab.label}
-          </button>
-        ))}
+      <div role="tablist" className="flex justify-center gap-2 py-1">
+        {tabs.map(tab => {
+          const Icon = tab.icon
+          const isActive = active === tab.id
+          return (
+            <button
+              key={tab.id}
+              role="tab"
+              aria-selected={isActive}
+              onClick={() => handleClick(tab.id)}
+              className={`px-3 py-1 text-sm border-b-2 focus:outline-none ${
+                isActive
+                  ? 'border-green-600 font-semibold'
+                  : 'border-transparent text-gray-500'
+              }`}
+            >
+              {Icon && <Icon className="inline w-4 h-4 mr-1" aria-hidden="true" />}
+              {tab.label}
+            </button>
+          )
+        })}
       </div>
       <div className="mt-4">{activeTab?.content}</div>
     </div>

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -177,6 +177,7 @@ export default function PlantDetail() {
     {
       id: 'summary',
       label: 'Care Summary',
+      icon: Info,
       content: (
         <SectionCard className="space-y-3">
           <div className="space-y-3">
@@ -244,6 +245,7 @@ export default function PlantDetail() {
     {
       id: 'activity',
       label: 'Activity',
+      icon: Note,
       content: (
         <SectionCard className="space-y-4">
           <div className="flex justify-end gap-2">
@@ -321,6 +323,7 @@ export default function PlantDetail() {
     {
       id: 'gallery',
       label: 'Gallery',
+      icon: Image,
       content: (
         <SectionCard className="space-y-2">
           <div className="flex flex-nowrap gap-3 overflow-x-auto pb-1 sm:pb-2">


### PR DESCRIPTION
## Summary
- style DetailTabs with underlines instead of pill buttons
- allow optional icons in DetailTabs
- pass icons from PlantDetail

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b306e07b08324b92f1054425ec8f0