### PR TITLE
Adjust swipe threshold and animate completion

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -67,10 +67,10 @@ export default function TaskCard({
   const { dx, start, move, end } = useSwipe(
     diff => {
       if (!swipeable) return
-      if (diff > 60) {
+      if (diff > 40) {
         handleComplete()
         navigator.vibrate?.(10)
-      } else if (diff < -60) {
+      } else if (diff < -40) {
         const room = task.room ? encodeURIComponent(task.room) : null
         navigate(
           room ? `/room/${room}/plant/${task.plantId}` : `/plant/${task.plantId}`
@@ -80,7 +80,7 @@ export default function TaskCard({
     { threshold: 30 }
   )
 
-  const showActionBar = dx < 0 && dx > -60
+  const showActionBar = dx < 0 && dx > -40
 
   return (
     <>
@@ -188,7 +188,7 @@ export default function TaskCard({
           {completed && (
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none task-complete-fade">
               <svg
-                className="w-8 h-8 text-healthy-600 check-pop swipe-check"
+                className="w-8 h-8 text-healthy-600 check-pop swipe-check fade-in"
                 xmlns="http://www.w3.org/2000/svg"
                 fill="none"
                 viewBox="0 0 24 24"

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -110,17 +110,17 @@ export default function UnifiedTaskCard({
   const { dx, start, move, end } = useSwipe(
     diff => {
       if (!swipeable) return
-      if (diff > 60) {
+      if (diff > 40) {
         handleComplete()
         navigator.vibrate?.(10)
-      } else if (diff < -60) {
+      } else if (diff < -40) {
         goToDetail()
       }
     },
     { threshold: 30 }
   )
 
-  const showActionBar = dx < 0 && dx > -60
+  const showActionBar = dx < 0 && dx > -40
 
   return (
     <div
@@ -216,7 +216,7 @@ export default function UnifiedTaskCard({
       {completed && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none task-complete-fade">
           <svg
-            className="w-8 h-8 text-healthy-600 check-pop swipe-check"
+            className="w-8 h-8 text-healthy-600 check-pop swipe-check fade-in"
             xmlns="http://www.w3.org/2000/svg"
             fill="none"
             viewBox="0 0 24 24"

--- a/src/index.css
+++ b/src/index.css
@@ -217,6 +217,19 @@ body {
   animation: task-complete-fade 0.4s ease-out forwards;
 }
 
+@keyframes fade-in {
+  from {
+    opacity: 0;
+  }
+  to {
+    opacity: 1;
+  }
+}
+
+.fade-in {
+  animation: fade-in 0.3s ease-out;
+}
+
 
 /* Dropdown select styling */
 .dropdown-select {


### PR DESCRIPTION
## Summary
- reduce required swipe distance to 40px for completing or opening a task
- display a fade-in animation for the swipe completion checkmark

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ba1820640832488a8a8db5f63502d