### PR TITLE
Improve spacing in menu lists

### DIFF
--- a/src/components/AddMenu.jsx
+++ b/src/components/AddMenu.jsx
@@ -34,7 +34,7 @@ export default function AddMenu({ open = false, onClose = () => {} }) {
               to={to}
               onClick={onClose}
               title={label}
-              className="flex items-center gap-3 hover:text-accent"
+              className="flex items-center gap-4 hover:text-accent"
             >
               <Icon className="w-5 h-5" aria-hidden="true" />
               {label}

--- a/src/components/CreateFab.jsx
+++ b/src/components/CreateFab.jsx
@@ -35,7 +35,7 @@ export default function CreateFab() {
           onClick={() => setOpen(false)}
         >
           <ul
-            className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
+            className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-4 animate-fade-in-up"
             onClick={e => e.stopPropagation()}
           >
             <button
@@ -52,7 +52,7 @@ export default function CreateFab() {
                   to={to}
                   onClick={() => setOpen(false)}
                   title={label}
-                  className="flex items-center gap-3 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
+                  className="flex items-center gap-4 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
                 >
                   <span className={`p-2 rounded-full ${colorClasses[color].bg}`}>
                     <Icon className={`w-5 h-5 ${colorClasses[color].text}`} aria-hidden="true" />

--- a/src/components/NoteFab.jsx
+++ b/src/components/NoteFab.jsx
@@ -24,7 +24,7 @@ export default function NoteFab({ onAddNote }) {
           onClick={() => setOpen(false)}
         >
           <ul
-            className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-3 animate-fade-in-up"
+            className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-4 animate-fade-in-up"
             onClick={e => e.stopPropagation()}
           >
             <button
@@ -43,7 +43,7 @@ export default function NoteFab({ onAddNote }) {
                   onAddNote?.()
                 }}
                 title="Add Note"
-                className="flex items-center gap-3 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
+                className="flex items-center gap-4 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
               >
                 <span className="p-2 rounded-full bg-violet-100">
                   <Note className="w-5 h-5 text-violet-600" aria-hidden="true" />

--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -91,7 +91,7 @@ export default function PersistentBottomNav() {
                     to={to}
                     onClick={() => setOpen(false)}
                     title={label}
-                    className="flex items-center gap-3 hover:text-accent"
+                    className="flex items-center gap-4 hover:text-accent"
                   >
                     <ItemIcon className="w-5 h-5" aria-hidden="true" />
                     {label}
@@ -104,7 +104,7 @@ export default function PersistentBottomNav() {
                       onClick?.()
                     }}
                     title={label}
-                    className="flex items-center gap-3 w-full text-left hover:text-accent"
+                    className="flex items-center gap-4 w-full text-left hover:text-accent"
                   >
                     <ItemIcon className="w-5 h-5" aria-hidden="true" />
                     {label}


### PR DESCRIPTION
## Summary
- bump menu gaps from `gap-3` to `gap-4`
- adjust related overlay spacing
- verify tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bab47be3c8324b176708c5171be04