### PR TITLE
Improve plant detail tabs and FAB UI

### DIFF
--- a/src/components/DetailTabs.jsx
+++ b/src/components/DetailTabs.jsx
@@ -17,7 +17,7 @@ export default function DetailTabs({ tabs = [], value, onChange, className = '' 
     <div className={`bg-white dark:bg-gray-700 rounded-xl shadow ${className}`.trim()}>
       <div
         role="tablist"
-        className="flex justify-center gap-2 px-4 pt-2 border-b border-gray-200 dark:border-gray-600"
+        className="flex justify-around px-4 pt-2 border-b border-gray-200 dark:border-gray-600"
       >
         {tabs.map(tab => {
           const isActive = active === tab.id
@@ -27,10 +27,10 @@ export default function DetailTabs({ tabs = [], value, onChange, className = '' 
               role="tab"
               aria-selected={isActive}
               onClick={() => handleClick(tab.id)}
-              className={`px-3 py-1 text-sm border-b-2 focus:outline-none ${
+              className={`relative flex-1 px-3 py-1 text-sm focus:outline-none ${
                 isActive
-                  ? 'border-green-600 font-semibold'
-                  : 'border-transparent text-gray-500'
+                  ? 'font-semibold text-gray-900 dark:text-gray-100 after:absolute after:bottom-0 after:left-0 after:h-0.5 after:w-full after:bg-green-600'
+                  : 'text-gray-500'
               }`}
             >
               {tab.label}

--- a/src/components/PlantDetailFab.jsx
+++ b/src/components/PlantDetailFab.jsx
@@ -6,6 +6,7 @@ export default function PlantDetailFab({
   onAddNote,
   onWater,
   onFertilize,
+  icon: FabIcon = Plus,
 }) {
   const [open, setOpen] = useState(false)
 
@@ -39,7 +40,7 @@ export default function PlantDetailFab({
   }
 
   return (
-    <div className="absolute bottom-4 right-4 z-30">
+    <div className="absolute bottom-2 right-2 sm:bottom-4 sm:right-4 z-30">
       {open && (
         <div
           className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
@@ -123,9 +124,13 @@ export default function PlantDetailFab({
         title="Open create menu"
         aria-expanded={open}
         aria-haspopup="menu"
-        className={`bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
+        className={`bg-accent text-white w-12 h-12 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
       >
-        <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
+        {open ? (
+          <Plus className="w-6 h-6 rotate-45 transition-transform" aria-hidden="true" />
+        ) : (
+          <FabIcon className="w-6 h-6" aria-hidden="true" />
+        )}
       </button>
     </div>
   )

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -11,6 +11,8 @@ import {
   CaretRight,
   SortAscending,
   SortDescending,
+  Note,
+  Image as ImageIcon,
 } from 'phosphor-react'
 
 import Lightbox from '../components/Lightbox.jsx'
@@ -64,6 +66,7 @@ export default function PlantDetail() {
   const [showLegend, setShowLegend] = useState(false)
   const [collapsedMonths, setCollapsedMonths] = useState({})
   const [latestFirst, setLatestFirst] = useState(true)
+  const [activeTab, setActiveTab] = useState('summary')
 
   const ringClass = ringColors[plant?.urgency] || 'text-green-600'
   const progressPct = getWateringProgress(plant?.lastWatered, plant?.nextWater)
@@ -71,6 +74,12 @@ export default function PlantDetail() {
     plant?.lastFertilized,
     plant?.nextFertilize
   )
+
+  const fabIcons = {
+    summary: Drop,
+    activity: Note,
+    gallery: ImageIcon,
+  }
 
   const now = new Date()
   const nextWaterDate = plant?.nextWater ? new Date(plant.nextWater) : null
@@ -174,9 +183,18 @@ export default function PlantDetail() {
   const tabs = [
     {
       id: 'summary',
-      label: 'Care Summary',
+      label: (
+        <span>
+          <span role="img" aria-label="Care Summary" className="mr-1">🩺</span>
+          Care Summary
+        </span>
+      ),
       content: (
-        <SectionCard className="space-y-3">
+        <SectionCard className="space-y-3 bg-gray-50 dark:bg-gray-800/40">
+          <p className="font-semibold mb-2 flex items-center gap-1 text-lg">
+            <span role="img" aria-label="recent care">🌱</span>
+            Recent Care Summary
+          </p>
           <div className="space-y-3">
             <div className={`relative rounded-lg p-3 border-l-4 ${waterBorderClass} bg-water-50 dark:bg-water-900/30`}>
               <div className="flex items-center gap-1 font-headline font-semibold text-water-700 dark:text-water-200">
@@ -241,9 +259,18 @@ export default function PlantDetail() {
     },
     {
       id: 'activity',
-      label: 'Activity',
+      label: (
+        <span>
+          <span role="img" aria-label="Activity" className="mr-1">📅</span>
+          Activity
+        </span>
+      ),
       content: (
-        <SectionCard className="space-y-4">
+        <SectionCard className="space-y-4 bg-gray-50 dark:bg-gray-800/40">
+          <p className="font-semibold mb-2 flex items-center gap-1 text-lg">
+            <span role="img" aria-label="recent activity">📝</span>
+            Recent Activity
+          </p>
           <div className="flex justify-end gap-2">
             <button
               type="button"
@@ -318,9 +345,18 @@ export default function PlantDetail() {
     },
     {
       id: 'gallery',
-      label: 'Gallery',
+      label: (
+        <span>
+          <span role="img" aria-label="Gallery" className="mr-1">🖼</span>
+          Gallery
+        </span>
+      ),
       content: (
-        <SectionCard className="space-y-2">
+        <SectionCard className="space-y-2 bg-gray-50 dark:bg-gray-800/40">
+          <p className="font-semibold mb-2 flex items-center gap-1 text-lg">
+            <span role="img" aria-label="plant gallery">📷</span>
+            Your Plant Gallery
+          </p>
           <div className="flex flex-nowrap gap-3 overflow-x-auto pb-1 sm:pb-2">
             {(plant.photos || [])
               .slice(0, 3)
@@ -433,13 +469,14 @@ export default function PlantDetail() {
             />
           </div>
 
-          <DetailTabs tabs={tabs} />
+          <DetailTabs tabs={tabs} value={activeTab} onChange={setActiveTab} />
         </div>
         <PlantDetailFab
           onAddPhoto={openFileInput}
           onAddNote={handleLogEvent}
           onWater={handleWatered}
           onFertilize={handleFertilized}
+          icon={fabIcons[activeTab]}
         />
         {showNoteModal && (
           <NoteModal label="Note" onSave={saveNote} onCancel={cancelNote} />


### PR DESCRIPTION
## Summary
- enhance tab visual hierarchy with underline and icons
- add tab state handling in PlantDetail
- switch FAB icon based on active tab
- lighten tab section cards
- tweak FAB size and positioning

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b36a7de648324a96a594555024b2d