### PR TITLE
Implement gallery lightbox feature

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -1,26 +1,75 @@
-import React from 'react'
+import React, { useState } from 'react'
 import { Link } from 'react-router-dom'
-import PageContainer from "../components/PageContainer.jsx"
-import { addBase } from '../PlantContext.jsx'
+import PageContainer from '../components/PageContainer.jsx'
+import Lightbox from '../components/Lightbox.jsx'
+import { usePlants, addBase } from '../PlantContext.jsx'
 
 export default function Gallery() {
+  const { plants } = usePlants()
+  const photos = plants.flatMap(p =>
+    (p.photos || []).map(photo => ({ ...photo, plant: p.name }))
+  )
+  const [lightboxIndex, setLightboxIndex] = useState(null)
+
+  if (photos.length === 0) {
+    return (
+      <PageContainer className="text-center space-y-4">
+        <h2 className="text-heading font-headline">Gallery</h2>
+        <img
+          src={addBase('/happy-plant.svg')}
+          alt="Empty gallery"
+          className="w-32 h-32 mx-auto"
+        />
+        <p className="text-gray-700 dark:text-gray-200">
+          Gallery will unlock once you add photos.
+        </p>
+        <Link
+          to="/add"
+          className="inline-block px-4 py-2 bg-green-600 text-white rounded"
+        >
+          Add a plant
+        </Link>
+      </PageContainer>
+    )
+  }
+
   return (
-    <PageContainer className="text-center space-y-4">
-      <h2 className="text-heading font-headline">Gallery</h2>
-      <img
-        src={addBase('/happy-plant.svg')}
-        alt="Empty gallery"
-        className="w-32 h-32 mx-auto"
-      />
-      <p className="text-gray-700 dark:text-gray-200">
-        Gallery will unlock once you add photos.
-      </p>
-      <Link
-        to="/add"
-        className="inline-block px-4 py-2 bg-green-600 text-white rounded"
+    <PageContainer className="space-y-4">
+      <h2 className="text-heading font-headline text-center">Gallery</h2>
+      <div
+        className="grid gap-2"
+        style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(120px,1fr))' }}
       >
-        Add a plant
-      </Link>
+        {photos.map((photo, i) => (
+          <button
+            key={i}
+            type="button"
+            onClick={() => setLightboxIndex(i)}
+            className="focus:outline-none"
+          >
+            <img
+              src={photo.src}
+              alt={photo.caption || `${photo.plant} photo ${i + 1}`}
+              className="w-full aspect-[4/3] object-cover rounded-lg"
+            />
+          </button>
+        ))}
+      </div>
+      {lightboxIndex !== null && (
+        <div
+          role="dialog"
+          aria-modal="true"
+          aria-label="Gallery viewer"
+          className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-40"
+        >
+          <Lightbox
+            images={photos}
+            startIndex={lightboxIndex}
+            onClose={() => setLightboxIndex(null)}
+            label="Gallery viewer"
+          />
+        </div>
+      )}
     </PageContainer>
   )
 }

--- a/src/pages/__tests__/Gallery.test.jsx
+++ b/src/pages/__tests__/Gallery.test.jsx
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import Gallery from '../Gallery.jsx'
+import { usePlants } from '../../PlantContext.jsx'
+
+jest.mock('../../PlantContext.jsx', () => {
+  const actual = jest.requireActual('../../PlantContext.jsx')
+  return {
+    ...actual,
+    usePlants: jest.fn(),
+  }
+})
+
+const usePlantsMock = usePlants
+
+let mockPlants = []
+
+beforeEach(() => {
+  mockPlants = [
+    {
+      id: 1,
+      name: 'Plant A',
+      photos: [
+        { src: 'a.jpg', caption: 'first' },
+        { src: 'b.jpg', caption: 'second' },
+      ],
+    },
+  ]
+  usePlantsMock.mockReturnValue({ plants: mockPlants })
+})
+
+afterEach(() => {
+  jest.resetAllMocks()
+})
+
+test('clicking a photo opens the lightbox viewer', () => {
+  render(
+    <MemoryRouter>
+      <Gallery />
+    </MemoryRouter>
+  )
+
+  const img = screen.getByAltText('first')
+  fireEvent.click(img)
+
+  const dialogs = screen.getAllByRole('dialog', { name: /gallery viewer/i })
+  const viewer = dialogs[0]
+  expect(viewer).toBeInTheDocument()
+
+  const viewerImg = screen.getAllByAltText('first')[1]
+  expect(viewerImg).toHaveAttribute('src', 'a.jpg')
+
+  fireEvent.keyDown(window, { key: 'ArrowRight' })
+  expect(screen.getAllByAltText('second')[1]).toHaveAttribute('src', 'b.jpg')
+
+  fireEvent.keyDown(window, { key: 'Escape' })
+  expect(screen.queryByRole('dialog', { name: /gallery viewer/i })).toBeNull()
+})


### PR DESCRIPTION
## Summary
- show plant photos on the Gallery page
- allow opening the Lightbox viewer from the Gallery
- add Gallery page tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c3c92aaac8324984ba8815cab6c34