### PR TITLE
Add swipe feedback visuals

### DIFF
--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,4 +1,4 @@
-import { Drop, Sun, PencilSimpleLine, ClockCounterClockwise, Trash } from 'phosphor-react'
+import { Drop, Sun, PencilSimpleLine, ClockCounterClockwise, Trash, CheckCircle } from 'phosphor-react'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useState } from 'react'
 import { getWateringInfo } from '../utils/watering.js'
@@ -98,13 +98,27 @@ export default function TaskCard({
       data-testid="task-card"
       tabIndex="0"
       aria-label={`Task card for ${task.plantName}`}
-      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 touch-pan-y select-none ${completed ? 'bg-gray-100 dark:bg-gray-800 opacity-50' : overdue ? 'bg-amber-100 dark:bg-amber-800' : urgent ? 'bg-amber-50 dark:bg-gray-700' : 'bg-slate-50 dark:bg-gray-700'}${overdue ? ' ring-2 ring-amber-300 dark:ring-amber-400' : urgent ? ' ring-2 ring-amber-300 dark:ring-amber-400' : ''} ${navigating ? 'swipe-left-out' : ''}`}
-      style={{ transform: navigating ? undefined : `translateX(${swipeable ? dx : 0}px)`, transition: navigating ? undefined : dx === 0 ? 'transform 0.2s' : 'none' }}
+      className={`relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 touch-pan-y select-none ${completed ? 'bg-green-50 dark:bg-green-900 opacity-50' : overdue ? 'bg-amber-100 dark:bg-amber-800' : urgent ? 'bg-amber-50 dark:bg-gray-700' : 'bg-slate-50 dark:bg-gray-700'}${overdue ? ' ring-2 ring-amber-300 dark:ring-amber-400' : urgent ? ' ring-2 ring-amber-300 dark:ring-amber-400' : ''} ${navigating ? 'swipe-left-out' : ''}`}
+      style={{ transform: navigating ? undefined : `translateX(${swipeable ? dx : 0}px) rotate(${dx / 50}deg)`, transition: navigating ? undefined : dx === 0 ? 'transform 0.2s' : 'none' }}
       onPointerDown={start}
       onPointerMove={move}
       onPointerUp={end}
       onPointerCancel={end}
     >
+      <div
+        className={`swipe-feedback swipe-right-bg ${dx > 0 ? 'show' : ''}`}
+        style={{ opacity: dx > 0 ? Math.min(dx / 40, 1) : 0 }}
+      >
+        <CheckCircle className="w-5 h-5 mr-2" aria-hidden="true" />
+        {task.type === 'Water' ? 'Watered' : 'Fertilized'}
+      </div>
+      <div
+        className={`swipe-feedback swipe-left-bg ${dx < 0 ? 'show' : ''}`}
+        style={{ opacity: dx < 0 ? Math.min(-dx / 40, 1) : 0 }}
+      >
+        <PencilSimpleLine className="w-5 h-5 mr-2" aria-hidden="true" />
+        Edit
+      </div>
       <div
         className={`task-action-bar ${showActionBar ? 'show' : ''}`}
         role="group"

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -101,7 +101,7 @@ test('shows completed state', () => {
   )
   const wrapper = container.querySelector('.shadow')
   expect(wrapper).toHaveClass('opacity-50')
-  expect(wrapper).toHaveClass('bg-gray-100')
+  expect(wrapper).toHaveClass('bg-green-50')
   expect(container.querySelector('.check-pop')).toBeInTheDocument()
 })
 
@@ -160,6 +160,7 @@ test('partial left swipe reveals actions', () => {
   fireEvent.click(screen.getByRole('button', { name: /delete task/i }))
   expect(updatePlant).toHaveBeenCalledTimes(2)
 })
+
 
 
 

--- a/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/TaskCard.test.jsx.snap
@@ -8,9 +8,99 @@ exports[`matches snapshot in dark mode 1`] = `
     aria-label="Task card for Monstera"
     class="relative flex items-center p-5 gap-4 rounded-2xl shadow border border-neutral-200 dark:border-gray-600 touch-pan-y select-none bg-amber-50 dark:bg-gray-700 ring-2 ring-amber-300 dark:ring-amber-400 "
     data-testid="task-card"
-    style="transform: translateX(0px); transition: transform 0.2s;"
+    style="transform: translateX(0px) rotate(0deg); transition: transform 0.2s;"
     tabindex="0"
   >
+    <div
+      class="swipe-feedback swipe-right-bg "
+      style="opacity: 0;"
+    >
+      <svg
+        aria-hidden="true"
+        class="w-5 h-5 mr-2"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 256 256"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect
+          fill="none"
+          height="256"
+          width="256"
+        />
+        <polyline
+          fill="none"
+          points="172 104 113.3 160 84 132"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+        />
+        <circle
+          cx="128"
+          cy="128"
+          fill="none"
+          r="96"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+        />
+      </svg>
+      Watered
+    </div>
+    <div
+      class="swipe-feedback swipe-left-bg "
+      style="opacity: 0;"
+    >
+      <svg
+        aria-hidden="true"
+        class="w-5 h-5 mr-2"
+        fill="currentColor"
+        height="1em"
+        viewBox="0 0 256 256"
+        width="1em"
+        xmlns="http://www.w3.org/2000/svg"
+      >
+        <rect
+          fill="none"
+          height="256"
+          width="256"
+        />
+        <path
+          d="M96,216H48a8,8,0,0,1-8-8V163.3a7.9,7.9,0,0,1,2.3-5.6l120-120a8,8,0,0,1,11.4,0l44.6,44.6a8,8,0,0,1,0,11.4Z"
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="216"
+          x2="96"
+          y1="216"
+          y2="216"
+        />
+        <line
+          fill="none"
+          stroke="currentColor"
+          stroke-linecap="round"
+          stroke-linejoin="round"
+          stroke-width="16"
+          x1="136"
+          x2="192"
+          y1="64"
+          y2="120"
+        />
+      </svg>
+      Edit
+    </div>
     <div
       aria-label="Task actions"
       class="task-action-bar "

--- a/src/index.css
+++ b/src/index.css
@@ -324,6 +324,23 @@ body {
   @apply px-2 py-1 rounded text-xs flex items-center gap-1 font-body transition;
 }
 
+/* Swipe feedback backgrounds */
+.swipe-feedback {
+  @apply absolute inset-0 rounded-2xl flex items-center pointer-events-none font-semibold text-sm opacity-0 transition-opacity;
+}
+
+.swipe-feedback.show {
+  opacity: 1;
+}
+
+.swipe-right-bg {
+  @apply justify-start pl-5 bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100;
+}
+
+.swipe-left-bg {
+  @apply justify-end pr-5 bg-slate-200 text-white dark:bg-slate-700;
+}
+
 
 /* Standard close button for modals and menus */
 .modal-close {


### PR DESCRIPTION
## Summary
- add swipe feedback CSS styles
- show 'mark as done' and 'edit' backgrounds on swipe
- tweak completed task color to soft green
- update TaskCard tests and snapshots

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_687c77bd0c648324a4243d4cc0aedc21