### PR TITLE
Replace swipe actions with kebab menu

### DIFF
--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -8,6 +8,7 @@ import {
   PencilSimpleLine,
   ClockCounterClockwise,
   Trash,
+  DotsThreeVertical,
 } from 'phosphor-react'
 import { formatDaysAgo } from '../utils/dateFormat.js'
 import { useNavigate } from 'react-router-dom'
@@ -26,6 +27,7 @@ export default function UnifiedTaskCard({
   const { name, image, dueWater, dueFertilize, lastCared } = plant
 
   const [completed, setCompleted] = useState(false)
+  const [showMenu, setShowMenu] = useState(false)
   const navigate = useNavigate()
   const { plants, markWatered, markFertilized, updatePlant } = usePlants()
   const { showSnackbar } = useSnackbar()
@@ -120,51 +122,82 @@ export default function UnifiedTaskCard({
     { threshold: 30 }
   )
 
-  const showActionBar = dx < 0 && dx > -40
 
   return (
     <div
       data-testid="unified-task-card"
       className={`relative rounded-2xl border border-neutral-200 dark:border-gray-600 shadow overflow-hidden touch-pan-y select-none ${bgClass}`}
-      style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
+      style={{ transform: `translateX(${swipeable ? (dx > 0 ? dx : 0) : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
       onPointerDown={start}
       onPointerMove={move}
       onPointerUp={end}
       onPointerCancel={end}
     >
-      <div
-        className={`task-action-bar ${showActionBar ? 'show' : ''}`}
-        role="group"
-        aria-label="Task actions"
-      >
-        <button
-          type="button"
-          aria-label="Edit task"
-          onClick={handleEdit}
-          className="task-action bg-blue-600 text-white"
+      {showMenu && (
+        <div
+          className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
+          role="dialog"
+          aria-modal="true"
+          aria-label="Task actions menu"
+          onClick={() => setShowMenu(false)}
         >
-          <PencilSimpleLine className="w-4 h-4" aria-hidden="true" />
-          Edit
-        </button>
-        <button
-          type="button"
-          aria-label="Reschedule task"
-          onClick={handleReschedule}
-          className="task-action bg-yellow-600 text-white"
-        >
-          <ClockCounterClockwise className="w-4 h-4" aria-hidden="true" />
-          Reschedule
-        </button>
-        <button
-          type="button"
-          aria-label="Delete task"
-          onClick={handleDelete}
-          className="task-action bg-red-600 text-white"
-        >
-          <Trash className="w-4 h-4" aria-hidden="true" />
-          Delete
-        </button>
-      </div>
+          <ul
+            className="modal-box relative p-4 space-y-3"
+            onClick={e => e.stopPropagation()}
+          >
+            <button
+              type="button"
+              aria-label="Close menu"
+              onClick={() => setShowMenu(false)}
+              className="modal-close"
+            >
+              &times;
+            </button>
+            <li>
+              <button
+                type="button"
+                aria-label="Edit task"
+                onClick={() => {
+                  setShowMenu(false)
+                  handleEdit()
+                }}
+                className="task-action bg-blue-600 text-white w-full justify-start"
+              >
+                <PencilSimpleLine className="w-4 h-4" aria-hidden="true" />
+                Edit
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                aria-label="Reschedule task"
+                onClick={() => {
+                  setShowMenu(false)
+                  handleReschedule()
+                }}
+                className="task-action bg-yellow-600 text-white w-full justify-start"
+              >
+                <ClockCounterClockwise className="w-4 h-4" aria-hidden="true" />
+                Reschedule
+              </button>
+            </li>
+            <li>
+              <button
+                type="button"
+                aria-label="Delete task"
+                onClick={() => {
+                  setShowMenu(false)
+                  handleDelete()
+                }}
+                className="task-action bg-red-600 text-white w-full justify-start"
+              >
+                <Trash className="w-4 h-4" aria-hidden="true" />
+                Delete
+              </button>
+            </li>
+          </ul>
+        </div>
+      )}
       <div className="flex items-center gap-4 p-4">
         <div className="w-14 h-14 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-700">
           <img src={image} alt={name} className="w-12 h-12 rounded-full object-cover" />
@@ -174,15 +207,25 @@ export default function UnifiedTaskCard({
             <p className="font-semibold font-headline text-gray-900 dark:text-gray-100 truncate">
               {name}
             </p>
-            {overdue ? (
-              <Badge variant="overdue" size="sm" Icon={WarningCircle}>
-                Overdue
-              </Badge>
-            ) : urgent ? (
-              <Badge variant="urgent" size="sm" Icon={CheckCircle}>
-                Today
-              </Badge>
-            ) : null}
+            <div className="flex items-center gap-2">
+              {overdue ? (
+                <Badge variant="overdue" size="sm" Icon={WarningCircle}>
+                  Overdue
+                </Badge>
+              ) : urgent ? (
+                <Badge variant="urgent" size="sm" Icon={CheckCircle}>
+                  Today
+                </Badge>
+              ) : null}
+              <button
+                type="button"
+                aria-label="Open task menu"
+                onClick={() => setShowMenu(true)}
+                className="p-1 text-gray-500 hover:text-gray-700"
+              >
+                <DotsThreeVertical className="w-5 h-5" aria-hidden="true" />
+              </button>
+            </div>
           </div>
           <div className="flex items-center gap-4 mt-1 font-semibold">
             {dueWater && (

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -101,18 +101,17 @@ test('does not render a completion button', () => {
   expect(screen.queryByRole('button', { name: /mark as done/i })).toBeNull()
 })
 
-test('partial left swipe reveals actions', () => {
+test('kebab menu exposes actions', () => {
   renderWithSnackbar(
       <UnifiedTaskCard plant={plant} />
   )
-  const wrapper = screen.getByTestId('unified-task-card')
-  fireEvent.pointerDown(wrapper, { clientX: 100, buttons: 1 })
-  fireEvent.pointerMove(wrapper, { clientX: 70, buttons: 1 })
-  expect(screen.getByRole('button', { name: /edit task/i })).toBeInTheDocument()
+  fireEvent.click(screen.getByRole('button', { name: /open task menu/i }))
   fireEvent.click(screen.getByRole('button', { name: /edit task/i }))
   expect(navigateMock).toHaveBeenCalledWith('/plant/1/edit')
+  fireEvent.click(screen.getByRole('button', { name: /open task menu/i }))
   fireEvent.click(screen.getByRole('button', { name: /reschedule task/i }))
   expect(updatePlant).toHaveBeenCalled()
+  fireEvent.click(screen.getByRole('button', { name: /open task menu/i }))
   fireEvent.click(screen.getByRole('button', { name: /delete task/i }))
   expect(updatePlant).toHaveBeenCalledTimes(2)
 })

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -7,195 +7,6 @@ exports[`matches snapshot in dark mode 1`] = `
   style="transform: translateX(0px); transition: transform 0.2s;"
 >
   <div
-    aria-label="Task actions"
-    class="task-action-bar "
-    role="group"
-  >
-    <button
-      aria-label="Edit task"
-      class="task-action bg-blue-600 text-white"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="w-4 h-4"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 256 256"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <rect
-          fill="none"
-          height="256"
-          width="256"
-        />
-        <path
-          d="M96,216H48a8,8,0,0,1-8-8V163.3a7.9,7.9,0,0,1,2.3-5.6l120-120a8,8,0,0,1,11.4,0l44.6,44.6a8,8,0,0,1,0,11.4Z"
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-        <line
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-          x1="216"
-          x2="96"
-          y1="216"
-          y2="216"
-        />
-        <line
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-          x1="136"
-          x2="192"
-          y1="64"
-          y2="120"
-        />
-      </svg>
-      Edit
-    </button>
-    <button
-      aria-label="Reschedule task"
-      class="task-action bg-yellow-600 text-white"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="w-4 h-4"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 256 256"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <rect
-          fill="none"
-          height="256"
-          width="256"
-        />
-        <line
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-          x1="128"
-          x2="128"
-          y1="80"
-          y2="128"
-        />
-        <line
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-          x1="169.6"
-          x2="128"
-          y1="152"
-          y2="128"
-        />
-        <polyline
-          fill="none"
-          points="71.8 99.7 31.8 99.7 31.8 59.7"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-        <path
-          d="M65.8,190.2a88,88,0,1,0,0-124.4l-34,33.9"
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-      </svg>
-      Reschedule
-    </button>
-    <button
-      aria-label="Delete task"
-      class="task-action bg-red-600 text-white"
-      type="button"
-    >
-      <svg
-        aria-hidden="true"
-        class="w-4 h-4"
-        fill="currentColor"
-        height="1em"
-        viewBox="0 0 256 256"
-        width="1em"
-        xmlns="http://www.w3.org/2000/svg"
-      >
-        <rect
-          fill="none"
-          height="256"
-          width="256"
-        />
-        <line
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-          x1="216"
-          x2="40"
-          y1="56"
-          y2="56"
-        />
-        <line
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-          x1="104"
-          x2="104"
-          y1="104"
-          y2="168"
-        />
-        <line
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-          x1="152"
-          x2="152"
-          y1="104"
-          y2="168"
-        />
-        <path
-          d="M200,56V208a8,8,0,0,1-8,8H64a8,8,0,0,1-8-8V56"
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-        <path
-          d="M168,56V40a16,16,0,0,0-16-16H104A16,16,0,0,0,88,40V56"
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-        />
-      </svg>
-      Delete
-    </button>
-  </div>
-  <div
     class="flex items-center gap-4 p-4"
   >
     <div
@@ -218,6 +29,46 @@ exports[`matches snapshot in dark mode 1`] = `
         >
           Fern
         </p>
+        <div
+          class="flex items-center gap-2"
+        >
+          <button
+            aria-label="Open task menu"
+            class="p-1 text-gray-500 hover:text-gray-700"
+            type="button"
+          >
+            <svg
+              aria-hidden="true"
+              class="w-5 h-5"
+              fill="currentColor"
+              height="1em"
+              viewBox="0 0 256 256"
+              width="1em"
+              xmlns="http://www.w3.org/2000/svg"
+            >
+              <rect
+                fill="none"
+                height="256"
+                width="256"
+              />
+              <circle
+                cx="128"
+                cy="128"
+                r="12"
+              />
+              <circle
+                cx="128"
+                cy="64"
+                r="12"
+              />
+              <circle
+                cx="128"
+                cy="192"
+                r="12"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
       <div
         class="flex items-center gap-4 mt-1 font-semibold"


### PR DESCRIPTION
## Summary
- swap swipe action menu in `UnifiedTaskCard` for a kebab menu
- update tests and snapshots

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687ba51b5da48324bc1e7a469dd39fb5