### PR TITLE
Reduce detail hero spacing

### DIFF
--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -1,8 +1,8 @@
 import Breadcrumb from './Breadcrumb.jsx'
 
-export default function PageHeader({ title, breadcrumb }) {
+export default function PageHeader({ title, breadcrumb, className = '' }) {
   return (
-    <header className="mb-4 space-y-1 text-left">
+    <header className={`mb-4 space-y-1 text-left ${className}`.trim()}>
       {breadcrumb && <Breadcrumb {...breadcrumb} />}
       {title && (
         <h1 className="text-2xl tracking-wide font-bold font-headline">{title}</h1>

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -397,7 +397,7 @@ export default function PlantDetail() {
 
   return (
     <>
-      <div className="full-bleed relative -mt-8">
+      <div className="full-bleed relative mb-2 -mt-8">
         <div className="hidden lg:block absolute inset-0 overflow-hidden -z-10">
           <img
             src={plant.image}
@@ -428,11 +428,14 @@ export default function PlantDetail() {
           </div>
         </div>
       </div>
-      <PageContainer className="relative text-left pt-0">
+      <PageContainer className="relative text-left pt-0 space-y-4">
         <Toast />
         <div className="space-y-4">
           <div className="flex items-start justify-between">
-            <PageHeader breadcrumb={{ room: plant.room, plant: plant.name }} />
+            <PageHeader
+              breadcrumb={{ room: plant.room, plant: plant.name }}
+              className="mb-2"
+            />
           </div>
 
           <div className="bg-white rounded-b-xl shadow-md">


### PR DESCRIPTION
## Summary
- reduce hero margin spacing
- tweak padding and spacing for plant detail page
- allow custom styles for `PageHeader`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b316fdd608324a09e0aa725931e00