### PR TITLE
Improve home experience

### DIFF
--- a/src/components/CareStats.jsx
+++ b/src/components/CareStats.jsx
@@ -21,9 +21,9 @@ function StatBlock({ id, label, Icon, completed, total, ringClass, onClick }) {
       aria-label={ariaLabel}
       onClick={onClick}
     >
-      <div className="relative" style={{ width: size, height: size }}>
+      <div className="relative drop-shadow-sm" style={{ width: size, height: size }}>
         <ProgressRing percent={pct} size={size} colorClass={ringClass} />
-        <div className="bg-white absolute inset-2 rounded-full flex items-center justify-center overflow-hidden">
+        <div className="absolute inset-2 rounded-full flex items-center justify-center overflow-hidden bg-white dark:bg-gray-700 shadow-sm">
           <div className="flex flex-col items-center">
             <Icon className="w-3 h-3" aria-hidden="true" />
             <span

--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -55,7 +55,16 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
   const name = plant.plantName || plant.name
   const id = plant.plantId || plant.id
   const placeholder = useINatPhoto(name)
-  const preview = formatCareSummary(plant.lastWatered, plant.nextWater)
+  const todayIso = new Date().toISOString().slice(0, 10)
+  const caredToday =
+    plant.lastWatered === todayIso || plant.lastFertilized === todayIso
+  const needsCareToday =
+    (plant.nextWater && plant.nextWater <= todayIso) ||
+    (plant.nextFertilize && plant.nextFertilize <= todayIso)
+  const preview =
+    caredToday && !needsCareToday
+      ? `${name} is all set today!`
+      : formatCareSummary(plant.lastWatered, plant.nextWater)
   const imageSrc =
     (plant.photos && plant.photos[0]?.src) ||
     plant.image ||


### PR DESCRIPTION
## Summary
- tweak ring visuals with subtle dropshadows
- show a friendly 'all set' message on Featured Plant when care is complete

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c6e3c96c883249e9d6282c2db40bb