### PR TITLE
Improve swipe handling

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -88,7 +88,7 @@ export default function TaskCard({
       data-testid="task-card"
       tabIndex="0"
       aria-label={`Task card for ${task.plantName}`}
-      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-neutral-50 dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
+      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 touch-pan-y select-none ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-neutral-50 dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
       style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
       onPointerDown={start}
       onPointerMove={move}

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -125,7 +125,7 @@ export default function UnifiedTaskCard({
   return (
     <div
       data-testid="unified-task-card"
-      className={`relative rounded-2xl border border-neutral-200 dark:border-gray-600 shadow overflow-hidden ${bgClass}`}
+      className={`relative rounded-2xl border border-neutral-200 dark:border-gray-600 shadow overflow-hidden touch-pan-y select-none ${bgClass}`}
       style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
       onPointerDown={start}
       onPointerMove={move}

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -6,7 +6,7 @@ exports[`matches snapshot in dark mode 1`] = `
 >
   <div
     aria-label="Task card for Monstera"
-    class="relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 bg-neutral-50 dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
+    class="relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 touch-pan-y select-none bg-neutral-50 dark:bg-gray-700 ring-2 ring-green-300 dark:ring-green-400"
     data-testid="task-card"
     style="transform: translateX(0px); transition: transform 0.2s;"
     tabindex="0"

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -2,7 +2,7 @@
 
 exports[`matches snapshot in dark mode 1`] = `
 <div
-  class="relative rounded-2xl border border-neutral-200 dark:border-gray-600 shadow overflow-hidden bg-gray-50 dark:bg-gray-800"
+  class="relative rounded-2xl border border-neutral-200 dark:border-gray-600 shadow overflow-hidden touch-pan-y select-none bg-gray-50 dark:bg-gray-800"
   data-testid="unified-task-card"
   style="transform: translateX(0px); transition: transform 0.2s;"
 >

--- a/src/hooks/__tests__/useSwipe.test.js
+++ b/src/hooks/__tests__/useSwipe.test.js
@@ -29,3 +29,16 @@ test('calls callback with swipe distance', () => {
   fireEvent.pointerUp(el, { clientX: 80 })
   expect(cb).toHaveBeenCalledWith(80)
 })
+
+test('sets pointer capture on pointer down', () => {
+  let startFn
+  function CaptureTest() {
+    const { start } = useSwipe(() => {})
+    startFn = start
+    return null
+  }
+  render(<CaptureTest />)
+  const mockTarget = { setPointerCapture: jest.fn() }
+  startFn({ clientX: 0, pointerId: 1, currentTarget: mockTarget })
+  expect(mockTarget.setPointerCapture).toHaveBeenCalledWith(1)
+})

--- a/src/hooks/useSwipe.js
+++ b/src/hooks/useSwipe.js
@@ -7,6 +7,9 @@ export default function useSwipe(onEnd, options = {}) {
 
   const start = e => {
     startX.current = e?.clientX ?? e?.touches?.[0]?.clientX ?? 0
+    if (e?.currentTarget?.setPointerCapture && e.pointerId != null) {
+      e.currentTarget.setPointerCapture(e.pointerId)
+    }
   }
 
   const move = e => {
@@ -23,6 +26,9 @@ export default function useSwipe(onEnd, options = {}) {
     }
     setDx(0)
     startX.current = 0
+    if (e?.currentTarget?.releasePointerCapture && e.pointerId != null) {
+      e.currentTarget.releasePointerCapture(e.pointerId)
+    }
   }
 
   return { dx, start, move, end }


### PR DESCRIPTION
## Summary
- capture pointer events in `useSwipe` to prevent scroll from stealing them
- add `touch-pan-y` and `select-none` utilities to task card components
- test pointer capture functionality

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_687b33d781508324b5f3e5df981f6f38