### PR TITLE
Overlay care progress on image

### DIFF
--- a/src/components/FertilizeProgress.jsx
+++ b/src/components/FertilizeProgress.jsx
@@ -1,0 +1,30 @@
+import { Sun, Flower } from 'phosphor-react'
+import useRipple from '../utils/useRipple.js'
+
+export default function FertilizeProgress({ completed = 0, total = 0 }) {
+  const [, createRipple] = useRipple()
+  const drops = Array.from({ length: total })
+  return (
+    <div className="flex gap-1" data-testid="fert-progress-bar">
+      {drops.map((_, i) => (
+        <span
+          key={i}
+          data-testid="fert-drop"
+          onMouseDown={createRipple}
+          onTouchStart={createRipple}
+          className="relative inline-flex overflow-hidden rounded-full"
+          aria-label={`Fertilizer drop ${i + 1} of ${total}`}
+          title={`Fertilizer drop ${i + 1} of ${total}`}
+        >
+          <Sun
+            aria-hidden="true"
+            className={`w-5 h-5 ${i < completed ? 'text-yellow-500' : 'text-gray-400'}`}
+          />
+        </span>
+      ))}
+      {total > 0 && completed === total && (
+        <Flower role="img" aria-label="Bloom" className="w-5 h-5 text-green-600 bloom-pop" />
+      )}
+    </div>
+  )
+}

--- a/src/components/__tests__/FertilizeProgress.test.jsx
+++ b/src/components/__tests__/FertilizeProgress.test.jsx
@@ -1,0 +1,23 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import FertilizeProgress from '../FertilizeProgress.jsx'
+
+test('renders sun icons with correct colors', () => {
+  const { container } = render(<FertilizeProgress completed={1} total={3} />)
+  const drops = screen.getAllByTestId('fert-drop')
+  expect(drops).toHaveLength(3)
+  const svgs = container.querySelectorAll('svg')
+  expect(svgs[0].getAttribute('class')).toMatch(/text-yellow-500/)
+  expect(svgs[1].getAttribute('class')).toMatch(/text-gray-400/)
+})
+
+test('shows bloom when all complete', () => {
+  render(<FertilizeProgress completed={2} total={2} />)
+  expect(screen.getByRole('img', { name: 'Bloom' })).toBeInTheDocument()
+})
+
+test('tap creates ripple', () => {
+  const { container } = render(<FertilizeProgress completed={0} total={1} />)
+  const drop = screen.getByTestId('fert-drop')
+  fireEvent.mouseDown(drop)
+  expect(container.querySelector('.ripple-effect')).toBeInTheDocument()
+})

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -22,6 +22,7 @@ import NoteModal from '../components/NoteModal.jsx'
 import { useMenu, defaultMenu } from '../MenuContext.jsx'
 import LegendModal from '../components/LegendModal.jsx'
 import WaterProgress from '../components/WaterProgress.jsx'
+import FertilizeProgress from '../components/FertilizeProgress.jsx'
 import PageHeader from '../components/PageHeader.jsx'
 import PlantDetailFab from '../components/PlantDetailFab.jsx'
 import SectionCard from '../components/SectionCard.jsx'
@@ -63,6 +64,13 @@ export default function PlantDetail() {
   const progressPct = getWateringProgress(plant?.lastWatered, plant?.nextWater)
   const waterTotal = 3
   const waterCompleted = Math.round(progressPct * waterTotal)
+
+  const fertPct = getWateringProgress(
+    plant?.lastFertilized,
+    plant?.nextFertilize
+  )
+  const fertTotal = 3
+  const fertCompleted = Math.round(fertPct * fertTotal)
 
   const now = new Date()
   const nextWaterDate = plant?.nextWater ? new Date(plant.nextWater) : null
@@ -401,14 +409,19 @@ export default function PlantDetail() {
             className="w-full h-64 object-cover"
           />
           <div className="img-gradient-overlay" aria-hidden="true"></div>
+          <div className="absolute top-2 right-2 flex gap-2">
+            <div className="bg-black/50 rounded p-1" aria-label="Watering progress">
+              <WaterProgress completed={waterCompleted} total={waterTotal} />
+            </div>
+            {plant.nextFertilize && (
+              <div className="bg-black/50 rounded p-1" aria-label="Fertilizing progress">
+                <FertilizeProgress completed={fertCompleted} total={fertTotal} />
+              </div>
+            )}
+          </div>
           <div className="absolute bottom-2 left-3 right-3 flex flex-col sm:flex-row justify-between text-white drop-shadow space-y-1 sm:space-y-0">
             <div>
-              <div className="flex items-center gap-2">
-                <h2 className="text-heading font-semibold font-headline">{plant.name}</h2>
-                <div className="relative" style={{ width: 24, height: 24 }} aria-label="Watering progress">
-                  <WaterProgress completed={waterCompleted} total={waterTotal} />
-                </div>
-              </div>
+              <h2 className="text-heading font-semibold font-headline">{plant.name}</h2>
               {plant.nickname && <p className="text-sm text-gray-200">{plant.nickname}</p>}
             </div>
             {/* brief care stats moved to Care Summary tab */}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -59,6 +59,7 @@ test('shows watering progress indicator', () => {
   )
 
   expect(screen.getByLabelText(/watering progress/i)).toBeInTheDocument()
+  expect(screen.getByLabelText(/fertilizing progress/i)).toBeInTheDocument()
 })
 
 


### PR DESCRIPTION
## Summary
- add FertilizeProgress component
- overlay watering and fertilizing progress in PlantDetail image
- test new FertilizeProgress
- update PlantDetail tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687b37920bf483249a70556fff0dbfb1