### PR TITLE
Add plant search on MyPlants page

### DIFF
--- a/src/pages/__tests__/MyPlants.test.jsx
+++ b/src/pages/__tests__/MyPlants.test.jsx
@@ -121,3 +121,27 @@ test('filters rooms needing love', () => {
   expect(links[0]).toHaveTextContent('Living')
   jest.useRealTimers()
 })
+
+test('searches plants by name', () => {
+  mockRooms = ['Kitchen', 'Living']
+  mockPlants = [
+    { id: 1, name: 'Fern', room: 'Living', lastWatered: '2025-07-01' },
+    { id: 2, name: 'Basil', room: 'Kitchen', lastWatered: '2025-07-01' },
+  ]
+  render(
+    <MemoryRouter>
+      <MyPlants />
+    </MemoryRouter>
+  )
+
+  const search = screen.getByRole('searchbox', { name: /search plants/i })
+  fireEvent.change(search, { target: { value: 'fer' } })
+
+  const links = screen
+    .getAllByRole('link')
+    .filter(l => l.getAttribute('href') !== '/room/add')
+
+  expect(screen.queryByText('Kitchen')).toBeNull()
+  expect(links).toHaveLength(1)
+  expect(links[0]).toHaveTextContent('Living')
+})


### PR DESCRIPTION
## Summary
- add a search box to **MyPlants** for filtering by plant name
- filter room stats based on search results
- test searching functionality

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b30dacc208324a9858387f77d9a1d