### PR TITLE
Replace emojis with icons on plant detail view

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -10,6 +10,8 @@ import {
   SortDescending,
   Trash,
   ArrowLeft,
+  Sun,
+  Leaf,
 } from 'phosphor-react'
 
 import Lightbox from '../components/Lightbox.jsx'
@@ -228,17 +230,17 @@ export default function PlantDetail() {
             <div className="mt-4 flex flex-wrap gap-2 text-xs text-gray-600">
               {plant.light && (
                 <span className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1">
-                  ☀ {plant.light}
+                  <Sun className="w-3 h-3" aria-hidden="true" /> {plant.light}
                 </span>
               )}
               {plant.humidity && (
                 <span className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1">
-                  💧 {plant.humidity}
+                  <Drop className="w-3 h-3" aria-hidden="true" /> {plant.humidity}
                 </span>
               )}
               {plant.difficulty && (
                 <span className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1">
-                  🪴 {plant.difficulty}
+                  <Leaf className="w-3 h-3" aria-hidden="true" /> {plant.difficulty}
                 </span>
               )}
             </div>


### PR DESCRIPTION
## Summary
- update plant detail view to use icons instead of emojis

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c58d84c648324b221db779095387d