### PR TITLE
Adjust badge styling

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -18,13 +18,13 @@ export default function Badge({
   const cls = colorClass || variants[variant] || 'bg-gray-200 text-gray-800'
 
   const sizeClasses = {
-    base: 'px-2 py-0.5 text-badge',
-    sm: 'px-1.5 py-0 text-[10px]',
+    base: 'px-3 py-1 text-badge',
+    sm: 'px-2 py-0.5 text-[10px]',
   }
 
   const sizeClass = sizeClasses[size] || sizeClasses.base
 
-  const classes = `inline-flex items-center gap-1 rounded-full font-medium ${sizeClass} ${cls} ${className}`.trim()
+  const classes = `inline-flex items-center gap-1 rounded-full font-medium shadow-sm ${sizeClass} ${cls} ${className}`.trim()
 
   return (
     <span

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -178,7 +178,7 @@ exports[`matches snapshot in dark mode 1`] = `
     class="absolute top-2 right-2 pointer-events-none"
   >
     <span
-      class="inline-flex items-center gap-1 rounded-full font-medium px-1.5 py-0 text-[10px] bg-red-50 text-red-500"
+      class="inline-flex items-center gap-1 rounded-full font-medium shadow-sm px-2 py-0.5 text-[10px] bg-red-50 text-red-500"
     >
       Thirsty
     </span>

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -229,7 +229,7 @@ exports[`matches snapshot in dark mode 1`] = `
           class="flex items-center gap-2 mt-1"
         >
           <span
-            class="inline-flex items-center gap-1 rounded-full font-medium px-2 py-0.5 text-badge bg-blue-100 text-blue-800"
+            class="inline-flex items-center gap-1 rounded-full font-medium shadow-sm px-3 py-1 text-badge bg-blue-100 text-blue-800"
           >
             <svg
               aria-hidden="true"

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -159,7 +159,7 @@ export default function MyPlants() {
               {overdue > 0 && (
                 <Badge
                   variant="overdue"
-                  className="absolute top-2 right-2 slide-in animate-pulse rounded-full text-badge"
+                  className="absolute top-3 right-3 slide-in animate-pulse rounded-full text-badge"
                   Icon={WarningCircle}
                 >
                   {overdue} needs love


### PR DESCRIPTION
## Summary
- add subtle shadow and extra padding for badges
- tweak MyPlants page to offset repositioned badge
- update snapshots

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_687bb8577a6c8324b910035b74449b62