### PR TITLE
Remove emoji in preferences label

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -124,7 +124,7 @@ export default function Settings() {
             <ToggleSwitch
               checked={theme === 'dark'}
               onChange={handleThemeToggle}
-              label="🌙 Enable Dark Mode for a softer nighttime experience"
+              label="Enable Dark Mode for a softer nighttime experience"
             />
           </div>
           <button


### PR DESCRIPTION
## Summary
- clean up the dark mode toggle label by removing the moon emoji

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687bbe685a708324b9491197aadbf741