### PR TITLE
Clarify care rings on plant detail

### DIFF
--- a/src/components/CareStats.jsx
+++ b/src/components/CareStats.jsx
@@ -2,9 +2,18 @@ import React from 'react'
 import { ListChecks, Drop, Sun } from 'phosphor-react'
 import ProgressRing from './ProgressRing.jsx'
 
-function StatBlock({ id, label, Icon, completed, total, ringClass, onClick }) {
+function StatBlock({
+  id,
+  label,
+  Icon,
+  completed,
+  total,
+  ringClass,
+  onClick,
+  display,
+}) {
   const pct = total > 0 ? Math.min(completed / total, 1) : 0
-  const display = `${completed}/${total}`
+  const displayText = display ?? `${completed}/${total}`
 
   const size = 64
 
@@ -30,7 +39,7 @@ function StatBlock({ id, label, Icon, completed, total, ringClass, onClick }) {
               className="text-sm font-semibold font-body"
               data-testid="stat-text"
             >
-              {display}
+              {displayText}
             </span>
           </div>
         </div>
@@ -52,6 +61,9 @@ export default function CareStats({
   onTotalClick,
   onWaterClick,
   onFertClick,
+  waterDisplay,
+  fertDisplay,
+  totalDisplay,
 }) {
   const totalCompleted = waterCompleted + fertCompleted
   const totalTasks = waterTotal + fertTotal
@@ -64,6 +76,7 @@ export default function CareStats({
       total: totalTasks,
       ringClass: 'text-emerald-600',
       onClick: onTotalClick,
+      display: totalDisplay,
     },
     {
       id: 'water',
@@ -73,6 +86,7 @@ export default function CareStats({
       total: waterTotal,
       ringClass: 'text-sky-500',
       onClick: onWaterClick,
+      display: waterDisplay,
     },
     {
       id: 'fertilize',
@@ -82,6 +96,7 @@ export default function CareStats({
       total: fertTotal,
       ringClass: 'text-amber-600',
       onClick: onFertClick,
+      display: fertDisplay,
     },
   ]
   return (

--- a/src/components/__tests__/CareStats.test.jsx
+++ b/src/components/__tests__/CareStats.test.jsx
@@ -59,3 +59,18 @@ test('container has vertical margins for spacing', () => {
   render(<CareStats />)
   expect(screen.getByTestId('care-stats')).toHaveClass('my-4')
 })
+
+test('allows custom display text', () => {
+  render(
+    <CareStats
+      waterCompleted={1}
+      waterTotal={2}
+      fertCompleted={2}
+      fertTotal={2}
+      waterDisplay="3 days left"
+      fertDisplay="1 day left"
+    />
+  )
+  const texts = screen.getAllByTestId('stat-text').map(el => el.textContent)
+  expect(texts).toEqual(['3/4', '3 days left', '1 day left'])
+})

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -36,7 +36,7 @@ import UnifiedTaskCard from '../components/UnifiedTaskCard.jsx'
 import useToast from "../hooks/useToast.jsx"
 import confetti from 'canvas-confetti'
 
-import { formatMonth, formatDate } from '../utils/date.js'
+import { formatMonth, formatDate, daysUntil } from '../utils/date.js'
 import { formatDaysAgo, formatTimeOfDay } from '../utils/dateFormat.js'
 import { getWateringProgress } from '../utils/watering.js'
 
@@ -90,12 +90,28 @@ export default function PlantDetail() {
   const waterTotal = 3
   const waterCompleted = Math.round(progressPct * waterTotal)
 
+  const waterDays = daysUntil(plant?.nextWater)
+  let waterDisplay = null
+  if (waterDays != null) {
+    if (waterDays <= 0) waterDisplay = 'Today'
+    else if (waterDays === 1) waterDisplay = '1 day left'
+    else waterDisplay = `${waterDays} days left`
+  }
+
   const fertPct = getWateringProgress(
     plant?.lastFertilized,
     plant?.nextFertilize
   )
   const fertTotal = 3
   const fertCompleted = Math.round(fertPct * fertTotal)
+
+  const fertDays = daysUntil(plant?.nextFertilize)
+  let fertDisplay = null
+  if (fertDays != null) {
+    if (fertDays <= 0) fertDisplay = 'Today'
+    else if (fertDays === 1) fertDisplay = '1 day left'
+    else fertDisplay = `${fertDays} days left`
+  }
 
   const todayIso = new Date().toISOString().slice(0, 10)
   const dueWater = plant?.nextWater && plant.nextWater <= todayIso
@@ -466,13 +482,18 @@ export default function PlantDetail() {
       </div>
       <PageContainer className="relative text-left pt-0 space-y-3">
         <Toast />
-        <div className="flex justify-center mt-4" aria-label="Care progress">
+        <div className="flex flex-col items-center mt-4" aria-label="Care progress">
           <CareStats
             waterCompleted={waterCompleted}
             waterTotal={waterTotal}
             fertCompleted={fertCompleted}
             fertTotal={fertTotal}
+            waterDisplay={waterDisplay}
+            fertDisplay={fertDisplay}
           />
+          <p className="text-xs text-gray-500 dark:text-gray-400" data-testid="progress-hint">
+            Progress toward next scheduled care
+          </p>
         </div>
         <div className="space-y-3">
           <DetailTabs tabs={tabs} />

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -50,6 +50,26 @@ test('shows watering progress indicator', () => {
   expect(screen.getByLabelText(/care progress/i)).toBeInTheDocument()
 })
 
+test('shows countdown text inside care rings', () => {
+  const plant = plants[0]
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-20'))
+  render(
+    <MenuProvider>
+      <PlantProvider>
+        <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+          <Routes>
+            <Route path="/plant/:id" element={<PlantDetail />} />
+          </Routes>
+        </MemoryRouter>
+      </PlantProvider>
+    </MenuProvider>
+  )
+
+  expect(screen.getByTestId('stat-water')).toHaveTextContent(/5 days left/i)
+  expect(screen.getByTestId('stat-fertilize')).toHaveTextContent(/28 days left/i)
+  jest.useRealTimers()
+})
+
 
 test('displays all sections', () => {
   const plant = plants[0]

--- a/src/utils/__tests__/date.test.js
+++ b/src/utils/__tests__/date.test.js
@@ -1,8 +1,14 @@
-import { daysAgo, formatCareSummary } from '../date.js'
+import { daysAgo, daysUntil, formatCareSummary } from '../date.js'
 
 test('daysAgo calculates difference in days', () => {
   jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
   expect(daysAgo('2025-07-07')).toBe(3)
+  jest.useRealTimers()
+})
+
+test('daysUntil returns positive countdown', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
+  expect(daysUntil('2025-07-13')).toBe(3)
   jest.useRealTimers()
 })
 

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -44,6 +44,13 @@ export function daysAgo(dateStr, today = new Date()) {
   return Math.floor((today - d) / 86400000)
 }
 
+export function daysUntil(dateStr, today = new Date()) {
+  if (!dateStr) return null
+  const d = new Date(dateStr)
+  if (isNaN(d)) return null
+  return Math.ceil((d - today) / 86400000)
+}
+
 export function formatCareSummary(lastWatered, nextWater, today = new Date()) {
   const ago = daysAgo(lastWatered, today)
   const nextDate = nextWater ? new Date(nextWater) : null


### PR DESCRIPTION
## Summary
- show countdown text inside plant care rings
- support custom ring labels in `<CareStats>`
- add `daysUntil` date helper
- test new countdown behavior

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c6649597483249a409b759d6b27a6