### PR TITLE
Implement timeline review suggestions

### DIFF
--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -16,6 +16,7 @@ export default function Timeline() {
   const { plants, timelineNotes = [], addTimelineNote = () => {} } = usePlants()
   const [showNoteModal, setShowNoteModal] = useState(false)
   const [latestFirst, setLatestFirst] = useState(true)
+  const [filter, setFilter] = useState('all')
 
   const plantEvents = useMemo(
     () => buildEvents(plants, { includePlantName: true }),
@@ -38,17 +39,38 @@ export default function Timeline() {
     [plantEvents, noteEvents]
   )
 
+  const filteredEvents = useMemo(
+    () =>
+      events.filter(e => {
+        if (filter === 'all') return true
+        if (filter === 'water') return e.type === 'water'
+        if (filter === 'fertilize') return e.type === 'fertilize'
+        if (filter === 'notes') return e.note || e.type === 'note' || e.type === 'noteText'
+        return true
+      }),
+    [events, filter]
+  )
+
   const groupedEvents = useMemo(() => {
-    const grouped = groupEventsByMonth(events)
+    const grouped = groupEventsByMonth(filteredEvents)
     if (latestFirst) {
       return grouped
         .map(([month, list]) => [month, [...list].reverse()])
         .reverse()
     }
     return grouped
-  }, [events, latestFirst])
+  }, [filteredEvents, latestFirst])
 
   const [selectedEvent, setSelectedEvent] = useState(null)
+  const [expandedMonths, setExpandedMonths] = useState(() => new Set())
+
+  const toggleMonth = m =>
+    setExpandedMonths(prev => {
+      const next = new Set(prev)
+      if (next.has(m)) next.delete(m)
+      else next.add(m)
+      return next
+    })
 
 
 
@@ -61,10 +83,48 @@ export default function Timeline() {
     noteText: 'bg-gray-400',
   }
 
+  if (filteredEvents.length === 0) {
+    return (
+      <div className="relative overflow-y-auto max-h-full max-w-md mx-auto space-y-8 py-4 px-4 text-gray-700 dark:text-gray-200">
+        <SectionCard className="border border-gray-100 text-center py-20">
+          <p className="mb-4">Nothing here yet! Your plant’s journey begins with the first care log.</p>
+          <button
+            type="button"
+            onClick={() => setShowNoteModal(true)}
+            className="mx-auto bg-green-600 text-white w-14 h-14 rounded-full flex items-center justify-center shadow hover:bg-green-700"
+          >
+            +
+            <span className="sr-only">Add first entry</span>
+          </button>
+        </SectionCard>
+        {showNoteModal && (
+          <NoteModal
+            label="Note"
+            onSave={text => {
+              if (text) addTimelineNote(text)
+              setShowNoteModal(false)
+            }}
+            onCancel={() => setShowNoteModal(false)}
+          />
+        )}
+      </div>
+    )
+  }
+
   return (
     <div className="relative overflow-y-auto max-h-full max-w-md mx-auto space-y-8 py-4 px-4 text-gray-700 dark:text-gray-200">
       <SectionCard className="border border-gray-100">
-        <div className="flex justify-end px-1">
+        <div className="flex items-center justify-between px-1 gap-2">
+          <select
+            className="border-gray-300 rounded text-sm px-1 py-0.5 bg-white dark:bg-gray-800"
+            value={filter}
+            onChange={e => setFilter(e.target.value)}
+          >
+            <option value="all">All</option>
+            <option value="water">Watering</option>
+            <option value="fertilize">Fertilizing</option>
+            <option value="notes">Notes</option>
+          </select>
           <button
             type="button"
             onClick={() => setLatestFirst(l => !l)}
@@ -86,15 +146,16 @@ export default function Timeline() {
               <h3 className="sticky top-0 z-10 bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm px-1 text-timestamp uppercase tracking-wider text-gray-500 mb-2">
                 {formatMonth(monthKey)}
               </h3>
-              <ul className="relative ml-3 space-y-6 pl-5 before:absolute before:inset-y-0 before:left-2 before:w-px before:bg-gray-200">
-                {list.map((e, i) => {
+              <ul className="relative ml-3 flex flex-col space-y-2 divide-y divide-gray-100 pl-5 before:absolute before:inset-y-0 before:left-2 before:w-px before:bg-gray-200">
+                {(expandedMonths.has(monthKey) ? list : list.slice(0,7)).map((e, i) => {
                   const Icon = actionIcons[e.type]
                   return (
                     <motion.li
+                      layout
                       key={`${e.date}-${e.label}-${i}`}
                       initial={{ opacity: 0, x: 20 }}
                       animate={{ opacity: 1, x: 0 }}
-                      className="relative text-sm"
+                      className={`relative text-sm ${Math.floor(i / 5) % 2 === 1 ? 'bg-gray-50 dark:bg-gray-800 rounded-md px-2 py-1' : ''}`}
                     >
                       {Icon && (
                         <div
@@ -109,7 +170,8 @@ export default function Timeline() {
                         className={`text-left w-full flex items-start ${e.note ? 'bg-gray-50 dark:bg-gray-700 rounded-xl p-3 shadow-sm' : ''}`}
                       >
                         <div>
-                          <span className="font-medium">{formatDate(e.date)}</span> — {e.label}
+                          <span className="text-gray-500">{formatDate(e.date)}</span> 
+                          <span className="font-medium">— {e.label}</span>
                           {e.note && (
                             <div className="text-xs italic text-green-700 mt-1">{e.note}</div>
                           )}
@@ -118,6 +180,17 @@ export default function Timeline() {
                     </motion.li>
                   )
                 })}
+                {list.length > 7 && (
+                  <li className="pt-2">
+                    <button
+                      type="button"
+                      onClick={() => toggleMonth(monthKey)}
+                      className="text-xs text-green-600 hover:underline"
+                    >
+                      {expandedMonths.has(monthKey) ? 'Show less' : 'Show more…'}
+                    </button>
+                  </li>
+                )}
               </ul>
             </div>
           ))}

--- a/src/pages/__tests__/TimelineFab.test.jsx
+++ b/src/pages/__tests__/TimelineFab.test.jsx
@@ -17,15 +17,13 @@ beforeEach(() => {
 
 test('fab opens note modal', () => {
   render(<Timeline />)
-  fireEvent.click(screen.getByRole('button', { name: /open create menu/i }))
-  fireEvent.click(screen.getByRole('button', { name: /add note/i }))
+  fireEvent.click(screen.getByRole('button', { name: /add first entry/i }))
   expect(screen.getByRole('dialog', { name: /note/i })).toBeInTheDocument()
 })
 
 test('saving note calls addTimelineNote', () => {
   render(<Timeline />)
-  fireEvent.click(screen.getByRole('button', { name: /open create menu/i }))
-  fireEvent.click(screen.getByRole('button', { name: /add note/i }))
+  fireEvent.click(screen.getByRole('button', { name: /add first entry/i }))
   fireEvent.change(
     screen.getByRole('textbox', { name: /note/i }),
     { target: { value: 'hi' } }


### PR DESCRIPTION
## Summary
- make Timeline entries filterable and collapsible
- alternate background tones every five entries and dim the date text
- show empty-state message with button to add first entry
- update tests for new empty state behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bbd2e4c948324841e1322f03acc75