### PR TITLE
Improve Settings usability and style

### DIFF
--- a/src/components/Avatar.jsx
+++ b/src/components/Avatar.jsx
@@ -1,0 +1,18 @@
+import React from 'react'
+
+export default function Avatar({ name = '', className = '' }) {
+  const initials = name
+    .split(/\s+/)
+    .map(part => part[0])
+    .join('')
+    .slice(0, 2)
+    .toUpperCase()
+
+  return (
+    <div
+      className={`flex items-center justify-center w-12 h-12 rounded-full bg-green-100 text-green-700 font-semibold ${className}`}
+    >
+      {initials || '?'}
+    </div>
+  )
+}

--- a/src/components/ToggleSwitch.jsx
+++ b/src/components/ToggleSwitch.jsx
@@ -15,10 +15,10 @@ export default function ToggleSwitch({ checked = false, onChange, label, classNa
         {...props}
       />
       <span
-        className="relative inline-block w-10 h-6 rounded-full bg-gray-300 dark:bg-gray-600 peer-checked:bg-green-600 transition-colors peer-focus:ring-2 peer-focus:ring-offset-2 peer-focus:ring-accent"
+        className="relative inline-block w-10 h-6 rounded-full bg-gray-300 dark:bg-gray-600 peer-checked:bg-green-600 transition-colors peer-focus:ring-2 peer-focus:ring-offset-2 peer-focus:ring-green-300"
       >
         <span
-          className="absolute left-0.5 top-0.5 w-5 h-5 bg-white rounded-full transition-transform peer-checked:translate-x-4 peer-active:w-6"
+          className="absolute left-0.5 top-0.5 w-5 h-5 bg-white rounded-full transition-transform duration-300 peer-checked:translate-x-4 peer-active:w-6"
         ></span>
       </span>
       {label && <span className="ml-2 select-none">{label}</span>}

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -5,26 +5,55 @@ import { useUser } from '../UserContext.jsx'
 import { User, MapPin, Clock } from 'phosphor-react'
 import Panel from '../components/Panel.jsx'
 import ToggleSwitch from '../components/ToggleSwitch.jsx'
-import PageContainer from "../components/PageContainer.jsx"
+import PageContainer from '../components/PageContainer.jsx'
+import Avatar from '../components/Avatar.jsx'
+import useToast from '../hooks/useToast.jsx'
 
 
 
 export default function Settings() {
   const { theme, toggleTheme } = useTheme()
-  const { location, setLocation, units, setUnits } = useWeather()
+  const { location, setLocation, units, setUnits, forecast } = useWeather()
   const { username, setUsername, timeZone, setTimeZone } = useUser()
+  const { Toast, showToast } = useToast()
+
+  const handleThemeToggle = checked => {
+    toggleTheme()
+    showToast(checked ? 'Dark mode enabled' : 'Light mode enabled')
+  }
+
+  const handleReset = () => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.clear()
+    }
+    window.location.reload()
+  }
+
+  const weatherIcon = forecast?.condition
+    ? {
+        Clear: '☀️',
+        Clouds: '☁️',
+        Rain: '🌧️',
+        Drizzle: '🌦️',
+        Thunderstorm: '⛈️',
+        Snow: '❄️',
+        Mist: '🌫️',
+      }[forecast.condition] || '🌡️'
+    : ''
 
   return (
     <PageContainer className="space-y-6 text-gray-700 dark:text-gray-200">
+      <Toast />
       <h1 className="text-heading font-semibold font-headline">Settings</h1>
 
-      <div className="space-y-4">
+      <div className="space-y-6">
         <Panel>
-          <h2 className="flex items-center gap-2 mb-6 text-heading font-semibold font-headline">
-            <User className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
+          <h2 className="flex items-center gap-2 mb-4 pb-2 border-b border-green-100 dark:border-green-800 text-lg font-semibold font-headline">
+            <User className="w-5 h-5 text-green-600" aria-hidden="true" />
             Profile
           </h2>
-          <div className="space-y-6">
+          <div className="flex items-center gap-4 mb-4">
+            <Avatar name={username} />
             <div className="grid gap-1 max-w-xs">
               <label htmlFor="username" className="font-medium">Name</label>
               <input
@@ -32,9 +61,11 @@ export default function Settings() {
                 type="text"
                 value={username}
                 onChange={e => setUsername(e.target.value)}
-                className="border rounded p-2"
+                className="border rounded p-2 focus:outline-none focus:ring-2 focus:ring-green-300"
               />
             </div>
+          </div>
+          <div className="space-y-4">
             <div className="grid gap-1 max-w-xs">
               <label htmlFor="timezone" className="font-medium">Time Zone</label>
               <input
@@ -42,18 +73,23 @@ export default function Settings() {
                 type="text"
                 value={timeZone}
                 onChange={e => setTimeZone(e.target.value)}
-                className="border rounded p-2"
+                className="border rounded p-2 focus:outline-none focus:ring-2 focus:ring-green-300"
               />
             </div>
           </div>
         </Panel>
 
         <Panel>
-          <h2 className="flex items-center gap-2 mb-6 text-heading font-semibold font-headline">
-            <MapPin className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
+          <h2 className="flex items-center gap-2 mb-4 pb-2 border-b border-green-100 dark:border-green-800 text-lg font-semibold font-headline">
+            <MapPin className="w-5 h-5 text-green-600" aria-hidden="true" />
             Weather &amp; Location
           </h2>
-          <div className="space-y-6">
+          {forecast && (
+            <p className="text-sm mb-2 text-gray-600 dark:text-gray-300">
+              {weatherIcon} {forecast.temp} in {location}
+            </p>
+          )}
+          <div className="space-y-4">
             <div className="grid gap-1 max-w-xs">
               <label htmlFor="location" className="font-medium">Weather Location</label>
               <input
@@ -61,7 +97,7 @@ export default function Settings() {
                 type="text"
                 value={location}
                 onChange={e => setLocation(e.target.value)}
-                className="border rounded p-2"
+                className="border rounded p-2 focus:outline-none focus:ring-2 focus:ring-green-300"
               />
             </div>
             <div className="grid gap-1 max-w-xs">
@@ -70,7 +106,7 @@ export default function Settings() {
                 id="units"
                 value={units}
                 onChange={e => setUnits(e.target.value)}
-                className="dropdown-select"
+                className="dropdown-select focus:outline-none focus:ring-2 focus:ring-green-300"
               >
                 <option value="imperial">Fahrenheit</option>
                 <option value="metric">Celsius</option>
@@ -80,17 +116,24 @@ export default function Settings() {
         </Panel>
 
         <Panel>
-          <h2 className="flex items-center gap-2 mb-6 text-heading font-semibold font-headline">
-            <Clock className="w-5 h-5 text-gray-600 dark:text-gray-200" aria-hidden="true" />
+          <h2 className="flex items-center gap-2 mb-4 pb-2 border-b border-green-100 dark:border-green-800 text-lg font-semibold font-headline">
+            <Clock className="w-5 h-5 text-green-600" aria-hidden="true" />
             Preferences
           </h2>
-          <div className="space-y-6">
+          <div className="space-y-4">
             <ToggleSwitch
               checked={theme === 'dark'}
-              onChange={toggleTheme}
-              label="Dark Mode"
+              onChange={handleThemeToggle}
+              label="🌙 Enable Dark Mode for a softer nighttime experience"
             />
           </div>
+          <button
+            type="button"
+            onClick={handleReset}
+            className="mt-4 text-sm text-red-600 underline"
+          >
+            Reset App
+          </button>
         </Panel>
       </div>
 


### PR DESCRIPTION
## Summary
- add Avatar component for user initials
- enhance ToggleSwitch focus and animation
- redesign Settings layout with colored icons and borders
- show live weather preview
- add dark mode feedback toast and app reset button

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687bbc3c6bd88324bf4222fff824b530