### PR TITLE
Remove Care Summary tab, rename tasks

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -100,28 +100,6 @@ export default function PlantDetail() {
     .filter(Boolean)
     .sort((a, b) => new Date(b) - new Date(a))[0]
 
-  const lightTag = plant?.light ? plant.light.replace(/Low to medium/i, 'Low') : ''
-  const humidityTag = plant?.humidity ? plant.humidity.replace(/Average/i, 'Avg') : ''
-  const difficultyTag = plant?.difficulty ? plant.difficulty.replace(/Easy/i, 'EZ') : ''
-
-  const now = new Date()
-  const nextWaterDate = plant?.nextWater ? new Date(plant.nextWater) : null
-  const overdueWaterDays =
-    nextWaterDate && now > nextWaterDate
-      ? Math.floor((now - nextWaterDate) / 86400000)
-      : 0
-  const nextFertDate = plant?.nextFertilize
-    ? new Date(plant.nextFertilize)
-    : null
-  const overdueFertDays =
-    nextFertDate && now > nextFertDate
-      ? Math.floor((now - nextFertDate) / 86400000)
-      : 0
-
-  const waterBorderClass =
-    overdueWaterDays > 0 ? 'border-rose-500' : 'border-green-400'
-  const fertBorderClass =
-    overdueFertDays > 0 ? 'border-rose-500' : 'border-green-500'
 
   const events = useMemo(() => buildEvents(plant), [plant])
   const groupedEvents = useMemo(() => {
@@ -239,129 +217,8 @@ export default function PlantDetail() {
 
   const tabs = [
     {
-      id: 'summary',
-      label: 'Care Summary',
-      content: (
-        <div className="space-y-4 p-4">
-          <div className="space-y-4">
-            <div className={`relative rounded-xl p-5 border-l-4 ${waterBorderClass} bg-water-50 dark:bg-water-900/30 shadow-sm mb-6`}>
-              <h3 className="flex items-center gap-2 text-sm font-semibold text-water-800 dark:text-water-200 mb-2">
-                <Drop className="w-4 h-4" aria-hidden="true" />
-                Watering Schedule
-              </h3>
-              <p className="text-sm text-gray-700 mb-1">
-                Last watered: {formatDaysAgo(plant.lastWatered)} · Next: {plant.nextWater}
-              </p>
-              {overdueWaterDays > 0 && (
-                <span className="inline-block rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
-                  Overdue {overdueWaterDays} {overdueWaterDays === 1 ? 'day' : 'days'}
-                </span>
-              )}
-              <div className="mt-2 flex justify-end gap-2">
-                <button
-                  type="button"
-                  aria-label="Edit task"
-                  onClick={handleEdit}
-                  className="task-action bg-blue-600 text-white"
-                >
-                  <PencilSimpleLine className="w-4 h-4" aria-hidden="true" />
-                  Edit
-                </button>
-                <button
-                  type="button"
-                  aria-label="Reschedule task"
-                  onClick={handleRescheduleWater}
-                  className="task-action bg-yellow-600 text-white"
-                >
-                  <ClockCounterClockwise className="w-4 h-4" aria-hidden="true" />
-                  Reschedule
-                </button>
-                <button
-                  type="button"
-                  aria-label="Delete task"
-                  onClick={handleDeleteWater}
-                  className="task-action bg-red-600 text-white"
-                >
-                  <Trash className="w-4 h-4" aria-hidden="true" />
-                  Delete
-                </button>
-              </div>
-            </div>
-            {plant.nextFertilize && (
-              <div className={`relative rounded-xl p-5 border-l-4 ${fertBorderClass} bg-fertilize-50 dark:bg-fertilize-900/30`}>
-                <div className="flex justify-between items-start">
-                  <h3 className="flex items-center gap-2 font-headline font-medium text-fertilize-800 dark:text-fertilize-200">
-                    <Flower className="w-4 h-4" aria-hidden="true" />
-                    Fertilizing Needs
-                  </h3>
-                  {overdueFertDays > 0 && (
-                    <span className="inline-block rounded-full bg-red-100 px-2 py-0.5 text-xs font-medium text-red-700">
-                      Overdue {overdueFertDays} {overdueFertDays === 1 ? 'day' : 'days'}
-                    </span>
-                  )}
-                </div>
-                <p className="mt-2 text-sm">
-                  Last fertilized: {plant.lastFertilized ? formatDaysAgo(plant.lastFertilized) : 'Never'}<br />
-                  Next: {plant.nextFertilize}
-                </p>
-                <div className="mt-2 flex justify-end gap-2">
-                  <button
-                    type="button"
-                    aria-label="Edit task"
-                    onClick={handleEdit}
-                    className="task-action bg-blue-600 text-white"
-                  >
-                    <PencilSimpleLine className="w-4 h-4" aria-hidden="true" />
-                    Edit
-                  </button>
-                  <button
-                    type="button"
-                    aria-label="Reschedule task"
-                    onClick={handleRescheduleFertilize}
-                    className="task-action bg-yellow-600 text-white"
-                  >
-                    <ClockCounterClockwise className="w-4 h-4" aria-hidden="true" />
-                    Reschedule
-                  </button>
-                  <button
-                    type="button"
-                    aria-label="Delete task"
-                    onClick={handleDeleteFertilize}
-                    className="task-action bg-red-600 text-white"
-                  >
-                    <Trash className="w-4 h-4" aria-hidden="true" />
-                    Delete
-                  </button>
-                </div>
-              </div>
-            )}
-          </div>
-
-          {(plant.light || plant.humidity || plant.difficulty) && (
-            <div className="mt-4 flex flex-wrap gap-2 text-xs text-gray-600">
-              {plant.light && (
-                <span className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1">
-                  <Sun className="w-3 h-3" aria-hidden="true" /> {plant.light}
-                </span>
-              )}
-              {plant.humidity && (
-                <span className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1">
-                  <Drop className="w-3 h-3" aria-hidden="true" /> {plant.humidity}
-                </span>
-              )}
-              {plant.difficulty && (
-                <span className="flex items-center gap-1 rounded-full bg-gray-100 px-3 py-1">
-                  <Leaf className="w-3 h-3" aria-hidden="true" /> {plant.difficulty}
-                </span>
-              )}
-            </div>
-          )}
-        </div>
-      ),
-    },
-    {
       id: 'tasks',
-      label: 'Tasks',
+      label: 'Care',
       content: (
         <div className="p-4 space-y-2">
           {dueWater || dueFertilize ? (
@@ -602,7 +459,6 @@ export default function PlantDetail() {
                 </p>
               )}
             </div>
-            {/* brief care stats moved to Care Summary tab */}
           </div>
         </div>
       </div>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -25,21 +25,8 @@ test('renders plant details without duplicates', () => {
   const images = screen.getAllByAltText(plant.name)
   expect(images).toHaveLength(1)
 
-  // Care Summary tab is active by default
-  const wateredLabels = screen.getAllByText(/Last watered/i)
-  const wateredLabel = wateredLabels[wateredLabels.length - 1]
-  expect(wateredLabel.textContent).toMatch(/Last watered:/i)
-  expect(wateredLabel.textContent).toMatch(new RegExp(plant.nextWater))
-
-  const fertHeading = screen.getByText('Fertilizing Needs')
-  expect(fertHeading).toBeInTheDocument()
-  const fertLabel = screen.getAllByText(new RegExp(plant.nextFertilize))
-  const fertText = fertLabel[fertLabel.length - 1]
-  expect(fertText.textContent).toMatch(new RegExp(plant.nextFertilize))
-
-  expect(screen.getByText(new RegExp(plant.light))).toBeInTheDocument()
-  expect(screen.getByText(new RegExp(plant.humidity))).toBeInTheDocument()
-  expect(screen.getByText(new RegExp(plant.difficulty))).toBeInTheDocument()
+  // Care tab is active by default
+  expect(screen.getByText(/no tasks due/i)).toBeInTheDocument()
 
   const subHeadings = screen.queryAllByRole('heading', { level: 4 })
   expect(subHeadings).toHaveLength(0)
@@ -77,7 +64,7 @@ test('displays all sections', () => {
     </MenuProvider>
   )
 
-  expect(screen.getByRole('tab', { name: /care summary/i })).toBeInTheDocument()
+  expect(screen.getByRole('tab', { name: /care/i })).toBeInTheDocument()
   expect(screen.getByRole('tab', { name: /activity/i })).toBeInTheDocument()
   expect(screen.getByRole('tab', { name: /gallery/i })).toBeInTheDocument()
   expect(screen.queryByRole('tab', { name: /overview/i })).toBeNull()

--- a/src/pages/__tests__/PlantDetailActions.test.jsx
+++ b/src/pages/__tests__/PlantDetailActions.test.jsx
@@ -3,6 +3,7 @@ import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import PlantDetail from '../PlantDetail.jsx'
 import { usePlants } from '../../PlantContext.jsx'
 import { MenuProvider } from '../../MenuContext.jsx'
+import SnackbarProvider, { Snackbar } from '../../hooks/SnackbarProvider.jsx'
 
 // Confetti relies on the canvas API which JSDOM doesn't fully implement.
 // Mock it here to avoid noisy warnings during tests.
@@ -48,13 +49,16 @@ beforeEach(() => {
 
 test('quick stats action buttons trigger handlers', () => {
   render(
-    <MenuProvider>
-      <MemoryRouter initialEntries={['/plant/1']}>
-        <Routes>
-          <Route path="/plant/:id" element={<PlantDetail />} />
-        </Routes>
-      </MemoryRouter>
-    </MenuProvider>
+    <SnackbarProvider>
+      <MenuProvider>
+        <MemoryRouter initialEntries={['/plant/1']}>
+          <Routes>
+            <Route path="/plant/:id" element={<PlantDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </MenuProvider>
+      <Snackbar />
+    </SnackbarProvider>
   )
 
   fireEvent.click(screen.getByRole('button', { name: /log new care/i }))
@@ -68,13 +72,16 @@ test('quick stats action buttons trigger handlers', () => {
 
 test('fab opens note modal', () => {
   render(
-    <MenuProvider>
-      <MemoryRouter initialEntries={['/plant/1']}>
-        <Routes>
-          <Route path="/plant/:id" element={<PlantDetail />} />
-        </Routes>
-      </MemoryRouter>
-    </MenuProvider>
+    <SnackbarProvider>
+      <MenuProvider>
+        <MemoryRouter initialEntries={['/plant/1']}>
+          <Routes>
+            <Route path="/plant/:id" element={<PlantDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </MenuProvider>
+      <Snackbar />
+    </SnackbarProvider>
   )
 
   fireEvent.click(screen.getByRole('button', { name: /log new care/i }))
@@ -88,13 +95,16 @@ test('fab triggers file input click', () => {
     .mockImplementation(() => {})
 
   render(
-    <MenuProvider>
-      <MemoryRouter initialEntries={['/plant/1']}>
-        <Routes>
-          <Route path="/plant/:id" element={<PlantDetail />} />
-        </Routes>
-      </MemoryRouter>
-    </MenuProvider>
+    <SnackbarProvider>
+      <MenuProvider>
+        <MemoryRouter initialEntries={['/plant/1']}>
+          <Routes>
+            <Route path="/plant/:id" element={<PlantDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </MenuProvider>
+      <Snackbar />
+    </SnackbarProvider>
   )
 
   fireEvent.click(screen.getByRole('tab', { name: /gallery/i }))


### PR DESCRIPTION
## Summary
- remove the Care Summary tab and related code
- rename the Tasks tab to Care
- update tests for new tab structure
- wrap PlantDetailActions tests in SnackbarProvider

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c5bd09fbc8324a3d8bb061268133d