### PR TITLE
Enhance overlay text styles

### DIFF
--- a/src/components/BalconyPlantCard.jsx
+++ b/src/components/BalconyPlantCard.jsx
@@ -34,7 +34,7 @@ export default function BalconyPlantCard({ plant }) {
         </Badge>
       )}
       <div className="absolute bottom-2 left-3 right-3 text-white drop-shadow space-y-0.5 text-left">
-        <h3 className="font-headline font-bold text-xl leading-none text-left">
+        <h3 className="font-headline font-extrabold text-xl leading-none text-left">
           {plant.name}
         </h3>
         <p className="text-sm text-left">Last watered {formatDaysAgo(plant.lastWatered)}</p>

--- a/src/components/ImageCard.jsx
+++ b/src/components/ImageCard.jsx
@@ -17,7 +17,7 @@ export default function ImageCard({
         {(title || badges) && (
           <div className="absolute bottom-1 left-2 right-2 drop-shadow text-white space-y-0.5">
             {title && (
-              <div className="font-bold text-xl font-headline leading-none">{title}</div>
+              <div className="font-extrabold text-xl font-headline leading-none">{title}</div>
             )}
             {badges && <div className="flex flex-wrap gap-1">{badges}</div>}
           </div>

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -204,7 +204,7 @@ exports[`matches snapshot in dark mode 1`] = `
         class="absolute bottom-1 left-2 right-2 drop-shadow text-white space-y-0.5"
       >
         <div
-          class="font-bold text-xl font-headline leading-none"
+          class="font-extrabold text-xl font-headline leading-none"
         >
           <a
             class="focus:outline-none"

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -184,8 +184,8 @@ export default function MyPlants() {
                   {pestAlert && <Bug className="w-4 h-4" aria-hidden="true" />}
                   {lastUpdated && <span>{formatDaysAgo(lastUpdated)}</span>}
                 </div>
-                <p className="font-bold text-xl font-headline leading-none">{room}</p>
-                <p className="text-xs text-white/80 leading-none">{countPlants(room)} plants</p>
+                <p className="font-extrabold text-xl font-headline leading-none">{room}</p>
+                <p className="text-[0.65rem] text-white/60 leading-none">{countPlants(room)} plants</p>
               </div>
             </Link>
           )

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -422,7 +422,7 @@ export default function PlantDetail() {
           </div>
           <div className="absolute bottom-2 left-3 right-3 flex flex-col sm:flex-row justify-between text-white drop-shadow space-y-1 sm:space-y-0">
             <div>
-              <h2 className="text-heading font-semibold font-headline">{plant.name}</h2>
+              <h2 className="text-heading font-extrabold font-headline">{plant.name}</h2>
               {plant.nickname && <p className="text-sm text-gray-200">{plant.nickname}</p>}
             </div>
             {/* brief care stats moved to Care Summary tab */}


### PR DESCRIPTION
## Summary
- emphasize card titles with heavier text weight
- deemphasize plant counts with smaller/lighter text

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bafecfb508324864e9f92c35b7079