### PR TITLE
Improve plant detail back button

### DIFF
--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -1,5 +1,5 @@
-import { Link } from 'react-router-dom'
 import { useState } from 'react'
+import { Link, useLocation } from 'react-router-dom'
 import { useWeather } from '../WeatherContext.jsx'
 import { formatCareSummary } from '../utils/date.js'
 import {
@@ -23,6 +23,7 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
   if (!items.length) return null
 
   const [index, setIndex] = useState(startIndex)
+  const location = useLocation()
   const { forecast } = useWeather() || {}
   const weatherIcons = {
     Clear: Sun,
@@ -63,6 +64,7 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
   return (
     <Link
       to={`/plant/${id}`}
+      state={{ from: location.pathname }}
       data-testid="featured-card"
       aria-label={`Featured plant card for ${name}`}
       onKeyDown={handleKeyDown}

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -1,4 +1,4 @@
-import { Link, useNavigate } from 'react-router-dom'
+import { Link, useNavigate, useLocation } from 'react-router-dom'
 import { useState, useRef } from 'react'
 import { Drop, PencilSimpleLine, Trash } from 'phosphor-react'
 import Badge from './Badge.jsx'
@@ -16,6 +16,7 @@ import { getWaterStatus } from '../utils/watering.js'
 
 export default function PlantCard({ plant }) {
   const navigate = useNavigate()
+  const location = useLocation()
   const { plants, markWatered, removePlant, updatePlant, restorePlant } =
     usePlants()
   const { showSnackbar } = useSnackbar()
@@ -224,6 +225,7 @@ export default function PlantCard({ plant }) {
                 ? `/room/${encodeURIComponent(plant.room)}/plant/${plant.id}`
                 : `/plant/${plant.id}`
             }
+            state={{ from: location.pathname }}
             className="focus:outline-none"
           >
             {plant.name}

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,5 +1,5 @@
 import { Drop, Sun, PencilSimpleLine, ClockCounterClockwise, Trash } from 'phosphor-react'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { useState } from 'react'
 import { getWateringInfo } from '../utils/watering.js'
 import { usePlants } from '../PlantContext.jsx'
@@ -17,6 +17,7 @@ export default function TaskCard({
 }) {
   const { daysSince, eto } = getWateringInfo(task.lastWatered, { eto: task.eto })
   const navigate = useNavigate()
+  const location = useLocation()
   const [navigating, setNavigating] = useState(false)
   const { plants, markWatered, markFertilized, updatePlant } = usePlants()
   const { showSnackbar } = useSnackbar()
@@ -28,7 +29,8 @@ export default function TaskCard({
     setTimeout(
       () =>
         navigate(
-          room ? `/room/${room}/plant/${task.plantId}` : `/plant/${task.plantId}`
+          room ? `/room/${room}/plant/${task.plantId}` : `/plant/${task.plantId}`,
+          { state: { from: location.pathname } }
         ),
       200
     )
@@ -48,7 +50,8 @@ export default function TaskCard({
   const handleEdit = () => {
     const room = task.room ? encodeURIComponent(task.room) : null
     navigate(
-      room ? `/room/${room}/plant/${task.plantId}/edit` : `/plant/${task.plantId}/edit`
+      room ? `/room/${room}/plant/${task.plantId}/edit` : `/plant/${task.plantId}/edit`,
+      { state: { from: location.pathname } }
     )
   }
 

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -12,7 +12,7 @@ import {
   DotsThreeVertical,
 } from 'phosphor-react'
 import { formatDaysAgo } from '../utils/dateFormat.js'
-import { useNavigate } from 'react-router-dom'
+import { useNavigate, useLocation } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
 import useSnackbar from '../hooks/useSnackbar.jsx'
 import useSwipe from '../hooks/useSwipe.js'
@@ -31,6 +31,7 @@ export default function UnifiedTaskCard({
   const [completed, setCompleted] = useState(false)
   const [showMenu, setShowMenu] = useState(false)
   const navigate = useNavigate()
+  const location = useLocation()
   const [navigating, setNavigating] = useState(false)
   const { plants, markWatered, markFertilized, updatePlant } = usePlants()
   const { showSnackbar } = useSnackbar()
@@ -70,7 +71,10 @@ export default function UnifiedTaskCard({
     setNavigating(true)
     setTimeout(
       () =>
-        navigate(room ? `/room/${room}/plant/${plant.id}` : `/plant/${plant.id}`),
+        navigate(
+          room ? `/room/${room}/plant/${plant.id}` : `/plant/${plant.id}`,
+          { state: { from: location.pathname } }
+        ),
       200
     )
   }
@@ -93,7 +97,10 @@ export default function UnifiedTaskCard({
 
   const handleEdit = () => {
     const room = plant.room ? encodeURIComponent(plant.room) : null
-    navigate(room ? `/room/${room}/plant/${plant.id}/edit` : `/plant/${plant.id}/edit`)
+    navigate(
+      room ? `/room/${room}/plant/${plant.id}/edit` : `/plant/${plant.id}/edit`,
+      { state: { from: location.pathname } }
+    )
   }
 
   const handleReschedule = () => {

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -152,7 +152,9 @@ test('partial left swipe reveals actions', () => {
   fireEvent.pointerMove(wrapper, { clientX: 70, buttons: 1 })
   expect(screen.getByRole('button', { name: /edit task/i })).toBeInTheDocument()
   fireEvent.click(screen.getByRole('button', { name: /edit task/i }))
-  expect(navigateMock).toHaveBeenCalledWith('/plant/1/edit')
+  expect(navigateMock).toHaveBeenCalledWith('/plant/1/edit', {
+    state: { from: '/' },
+  })
   fireEvent.click(screen.getByRole('button', { name: /reschedule task/i }))
   expect(updatePlant).toHaveBeenCalled()
   fireEvent.click(screen.getByRole('button', { name: /delete task/i }))

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -107,7 +107,9 @@ test('kebab menu exposes actions', () => {
   )
   fireEvent.click(screen.getByRole('button', { name: /open task menu/i }))
   fireEvent.click(screen.getByRole('button', { name: /edit task/i }))
-  expect(navigateMock).toHaveBeenCalledWith('/plant/1/edit')
+  expect(navigateMock).toHaveBeenCalledWith('/plant/1/edit', {
+    state: { from: '/' },
+  })
   fireEvent.click(screen.getByRole('button', { name: /open task menu/i }))
   fireEvent.click(screen.getByRole('button', { name: /reschedule task/i }))
   expect(updatePlant).toHaveBeenCalled()

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -1,4 +1,4 @@
-import { useParams, useNavigate } from 'react-router-dom'
+import { useParams, useNavigate, useLocation } from 'react-router-dom'
 import { useState, useRef, useMemo, useEffect } from 'react'
 
 import {
@@ -65,6 +65,17 @@ export default function PlantDetail() {
   } = usePlants()
   const plant = plants.find(p => p.id === Number(id))
   const navigate = useNavigate()
+  const location = useLocation()
+  const from = location.state?.from
+  let backLabel = 'Back'
+  if (from === '/') backLabel = 'Back to Today'
+  else if (from === '/myplants') backLabel = 'Back to All Plants'
+  else if (from === '/tasks') backLabel = 'Back to Tasks'
+  else if (from === '/timeline') backLabel = 'Back to Timeline'
+  else if (from && from.startsWith('/room/')) {
+    const name = decodeURIComponent(from.split('/')[2] || '')
+    backLabel = `Back to ${name}`
+  }
 
   const fileInputRef = useRef()
   const { Toast, showToast } = useToast()
@@ -437,18 +448,15 @@ export default function PlantDetail() {
             className="w-full h-[45vh] object-cover"
           />
           <div className="img-gradient-overlay" aria-hidden="true"></div>
-          <div className="absolute top-2 left-2 flex items-center gap-1 text-white">
+          <div className="fixed top-2 left-2 z-20 flex items-center gap-1 text-white">
             <button
               type="button"
               onClick={() => navigate(-1)}
-              className="p-1 rounded-full bg-black/40 hover:bg-black/50"
+              className="p-1 rounded-full bg-black/40 hover:bg-black/50 flex items-center gap-1"
             >
               <ArrowLeft className="w-4 h-4" aria-hidden="true" />
-              <span className="sr-only">Back</span>
+              <span className="ml-1">{backLabel}</span>
             </button>
-            {plant.room && (
-              <span className="text-sm font-medium">{plant.room}</span>
-            )}
           </div>
           <div className="absolute bottom-2 left-3 right-3 flex flex-col sm:flex-row justify-between text-white drop-shadow space-y-1 sm:space-y-0">
             <div>

--- a/src/pages/RoomList.jsx
+++ b/src/pages/RoomList.jsx
@@ -1,4 +1,4 @@
-import { useParams, Link } from 'react-router-dom'
+import { useParams, Link, useLocation } from 'react-router-dom'
 import { useState } from 'react'
 import BalconyPlantCard from '../components/BalconyPlantCard.jsx'
 
@@ -10,6 +10,7 @@ import FilterPills from '../components/FilterPills.jsx'
 
 export default function RoomList() {
   const { roomName } = useParams()
+  const location = useLocation()
   const { plants } = usePlants()
   const [sortBy, setSortBy] = useState('name')
   const list = plants.filter(p => p.room === roomName)
@@ -51,6 +52,7 @@ export default function RoomList() {
             <Link
               key={plant.id}
               to={`/room/${encodeURIComponent(roomName)}/plant/${plant.id}`}
+              state={{ from: location.pathname }}
               className="block transition-transform active:shadow"
               onMouseDown={createRipple}
               onTouchStart={createRipple}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -157,7 +157,13 @@ test('back button navigates to previous page', () => {
   render(
     <MenuProvider>
       <PlantProvider>
-        <MemoryRouter initialEntries={['/myplants', `/plant/${plant.id}`]} initialIndex={1}>
+        <MemoryRouter
+          initialEntries={[
+            '/myplants',
+            { pathname: `/plant/${plant.id}`, state: { from: '/myplants' } },
+          ]}
+          initialIndex={1}
+        >
           <Routes>
             <Route path="/myplants" element={<div>All Plants View</div>} />
             <Route path="/room/:roomName" element={<div>Room View</div>} />


### PR DESCRIPTION
## Summary
- persist previous route when navigating to PlantDetail
- show dynamic back label and keep button visible
- update affected tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c66fa434883249c4ac66b37958e98