### PR TITLE
Refactor progress components

### DIFF
--- a/src/components/FertilizeProgress.jsx
+++ b/src/components/FertilizeProgress.jsx
@@ -1,30 +1,15 @@
-import { Sun, Flower } from 'phosphor-react'
-import useRipple from '../utils/useRipple.js'
+import { Sun } from 'phosphor-react'
+import IconProgress from './IconProgress.jsx'
 
-export default function FertilizeProgress({ completed = 0, total = 0 }) {
-  const [, createRipple] = useRipple()
-  const drops = Array.from({ length: total })
+export default function FertilizeProgress(props) {
   return (
-    <div className="flex gap-1" data-testid="fert-progress-bar">
-      {drops.map((_, i) => (
-        <span
-          key={i}
-          data-testid="fert-drop"
-          onMouseDown={createRipple}
-          onTouchStart={createRipple}
-          className="relative inline-flex overflow-hidden rounded-full"
-          aria-label={`Fertilizer drop ${i + 1} of ${total}`}
-          title={`Fertilizer drop ${i + 1} of ${total}`}
-        >
-          <Sun
-            aria-hidden="true"
-            className={`w-5 h-5 ${i < completed ? 'text-yellow-500' : 'text-gray-400'}`}
-          />
-        </span>
-      ))}
-      {total > 0 && completed === total && (
-        <Flower role="img" aria-label="Bloom" className="w-5 h-5 text-green-600 bloom-pop" />
-      )}
-    </div>
+    <IconProgress
+      icon={Sun}
+      completedColor="text-yellow-500"
+      testId="fert-progress-bar"
+      itemTestId="fert-drop"
+      itemLabelPrefix="Fertilizer drop"
+      {...props}
+    />
   )
 }

--- a/src/components/IconProgress.jsx
+++ b/src/components/IconProgress.jsx
@@ -1,0 +1,38 @@
+import { Flower } from 'phosphor-react'
+import useRipple from '../utils/useRipple.js'
+
+export default function IconProgress({
+  icon: Icon,
+  completedColor,
+  completed = 0,
+  total = 0,
+  testId,
+  itemTestId,
+  itemLabelPrefix
+}) {
+  const [, createRipple] = useRipple()
+  const items = Array.from({ length: total })
+  return (
+    <div className="flex gap-1" data-testid={testId}>
+      {items.map((_, i) => (
+        <span
+          key={i}
+          data-testid={itemTestId}
+          onMouseDown={createRipple}
+          onTouchStart={createRipple}
+          className="relative inline-flex overflow-hidden rounded-full"
+          aria-label={`${itemLabelPrefix} ${i + 1} of ${total}`}
+          title={`${itemLabelPrefix} ${i + 1} of ${total}`}
+        >
+          <Icon
+            aria-hidden="true"
+            className={`w-5 h-5 ${i < completed ? completedColor : 'text-gray-400'}`}
+          />
+        </span>
+      ))}
+      {total > 0 && completed === total && (
+        <Flower role="img" aria-label="Bloom" className="w-5 h-5 text-green-600 bloom-pop" />
+      )}
+    </div>
+  )
+}

--- a/src/components/WaterProgress.jsx
+++ b/src/components/WaterProgress.jsx
@@ -1,30 +1,15 @@
-import { Drop, Flower } from 'phosphor-react'
-import useRipple from '../utils/useRipple.js'
+import { Drop } from 'phosphor-react'
+import IconProgress from './IconProgress.jsx'
 
-export default function WaterProgress({ completed = 0, total = 0 }) {
-  const [, createRipple] = useRipple()
-  const drops = Array.from({ length: total })
+export default function WaterProgress(props) {
   return (
-    <div className="flex gap-1" data-testid="water-progress-bar">
-      {drops.map((_, i) => (
-        <span
-          key={i}
-          data-testid="water-drop"
-          onMouseDown={createRipple}
-          onTouchStart={createRipple}
-          className="relative inline-flex overflow-hidden rounded-full"
-          aria-label={`Water drop ${i + 1} of ${total}`}
-          title={`Water drop ${i + 1} of ${total}`}
-        >
-          <Drop
-            aria-hidden="true"
-            className={`w-5 h-5 ${i < completed ? 'text-blue-500' : 'text-gray-400'}`}
-          />
-        </span>
-      ))}
-      {total > 0 && completed === total && (
-        <Flower role="img" aria-label="Bloom" className="w-5 h-5 text-green-600 bloom-pop" />
-      )}
-    </div>
+    <IconProgress
+      icon={Drop}
+      completedColor="text-blue-500"
+      testId="water-progress-bar"
+      itemTestId="water-drop"
+      itemLabelPrefix="Water drop"
+      {...props}
+    />
   )
 }


### PR DESCRIPTION
## Summary
- create `IconProgress` to handle generic progress icons
- refactor `WaterProgress` and `FertilizeProgress` to use new component

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687b8b29c6388324a9fc16348db0bd01