### PR TITLE
Fix Lightbox overlay

### DIFF
--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -1,4 +1,5 @@
 import { useEffect, useRef, useState } from 'react'
+import { createPortal } from 'react-dom'
 
 export default function Lightbox({ images, startIndex = 0, onClose, label = 'Image viewer' }) {
   const [index, setIndex] = useState(startIndex)
@@ -27,7 +28,7 @@ export default function Lightbox({ images, startIndex = 0, onClose, label = 'Ima
     }
   }, [images.length, onClose])
 
-  return (
+  return createPortal(
     <div
       role="dialog"
       aria-modal="true"
@@ -75,6 +76,7 @@ export default function Lightbox({ images, startIndex = 0, onClose, label = 'Ima
       >
         ›
       </button>
-    </div>
+    </div>,
+    document.body
   )
 }

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -56,19 +56,12 @@ export default function Gallery() {
         ))}
       </div>
       {lightboxIndex !== null && (
-        <div
-          role="dialog"
-          aria-modal="true"
-          aria-label="Gallery viewer"
-          className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-40"
-        >
-          <Lightbox
-            images={photos}
-            startIndex={lightboxIndex}
-            onClose={() => setLightboxIndex(null)}
-            label="Gallery viewer"
-          />
-        </div>
+        <Lightbox
+          images={photos}
+          startIndex={lightboxIndex}
+          onClose={() => setLightboxIndex(null)}
+          label="Gallery viewer"
+        />
       )}
     </PageContainer>
   )

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -392,19 +392,12 @@ export default function PlantDetail() {
             className="hidden"
           />
           {lightboxIndex !== null && (
-            <div
-              role="dialog"
-              aria-modal="true"
-              aria-label={`${plant.name} gallery`}
-              className="fixed inset-0 bg-black bg-opacity-70 flex items-center justify-center z-40"
-            >
-              <Lightbox
-                images={plant.photos}
-                startIndex={lightboxIndex}
-                onClose={() => setLightboxIndex(null)}
-                label={`${plant.name} gallery`}
-              />
-            </div>
+            <Lightbox
+              images={plant.photos}
+              startIndex={lightboxIndex}
+              onClose={() => setLightboxIndex(null)}
+              label={`${plant.name} gallery`}
+            />
           )}
         </div>
       ),

--- a/src/pages/__tests__/Gallery.test.jsx
+++ b/src/pages/__tests__/Gallery.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, within } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Gallery from '../Gallery.jsx'
 import { usePlants } from '../../PlantContext.jsx'
@@ -43,15 +43,14 @@ test('clicking a photo opens the lightbox viewer', () => {
   const img = screen.getByAltText('first')
   fireEvent.click(img)
 
-  const dialogs = screen.getAllByRole('dialog', { name: /gallery viewer/i })
-  const viewer = dialogs[0]
+  const viewer = screen.getByRole('dialog', { name: /gallery viewer/i })
   expect(viewer).toBeInTheDocument()
 
-  const viewerImg = screen.getAllByAltText('first')[1]
+  const viewerImg = within(viewer).getByAltText('first')
   expect(viewerImg).toHaveAttribute('src', 'a.jpg')
 
   fireEvent.keyDown(window, { key: 'ArrowRight' })
-  expect(screen.getAllByAltText('second')[1]).toHaveAttribute('src', 'b.jpg')
+  expect(within(viewer).getByAltText('second')).toHaveAttribute('src', 'b.jpg')
 
   fireEvent.keyDown(window, { key: 'Escape' })
   expect(screen.queryByRole('dialog', { name: /gallery viewer/i })).toBeNull()

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -98,23 +98,14 @@ test('opens lightbox from gallery', () => {
   )
   fireEvent.click(img.closest('button'))
 
-  const dialogsAfterOpen = screen.getAllByRole('dialog', {
+  const viewerDialog = screen.getByRole('dialog', {
     name: `${plant.name} gallery`,
   })
-  // First dialog is the gallery overlay
-  expect(dialogsAfterOpen[0]).toBeInTheDocument()
-  fireEvent.click(img)
-
-  const dialogs = screen.getAllByRole('dialog', {
-    name: `${plant.name} gallery`,
-  })
-  // The first dialog is the gallery overlay; the second is the Lightbox viewer
-  const viewerDialog = dialogs[1]
   expect(viewerDialog).toBeInTheDocument()
 
-  const viewerImg = screen.getAllByAltText(
+  const viewerImg = within(viewerDialog).getByAltText(
     plant.photos[0].caption || /gallery image/i
-  )[1]
+  )
   expect(viewerImg).toHaveAttribute('src', plant.photos[0].src)
 
   fireEvent.keyDown(window, { key: 'ArrowRight' })
@@ -146,9 +137,12 @@ test('view all button opens the viewer from first image', () => {
   const viewAll = screen.getByRole('button', { name: /view all photos/i })
   fireEvent.click(viewAll)
 
-  const viewerImg = screen.getAllByAltText(
+  const viewerDialog = screen.getByRole('dialog', {
+    name: `${plant.name} gallery`,
+  })
+  const viewerImg = within(viewerDialog).getByAltText(
     plant.photos[0].caption || /gallery image/i
-  )[1]
+  )
   expect(viewerImg).toHaveAttribute('src', plant.photos[0].src)
 })
 


### PR DESCRIPTION
## Summary
- mount `<Lightbox>` content via `createPortal`
- remove redundant overlay wrappers in `PlantDetail` and `Gallery`
- update tests to expect a single viewer dialog

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c6709193083248294494e3bf5cb31