### PR TITLE
Improve timeline filter style

### DIFF
--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -115,16 +115,20 @@ export default function Timeline() {
     <div className="relative overflow-y-auto max-h-full max-w-md mx-auto space-y-8 py-4 px-4 text-gray-700 dark:text-gray-200">
       <SectionCard className="border border-gray-100">
         <div className="flex items-center justify-between px-1 gap-2">
-          <select
-            className="border-gray-300 rounded text-sm px-1 py-0.5 bg-white dark:bg-gray-800"
-            value={filter}
-            onChange={e => setFilter(e.target.value)}
-          >
+          <label htmlFor="timeline-filter" className="flex items-center gap-1 text-sm">
+            Filter:
+            <select
+              id="timeline-filter"
+              className="dropdown-select shadow-lg border border-gray-200 text-sm bg-white dark:bg-gray-800"
+              value={filter}
+              onChange={e => setFilter(e.target.value)}
+            >
             <option value="all">All</option>
             <option value="water">Watering</option>
             <option value="fertilize">Fertilizing</option>
             <option value="notes">Notes</option>
-          </select>
+            </select>
+          </label>
           <button
             type="button"
             onClick={() => setLatestFirst(l => !l)}
@@ -142,11 +146,11 @@ export default function Timeline() {
         </div>
         <div className="relative">
           {groupedEvents.map(([monthKey, list]) => (
-            <div key={monthKey} className="mt-6 first:mt-0">
+            <div key={monthKey} className="mt-6 first:mt-0 space-y-3">
               <h3 className="sticky top-0 z-10 bg-white/70 dark:bg-gray-800/70 backdrop-blur-sm px-1 text-timestamp uppercase tracking-wider text-gray-500 mb-2">
                 {formatMonth(monthKey)}
               </h3>
-              <ul className="relative ml-3 flex flex-col space-y-2 divide-y divide-gray-100 pl-5 before:absolute before:inset-y-0 before:left-2 before:w-px before:bg-gray-200">
+              <ul className="relative ml-3 flex flex-col space-y-3 divide-y divide-gray-100 pl-5 before:absolute before:inset-y-0 before:left-2 before:w-px before:bg-gray-200">
                 {(expandedMonths.has(monthKey) ? list : list.slice(0,7)).map((e, i) => {
                   const Icon = actionIcons[e.type]
                   return (
@@ -155,7 +159,7 @@ export default function Timeline() {
                       key={`${e.date}-${e.label}-${i}`}
                       initial={{ opacity: 0, x: 20 }}
                       animate={{ opacity: 1, x: 0 }}
-                      className={`relative text-sm ${Math.floor(i / 5) % 2 === 1 ? 'bg-gray-50 dark:bg-gray-800 rounded-md px-2 py-1' : ''}`}
+                      className={`relative text-sm ${i % 2 === 1 ? 'bg-gray-50 dark:bg-gray-800 rounded-md px-2 py-1' : ''}`}
                     >
                       {Icon && (
                         <div


### PR DESCRIPTION
## Summary
- adjust timeline filter styling with label
- space out events a bit more
- alternate row backgrounds for readability

## Testing
- `npm test` *(fails: TaskCard and UnifiedTaskCard snapshots)*

------
https://chatgpt.com/codex/tasks/task_e_687bc139848883248da8b5074ee91bf3