### PR TITLE
Refine tasks UI

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -11,7 +11,7 @@ export default function Badge({
   const variants = {
     info: 'bg-sky-100 text-sky-700',
     urgent: 'bg-amber-100 text-amber-700',
-    overdue: 'bg-red-50 text-red-500',
+    overdue: 'bg-amber-100 text-amber-700',
     complete: 'bg-emerald-100 text-emerald-800',
   }
 

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -98,7 +98,7 @@ export default function TaskCard({
       data-testid="task-card"
       tabIndex="0"
       aria-label={`Task card for ${task.plantName}`}
-      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 touch-pan-y select-none ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : overdue ? 'bg-red-50 dark:bg-red-800' : urgent ? 'bg-amber-50 dark:bg-gray-700' : 'bg-slate-50 dark:bg-gray-700'}${overdue ? ' ring-2 ring-red-300 dark:ring-red-400' : urgent ? ' ring-2 ring-amber-300 dark:ring-amber-400' : ''} ${navigating ? 'swipe-left-out' : ''}`}
+      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 touch-pan-y select-none ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : overdue ? 'bg-amber-100 dark:bg-amber-800' : urgent ? 'bg-amber-50 dark:bg-gray-700' : 'bg-slate-50 dark:bg-gray-700'}${overdue ? ' ring-2 ring-amber-300 dark:ring-amber-400' : urgent ? ' ring-2 ring-amber-300 dark:ring-amber-400' : ''} ${navigating ? 'swipe-left-out' : ''}`}
       style={{ transform: navigating ? undefined : `translateX(${swipeable ? dx : 0}px)`, transition: navigating ? undefined : dx === 0 ? 'transform 0.2s' : 'none' }}
       onPointerDown={start}
       onPointerMove={move}
@@ -142,7 +142,7 @@ export default function TaskCard({
       <button
         type="button"
         onClick={goToDetail}
-        className={`w-16 h-16 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-800 ${
+        className={`w-16 h-16 rounded-full overflow-hidden flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-800 ${
             task.type === 'Water'
               ? 'ring-2 ring-water-300'
               : task.type === 'Fertilize'
@@ -153,7 +153,7 @@ export default function TaskCard({
         <img
           src={task.image}
           alt={task.plantName}
-          className="w-12 h-12 rounded-full object-cover"
+          className="w-16 h-16 object-cover scale-110"
         />
       </button>
         <div className="w-px self-stretch bg-gray-200 dark:bg-gray-600" aria-hidden="true" />

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -37,7 +37,7 @@ export default function UnifiedTaskCard({
   const { showSnackbar } = useSnackbar()
 
   const bgClass = overdue
-    ? 'bg-red-50 dark:bg-red-800'
+    ? 'bg-amber-100 dark:bg-amber-800'
     : urgent
     ? 'bg-amber-50 dark:bg-gray-700'
     : 'bg-slate-50 dark:bg-gray-800'
@@ -208,8 +208,8 @@ export default function UnifiedTaskCard({
           document.body
         )}
       <div className="flex items-center gap-4 p-4">
-        <div className="w-14 h-14 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-700">
-          <img src={image} alt={name} className="w-12 h-12 rounded-full object-cover" />
+        <div className="w-16 h-16 rounded-full overflow-hidden flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-700">
+          <img src={image} alt={name} className="w-16 h-16 object-cover scale-110" />
         </div>
         <div className="flex-1 min-w-0">
           <div className="flex items-center justify-between">
@@ -238,18 +238,16 @@ export default function UnifiedTaskCard({
               )}
             </div>
           </div>
-          <div className="flex flex-col gap-1 mt-1 font-semibold">
+          <div className="flex flex-col gap-1 mt-1">
             {dueWater && (
-              <span className="inline-flex items-center gap-1 text-sky-600">
-                <Drop className="w-4 h-4" aria-hidden="true" />
+              <Badge colorClass="bg-sky-100 text-sky-700" size="sm" Icon={Drop}>
                 Water
-              </span>
+              </Badge>
             )}
             {dueFertilize && (
-              <span className="inline-flex items-center gap-1 text-amber-600">
-                <Sun className="w-4 h-4" aria-hidden="true" />
+              <Badge colorClass="bg-amber-100 text-amber-700" size="sm" Icon={Sun}>
                 Fertilize
-              </span>
+              </Badge>
             )}
           </div>
           {lastText && (

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -82,7 +82,7 @@ test('applies overdue style', () => {
       <UnifiedTaskCard plant={plant} overdue />
   )
   const wrapper = container.querySelector('[data-testid="unified-task-card"]')
-  expect(wrapper).toHaveClass('bg-red-50')
+  expect(wrapper).toHaveClass('bg-amber-100')
 })
 
 test('matches snapshot in dark mode', () => {

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -178,7 +178,7 @@ exports[`matches snapshot in dark mode 1`] = `
     class="absolute top-2 right-2 pointer-events-none"
   >
     <span
-      class="inline-flex items-center gap-1 rounded-full font-medium shadow-sm px-2 py-0.5 text-[10px] bg-red-50 text-red-500"
+      class="inline-flex items-center gap-1 rounded-full font-medium shadow-sm px-2 py-0.5 text-[10px] bg-amber-100 text-amber-700"
     >
       Thirsty
     </span>

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -204,12 +204,12 @@ exports[`matches snapshot in dark mode 1`] = `
       class="flex items-center flex-1 gap-4"
     >
       <button
-        class="w-16 h-16 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-800 ring-2 ring-water-300"
+        class="w-16 h-16 rounded-full overflow-hidden flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-800 ring-2 ring-water-300"
         type="button"
       >
         <img
           alt="Monstera"
-          class="w-12 h-12 rounded-full object-cover"
+          class="w-16 h-16 object-cover scale-110"
           src="https://images.pexels.com/photos/5699660/pexels-photo-5699660.jpeg"
         />
       </button>

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -10,11 +10,11 @@ exports[`matches snapshot in dark mode 1`] = `
     class="flex items-center gap-4 p-4"
   >
     <div
-      class="w-14 h-14 rounded-full flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-700"
+      class="w-16 h-16 rounded-full overflow-hidden flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-700"
     >
       <img
         alt="Fern"
-        class="w-12 h-12 rounded-full object-cover"
+        class="w-16 h-16 object-cover scale-110"
         src="fern.jpg"
       />
     </div>
@@ -71,14 +71,14 @@ exports[`matches snapshot in dark mode 1`] = `
         </div>
       </div>
       <div
-        class="flex flex-col gap-1 mt-1 font-semibold"
+        class="flex flex-col gap-1 mt-1"
       >
         <span
-          class="inline-flex items-center gap-1 text-sky-600"
+          class="inline-flex items-center gap-1 rounded-full font-medium shadow-sm px-2 py-0.5 text-[10px] bg-sky-100 text-sky-700"
         >
           <svg
             aria-hidden="true"
-            class="w-4 h-4"
+            class="w-3 h-3"
             fill="currentColor"
             height="1em"
             viewBox="0 0 256 256"


### PR DESCRIPTION
## Summary
- tone down overdue badge color
- enlarge plant images and add slight zoom
- display due tasks as color-coded chips
- adjust snapshot tests

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_687c6e8f81888324a3ecee5dab4b18d8