### PR TITLE
Implement plant detail design tweaks

### DIFF
--- a/src/components/Badge.jsx
+++ b/src/components/Badge.jsx
@@ -10,8 +10,8 @@ export default function Badge({
 }) {
   const variants = {
     info: 'bg-sky-100 text-sky-700',
-    urgent: 'bg-amber-100 text-amber-700',
-    overdue: 'bg-amber-100 text-amber-700',
+    urgent: 'bg-rose-50 text-rose-600',
+    overdue: 'bg-rose-50 text-rose-600',
     complete: 'bg-emerald-100 text-emerald-800',
   }
 

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -211,7 +211,7 @@ export default function UnifiedTaskCard({
         <div className="w-16 h-16 rounded-full overflow-hidden flex items-center justify-center shadow-sm bg-neutral-100 dark:bg-gray-700">
           <img src={image} alt={name} className="w-16 h-16 object-cover scale-110" />
         </div>
-        <div className="flex-1 min-w-0">
+        <div className="flex-1 min-w-0 leading-relaxed">
           <div className="flex items-center justify-between">
             <p className="font-semibold font-headline text-gray-900 dark:text-gray-100 truncate">
               {name}
@@ -251,7 +251,7 @@ export default function UnifiedTaskCard({
             )}
           </div>
           {lastText && (
-            <p className="text-sm text-gray-500">Last cared for {lastText}</p>
+            <p className="text-xs text-gray-500">Last cared for {lastText}</p>
           )}
           {needsText && (
             <p

--- a/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/PlantCard.test.jsx.snap
@@ -178,7 +178,7 @@ exports[`matches snapshot in dark mode 1`] = `
     class="absolute top-2 right-2 pointer-events-none"
   >
     <span
-      class="inline-flex items-center gap-1 rounded-full font-medium shadow-sm px-2 py-0.5 text-[10px] bg-amber-100 text-amber-700"
+      class="inline-flex items-center gap-1 rounded-full font-medium shadow-sm px-2 py-0.5 text-[10px] bg-rose-50 text-rose-600"
     >
       Thirsty
     </span>

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -19,7 +19,7 @@ exports[`matches snapshot in dark mode 1`] = `
       />
     </div>
     <div
-      class="flex-1 min-w-0"
+      class="flex-1 min-w-0 leading-relaxed"
     >
       <div
         class="flex items-center justify-between"
@@ -111,7 +111,7 @@ exports[`matches snapshot in dark mode 1`] = `
         </span>
       </div>
       <p
-        class="text-sm text-gray-500"
+        class="text-xs text-gray-500"
       >
         Last cared for 
         3 days ago

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -85,6 +85,7 @@ export default function PlantDetail() {
   const [collapsedMonths, setCollapsedMonths] = useState({})
   const [latestFirst, setLatestFirst] = useState(true)
   const [offsetY, setOffsetY] = useState(0)
+  const [expandedNotes, setExpandedNotes] = useState({})
 
   const progressPct = getWateringProgress(plant?.lastWatered, plant?.nextWater)
   const waterTotal = 3
@@ -308,6 +309,8 @@ export default function PlantDetail() {
                 >
                   {list.map((e, i) => {
                     const Icon = actionIcons[e.type]
+                    const noteKey = `${e.date}-${i}`
+                    const expanded = expandedNotes[noteKey]
                     return (
                       <li key={`${e.date}-${i}`} className="relative text-xs sm:text-sm">
                         {Icon && (
@@ -319,7 +322,15 @@ export default function PlantDetail() {
                           <div>
                             <span className="font-medium">{formatDate(e.date)}</span> — {e.label}
                             {e.note && (
-                              <div className="text-xs italic text-green-700 mt-1">{e.note}</div>
+                              <button
+                                type="button"
+                                onClick={() =>
+                                  setExpandedNotes(n => ({ ...n, [noteKey]: !expanded }))
+                                }
+                                className="block text-left text-xs font-normal text-green-800 mt-1"
+                              >
+                                {expanded ? e.note : `${e.note.slice(0, 60)}${e.note.length > 60 ? '\u2026' : ''}`}
+                              </button>
                             )}
                           </div>
                         </div>
@@ -469,7 +480,7 @@ export default function PlantDetail() {
       </div>
       <PageContainer className="relative text-left pt-0 space-y-3">
         <Toast />
-        <div className="flex flex-col items-center mt-4" aria-label="Care progress">
+        <div className="flex flex-col items-center mt-4 mb-4" aria-label="Care progress">
           <CareStats
             waterCompleted={waterCompleted}
             waterTotal={waterTotal}

--- a/src/pages/__tests__/__snapshots__/PlantDetailCareLog.test.jsx.snap
+++ b/src/pages/__tests__/__snapshots__/PlantDetailCareLog.test.jsx.snap
@@ -82,11 +82,12 @@ exports[`timeline bullet markup matches snapshot 1`] = `
         </span>
          — 
         Watered
-        <div
-          class="text-xs italic text-green-700 mt-1"
+        <button
+          class="block text-left text-xs font-normal text-green-800 mt-1"
+          type="button"
         >
           deep soak
-        </div>
+        </button>
       </div>
     </div>
   </li>


### PR DESCRIPTION
## Summary
- lighten urgent/overdue badges
- add breathing room above tabs on plant detail
- adjust UnifiedTaskCard typography
- normal weight for activity notes with expansion
- update snapshots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c70ef5d0483249b30e7430f1832d2