### PR TITLE
Update overlay typography

### DIFF
--- a/src/components/BalconyPlantCard.jsx
+++ b/src/components/BalconyPlantCard.jsx
@@ -34,7 +34,7 @@ export default function BalconyPlantCard({ plant }) {
         </Badge>
       )}
       <div className="absolute bottom-2 left-3 right-3 text-white drop-shadow space-y-0.5 text-left">
-        <h3 className="font-headline font-bold text-lg leading-none text-left">
+        <h3 className="font-headline font-bold text-xl leading-none text-left">
           {plant.name}
         </h3>
         <p className="text-sm text-left">Last watered {formatDaysAgo(plant.lastWatered)}</p>

--- a/src/components/ImageCard.jsx
+++ b/src/components/ImageCard.jsx
@@ -17,7 +17,7 @@ export default function ImageCard({
         {(title || badges) && (
           <div className="absolute bottom-1 left-2 right-2 drop-shadow text-white space-y-0.5">
             {title && (
-              <div className="font-bold text-lg font-headline leading-none">{title}</div>
+              <div className="font-bold text-xl font-headline leading-none">{title}</div>
             )}
             {badges && <div className="flex flex-wrap gap-1">{badges}</div>}
           </div>

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -204,7 +204,7 @@ exports[`matches snapshot in dark mode 1`] = `
         class="absolute bottom-1 left-2 right-2 drop-shadow text-white space-y-0.5"
       >
         <div
-          class="font-bold text-lg font-headline leading-none"
+          class="font-bold text-xl font-headline leading-none"
         >
           <a
             class="focus:outline-none"

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -184,8 +184,8 @@ export default function MyPlants() {
                   {pestAlert && <Bug className="w-4 h-4" aria-hidden="true" />}
                   {lastUpdated && <span>{formatDaysAgo(lastUpdated)}</span>}
                 </div>
-                <p className="font-bold text-lg font-headline leading-none">{room}</p>
-                <p className="text-xs leading-none">{countPlants(room)} plants</p>
+                <p className="font-bold text-xl font-headline leading-none">{room}</p>
+                <p className="text-xs text-white/80 leading-none">{countPlants(room)} plants</p>
               </div>
             </Link>
           )


### PR DESCRIPTION
## Summary
- bump up overlay title text to `text-xl`
- lighten plant count text and update tests

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_687ba6a3bfb0832493278aade5043e5f