### PR TITLE
Fix canvas-confetti usage in PlantDetail

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -120,11 +120,15 @@ export default function PlantDetail() {
     showToast('Watered')
     if (typeof HTMLCanvasElement !== 'undefined' &&
         HTMLCanvasElement.prototype.getContext) {
-      confetti({
-        particleCount: 100,
-        spread: 70,
-        origin: { y: 0.6 },
-      })
+      try {
+        confetti({
+          particleCount: 100,
+          spread: 70,
+          origin: { y: 0.6 },
+        })
+      } catch {
+        // Canvas API may be missing in some environments (like jsdom)
+      }
     }
   }
 

--- a/src/pages/__tests__/PlantDetailActions.test.jsx
+++ b/src/pages/__tests__/PlantDetailActions.test.jsx
@@ -4,6 +4,13 @@ import PlantDetail from '../PlantDetail.jsx'
 import { usePlants } from '../../PlantContext.jsx'
 import { MenuProvider } from '../../MenuContext.jsx'
 
+// Confetti relies on the canvas API which JSDOM doesn't fully implement.
+// Mock it here to avoid noisy warnings during tests.
+jest.mock('canvas-confetti', () => ({
+  __esModule: true,
+  default: () => {},
+}))
+
 const markWatered = jest.fn()
 const markFertilized = jest.fn()
 let mockPlants = []


### PR DESCRIPTION
## Summary
- catch errors when confetti triggers without Canvas support
- silence canvas warnings in PlantDetailActions tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bb86dc6348324aff08b52c87f86d0