### PR TITLE
Improve gallery UI

### DIFF
--- a/src/components/Lightbox.jsx
+++ b/src/components/Lightbox.jsx
@@ -45,7 +45,7 @@ export default function Lightbox({ images, startIndex = 0, onClose, label = 'Ima
       </button>
       <button
         aria-label="Previous image"
-        className="absolute left-4 text-white text-3xl"
+        className="absolute top-1/2 -translate-y-1/2 left-4 text-white text-3xl p-2 rounded-full bg-black/40 opacity-70 hover:opacity-100"
         onClick={() => setIndex((index - 1 + images.length) % images.length)}
       >
         ‹
@@ -54,24 +54,24 @@ export default function Lightbox({ images, startIndex = 0, onClose, label = 'Ima
         const current =
           typeof images[index] === 'string' ? { src: images[index] } : images[index]
         return (
-          <>
+          <div className="relative">
             <img
               src={current.src}
               alt={current.caption || 'Gallery image'}
               className="max-w-full max-h-full object-contain"
             />
-            {current.caption && (
-              // <p className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white bg-black/60 px-2 py-1 rounded text-sm">
-              //   {current.caption}
-              // </p>
-              null
+            {(current.caption || current.date) && (
+              <p className="absolute bottom-4 left-1/2 -translate-x-1/2 text-white bg-black/60 px-2 py-1 rounded text-sm">
+                {current.caption}
+                {current.date && ` \u2014 ${current.date}`}
+              </p>
             )}
-          </>
+          </div>
         )
       })()}
       <button
         aria-label="Next image"
-        className="absolute right-4 text-white text-3xl"
+        className="absolute top-1/2 -translate-y-1/2 right-4 text-white text-3xl p-2 rounded-full bg-black/40 opacity-70 hover:opacity-100"
         onClick={() => setIndex((index + 1) % images.length)}
       >
         ›

--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -36,6 +36,7 @@ export default function Gallery() {
   return (
     <PageContainer className="space-y-4">
       <h2 className="text-heading font-headline text-center">Gallery</h2>
+      <h3 className="text-heading font-semibold">Recent Photos</h3>
       <div
         className="grid gap-2"
         style={{ gridTemplateColumns: 'repeat(auto-fill, minmax(120px,1fr))' }}
@@ -50,7 +51,7 @@ export default function Gallery() {
             <img
               src={photo.src}
               alt={photo.caption || `${photo.plant} photo ${i + 1}`}
-              className="w-full aspect-[4/3] object-cover rounded-lg"
+              className="w-full aspect-[4/3] object-cover rounded-2xl"
             />
           </button>
         ))}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -338,6 +338,9 @@ export default function PlantDetail() {
       label: 'Gallery',
       content: (
         <div className="space-y-4 p-4">
+          {(plant.photos || []).length > 0 && (
+            <h3 className="text-heading font-semibold">Recent Photos</h3>
+          )}
           {(plant.photos || []).length === 0 && (
             <p className="py-10 text-center text-sm text-gray-500 dark:text-gray-400">
               Add your first photo
@@ -362,7 +365,7 @@ export default function PlantDetail() {
                       <img
                         src={src}
                         alt={caption || `${plant.name} photo ${i + 1}`}
-                        className="w-24 aspect-[4/3] object-cover rounded-xl shadow-sm transition-transform duration-200 group-hover:scale-105"
+                        className="w-24 aspect-[4/3] object-cover rounded-2xl shadow-sm transition-transform duration-200 group-hover:scale-105"
                       />
                       {i === 2 && extra > 0 && (
                         <span className="absolute inset-0 rounded-xl bg-black/50 flex items-center justify-center text-white font-semibold text-sm">


### PR DESCRIPTION
## Summary
- tweak gallery tab with a heading and rounded tiles
- add heading and rounded tiles to Gallery page
- show caption in Lightbox and soften arrows

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c6f6553188324bcb70c305fb88940