### PR TITLE
Refine Plant Detail tabs

### DIFF
--- a/src/components/DetailTabs.jsx
+++ b/src/components/DetailTabs.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react'
 
-export default function DetailTabs({ tabs = [], value, onChange }) {
+export default function DetailTabs({ tabs = [], value, onChange, className = '' }) {
   const [internal, setInternal] = useState(value ?? tabs[0]?.id)
   const active = value ?? internal
 
@@ -14,10 +14,12 @@ export default function DetailTabs({ tabs = [], value, onChange }) {
   const activeTab = tabs.find(t => t.id === active)
 
   return (
-    <div>
-      <div role="tablist" className="flex justify-center gap-2 py-1">
+    <div className={`bg-white dark:bg-gray-700 rounded-xl shadow ${className}`.trim()}>
+      <div
+        role="tablist"
+        className="flex justify-center gap-2 px-4 pt-2 border-b border-gray-200 dark:border-gray-600"
+      >
         {tabs.map(tab => {
-          const Icon = tab.icon
           const isActive = active === tab.id
           return (
             <button
@@ -31,13 +33,12 @@ export default function DetailTabs({ tabs = [], value, onChange }) {
                   : 'border-transparent text-gray-500'
               }`}
             >
-              {Icon && <Icon className="inline w-4 h-4 mr-1" aria-hidden="true" />}
               {tab.label}
             </button>
           )
         })}
       </div>
-      <div className="mt-4">{activeTab?.content}</div>
+      <div className="px-4 pb-4 pt-2">{activeTab?.content}</div>
     </div>
   )
 }

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -6,8 +6,6 @@ import {
   Drop,
   Gauge,
   Flower,
-  Image,
-  Note,
   Info,
   CaretDown,
   CaretRight,
@@ -177,7 +175,6 @@ export default function PlantDetail() {
     {
       id: 'summary',
       label: 'Care Summary',
-      icon: Info,
       content: (
         <SectionCard className="space-y-3">
           <div className="space-y-3">
@@ -245,7 +242,6 @@ export default function PlantDetail() {
     {
       id: 'activity',
       label: 'Activity',
-      icon: Note,
       content: (
         <SectionCard className="space-y-4">
           <div className="flex justify-end gap-2">
@@ -323,7 +319,6 @@ export default function PlantDetail() {
     {
       id: 'gallery',
       label: 'Gallery',
-      icon: Image,
       content: (
         <SectionCard className="space-y-2">
           <div className="flex flex-nowrap gap-3 overflow-x-auto pb-1 sm:pb-2">
@@ -397,7 +392,7 @@ export default function PlantDetail() {
 
   return (
     <>
-      <div className="full-bleed relative mb-2 -mt-8">
+      <div className="full-bleed relative mb-1 -mt-8">
         <div className="hidden lg:block absolute inset-0 overflow-hidden -z-10">
           <img
             src={plant.image}
@@ -428,19 +423,17 @@ export default function PlantDetail() {
           </div>
         </div>
       </div>
-      <PageContainer className="relative text-left pt-0 space-y-4">
+      <PageContainer className="relative text-left pt-0 space-y-3">
         <Toast />
-        <div className="space-y-4">
+        <div className="space-y-3">
           <div className="flex items-start justify-between">
             <PageHeader
               breadcrumb={{ room: plant.room, plant: plant.name }}
-              className="mb-2"
+              className="mb-1"
             />
           </div>
 
-          <div className="bg-white rounded-b-xl shadow-md">
-            <DetailTabs tabs={tabs} />
-          </div>
+          <DetailTabs tabs={tabs} />
         </div>
         <PlantDetailFab
           onAddPhoto={openFileInput}


### PR DESCRIPTION
## Summary
- restyle `DetailTabs` with integrated card container
- trim header spacing in `PlantDetail` and remove tab icons

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b336ceeec8324913fd6912ac4240e