### PR TITLE
Implement design suggestions

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -9,10 +9,10 @@ export default function Badge({
   size = 'base',
 }) {
   const variants = {
-    info: 'bg-blue-100 text-blue-800',
-    urgent: 'bg-yellow-100 text-yellow-700',
+    info: 'bg-sky-100 text-sky-700',
+    urgent: 'bg-amber-100 text-amber-700',
     overdue: 'bg-red-50 text-red-500',
-    complete: 'bg-green-100 text-green-800',
+    complete: 'bg-emerald-100 text-emerald-800',
   }
 
   const cls = colorClass || variants[variant] || 'bg-gray-200 text-gray-800'

--- a/src/components/CareRings.jsx
+++ b/src/components/CareRings.jsx
@@ -29,6 +29,7 @@ export default function CareRings({
   const label = `${Math.round(waterPct * 100)}% watered, ${Math.round(
     fertPct * 100
   )}% fertilized`
+  const tooltip = `${totalCompleted}/${totalTasks} tasks complete\n- ${waterCompleted} water\n- ${fertCompleted} fertilize`
 
   const center = size / 2
   const rotate = `rotate(-90 ${center} ${center})`
@@ -53,7 +54,11 @@ export default function CareRings({
       style={{ width: displaySize, flexBasis: displaySize }}
       onClick={onClick}
     >
-      <div className="relative" style={{ width: displaySize, height: displaySize }}>
+      <div
+        className="relative"
+        style={{ width: displaySize, height: displaySize }}
+        title={tooltip}
+      >
         <svg
           width={displaySize}
           height={displaySize}
@@ -71,7 +76,7 @@ export default function CareRings({
             strokeWidth={strokeWidth}
             strokeDasharray={outerCirc}
             strokeDashoffset={waterOffset}
-            className={`text-blue-500 transition-[stroke-dashoffset] duration-300 ${onWaterClick ? 'cursor-pointer' : ''}`}
+            className={`text-sky-500 transition-[stroke-dashoffset] duration-300 ${onWaterClick ? 'cursor-pointer' : ''}`}
             transform={rotate}
             onClick={e => {
               e.stopPropagation()
@@ -87,7 +92,7 @@ export default function CareRings({
             strokeWidth={strokeWidth}
             strokeDasharray={innerCirc}
             strokeDashoffset={fertOffset}
-            className={`text-green-500 transition-[stroke-dashoffset] duration-300 ${onFertClick ? 'cursor-pointer' : ''}`}
+            className={`text-amber-500 transition-[stroke-dashoffset] duration-300 ${onFertClick ? 'cursor-pointer' : ''}`}
             transform={rotate}
             onClick={e => {
               e.stopPropagation()

--- a/src/components/CareStats.jsx
+++ b/src/components/CareStats.jsx
@@ -62,7 +62,7 @@ export default function CareStats({
       Icon: ListChecks,
       completed: totalCompleted,
       total: totalTasks,
-      ringClass: 'text-green-600',
+      ringClass: 'text-emerald-600',
       onClick: onTotalClick,
     },
     {
@@ -71,7 +71,7 @@ export default function CareStats({
       Icon: Drop,
       completed: waterCompleted,
       total: waterTotal,
-      ringClass: 'text-blue-500',
+      ringClass: 'text-sky-500',
       onClick: onWaterClick,
     },
     {
@@ -80,7 +80,7 @@ export default function CareStats({
       Icon: Sun,
       completed: fertCompleted,
       total: fertTotal,
-      ringClass: 'text-yellow-700',
+      ringClass: 'text-amber-600',
       onClick: onFertClick,
     },
   ]

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -9,6 +9,7 @@ import useSwipe from '../hooks/useSwipe.js'
 export default function TaskCard({
   task,
   urgent = false,
+  overdue = false,
   completed = false,
   compact = false,
   swipeable = true,
@@ -88,7 +89,7 @@ export default function TaskCard({
       data-testid="task-card"
       tabIndex="0"
       aria-label={`Task card for ${task.plantName}`}
-      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 touch-pan-y select-none ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : 'bg-neutral-50 dark:bg-gray-700'}${urgent ? ' ring-2 ring-green-300 dark:ring-green-400' : ''}`}
+      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 touch-pan-y select-none ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : overdue ? 'bg-red-50 dark:bg-red-800' : urgent ? 'bg-amber-50 dark:bg-gray-700' : 'bg-slate-50 dark:bg-gray-700'}${overdue ? ' ring-2 ring-red-300 dark:ring-red-400' : urgent ? ' ring-2 ring-amber-300 dark:ring-amber-400' : ''}`}
       style={{ transform: `translateX(${swipeable ? dx : 0}px)`, transition: dx === 0 ? 'transform 0.2s' : 'none' }}
       onPointerDown={start}
       onPointerMove={move}
@@ -175,7 +176,7 @@ export default function TaskCard({
                 : task.type}
             </Badge>
             {daysSince != null && (
-              <span className="text-timestamp text-gray-400">
+              <span className="text-sm text-gray-500">
                 {daysSince} {daysSince === 1 ? 'day' : 'days'} since care
               </span>
             )}

--- a/src/components/TaskTabs.jsx
+++ b/src/components/TaskTabs.jsx
@@ -1,7 +1,7 @@
 import React from 'react'
 
 export default function TaskTabs({ value = 'Upcoming', onChange }) {
-  const tabs = ['Upcoming', 'Past', 'By Plant']
+  const tabs = ['Upcoming', 'Past', 'By Plant', 'By Room']
   return (
     <div role="tablist" className="flex justify-center gap-2 my-2">
       {tabs.map(tab => (

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -34,15 +34,12 @@ export default function UnifiedTaskCard({
   const { showSnackbar } = useSnackbar()
 
   const bgClass = overdue
-    ? 'bg-pink-50 dark:bg-red-800'
+    ? 'bg-red-50 dark:bg-red-800'
     : urgent
-    ? 'bg-yellow-50 dark:bg-gray-700'
-    : 'bg-gray-50 dark:bg-gray-800'
+    ? 'bg-amber-50 dark:bg-gray-700'
+    : 'bg-slate-50 dark:bg-gray-800'
 
   const lastText = lastCared ? formatDaysAgo(lastCared) : null
-  const last = lastText ? (
-    <p className="text-timestamp text-gray-500">Last cared for {lastText}</p>
-  ) : null
 
   let intervalDays = null
   if (dueWater && plant.lastWatered && plant.nextWater) {
@@ -230,24 +227,26 @@ export default function UnifiedTaskCard({
               </button>
             </div>
           </div>
-          <div className="flex items-center gap-4 mt-1 font-semibold">
+          <div className="flex flex-col gap-1 mt-1 font-semibold">
             {dueWater && (
-              <span className="inline-flex items-center gap-1 text-amber-600">
+              <span className="inline-flex items-center gap-1 text-sky-600">
                 <Drop className="w-4 h-4" aria-hidden="true" />
                 Water
               </span>
             )}
             {dueFertilize && (
-              <span className="inline-flex items-center gap-1 text-red-600">
+              <span className="inline-flex items-center gap-1 text-amber-600">
                 <Sun className="w-4 h-4" aria-hidden="true" />
                 Fertilize
               </span>
             )}
           </div>
-          {last}
+          {lastText && (
+            <p className="text-sm text-gray-500">Last cared for {lastText}</p>
+          )}
           {needsText && (
             <p
-              className={`text-timestamp mt-0.5 flex items-center gap-1 ${
+              className={`text-timestamp italic mt-0.5 flex items-center gap-1 ${
                 overdue ? 'text-red-600' : 'text-gray-500'
               }`}
             >

--- a/src/components/__tests__/CareStats.test.jsx
+++ b/src/components/__tests__/CareStats.test.jsx
@@ -37,9 +37,9 @@ test('rings use accessible color classes', () => {
   )
   const getCircle = id =>
     screen.getByTestId(id).querySelector('svg circle')
-  expect(getCircle('stat-total')).toHaveClass('text-green-600')
-  expect(getCircle('stat-water')).toHaveClass('text-blue-500')
-  expect(getCircle('stat-fertilize')).toHaveClass('text-yellow-700')
+  expect(getCircle('stat-total')).toHaveClass('text-emerald-600')
+  expect(getCircle('stat-water')).toHaveClass('text-sky-500')
+  expect(getCircle('stat-fertilize')).toHaveClass('text-amber-600')
 })
 
 test('ring colors remain in dark mode', () => {
@@ -49,9 +49,9 @@ test('ring colors remain in dark mode', () => {
   )
   const getCircle = id =>
     screen.getByTestId(id).querySelector('svg circle')
-  expect(getCircle('stat-total')).toHaveClass('text-green-600')
-  expect(getCircle('stat-water')).toHaveClass('text-blue-500')
-  expect(getCircle('stat-fertilize')).toHaveClass('text-yellow-700')
+  expect(getCircle('stat-total')).toHaveClass('text-emerald-600')
+  expect(getCircle('stat-water')).toHaveClass('text-sky-500')
+  expect(getCircle('stat-fertilize')).toHaveClass('text-amber-600')
   document.documentElement.classList.remove('dark')
 })
 

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -65,8 +65,8 @@ test('renders task text', () => {
   const badge = screen.getByText('To Water')
   expect(badge).toBeInTheDocument()
   expect(badge).toHaveClass('inline-flex')
-  expect(badge).toHaveClass('bg-blue-100')
-  expect(badge).toHaveClass('text-blue-800')
+  expect(badge).toHaveClass('bg-sky-100')
+  expect(badge).toHaveClass('text-sky-700')
   expect(badge).toHaveClass('text-badge')
   expect(badge).toHaveClass('font-medium')
 })
@@ -88,8 +88,8 @@ test('applies highlight when urgent', () => {
       </BaseCard>
   )
   const wrapper = container.querySelector('.shadow')
-  expect(wrapper).toHaveClass('ring-green-300')
-  expect(wrapper).toHaveClass('dark:ring-green-400')
+  expect(wrapper).toHaveClass('ring-amber-300')
+  expect(wrapper).toHaveClass('dark:ring-amber-400')
 })
 
 


### PR DESCRIPTION
## Summary
- adjust badge colors to reduce visual overload
- tune care ring styling and progress tooltip
- update care stats palette
- refine task card hierarchy and urgency styling
- add "By Room" view option for tasks
- update tests for new colors

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bba5f18608324b572e3e8e7e10b9f