### PR TITLE
Improve overdue badge spacing

### DIFF
--- a/src/components/BalconyPlantCard.jsx
+++ b/src/components/BalconyPlantCard.jsx
@@ -26,7 +26,7 @@ export default function BalconyPlantCard({ plant }) {
       ></div>
       {overdue && (
         <Badge
-          className="absolute top-3 left-3 px-2 py-1 opacity-90 backdrop-blur-sm"
+          className="absolute top-4 left-4 px-3 py-1 opacity-80 backdrop-blur-sm shadow"
           colorClass="bg-yellow-200/90 text-yellow-900"
           size="sm"
         >


### PR DESCRIPTION
## Summary
- tweak BalconyPlantCard overdue badge spacing and opacity

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bafe7ca7c8324bce93f94cadda339