### PR TITLE
Remove kebab menu from plant detail care tab

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -232,6 +232,7 @@ export default function PlantDetail() {
                 }}
                 urgent={urgent}
                 overdue={overdue}
+                showMenuButton={false}
               />
             </BaseCard>
           ) : (

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -4,6 +4,7 @@ import PlantDetail from '../PlantDetail.jsx'
 import plants from '../../plants.json'
 import { PlantProvider } from '../../PlantContext.jsx'
 import { MenuProvider } from '../../MenuContext.jsx'
+import SnackbarProvider, { Snackbar } from '../../hooks/SnackbarProvider.jsx'
 
 test('renders plant details without duplicates', () => {
   const plant = plants[0]
@@ -173,4 +174,27 @@ test('back button navigates to previous page', () => {
   fireEvent.click(backBtn)
 
   expect(screen.getByText(/all plants view/i)).toBeInTheDocument()
+})
+
+test('care tab hides kebab menu for due tasks', () => {
+  const plant = plants[0]
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-25'))
+  render(
+    <SnackbarProvider>
+      <MenuProvider>
+        <PlantProvider>
+          <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+            <Routes>
+              <Route path="/plant/:id" element={<PlantDetail />} />
+            </Routes>
+          </MemoryRouter>
+        </PlantProvider>
+      </MenuProvider>
+      <Snackbar />
+    </SnackbarProvider>
+  )
+
+  expect(screen.queryByText(/no tasks due/i)).toBeNull()
+  expect(screen.queryByRole('button', { name: /open task menu/i })).toBeNull()
+  jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- disable the task menu button on the Plant Detail page
- test that the kebab menu is absent on the care tab when tasks are due

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c65d3dbf0832486cae1b0ff5bcd97