### PR TITLE
Introduce care cards on detail page

### DIFF
--- a/src/components/CareCard.jsx
+++ b/src/components/CareCard.jsx
@@ -1,0 +1,32 @@
+import React from 'react'
+
+export default function CareCard({ label, Icon, progress = 0, status, onDone }) {
+  const pct = Math.min(Math.max(progress, 0), 1)
+  const width = `${pct * 100}%`
+  return (
+    <div className="bg-white dark:bg-gray-700 rounded-2xl shadow p-4 space-y-2" data-testid="care-card">
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-2">
+          {Icon && <Icon className="w-5 h-5" aria-hidden="true" />}
+          <span className="font-semibold">{label}</span>
+        </div>
+        {onDone && (
+          <button
+            type="button"
+            onClick={onDone}
+            className="text-sm font-medium text-green-700 bg-green-100 hover:bg-green-200 rounded px-2 py-1"
+          >
+            Mark as Done
+          </button>
+        )}
+      </div>
+      {status && <p className="text-sm text-gray-500">{status}</p>}
+      <div className="h-2 rounded bg-gray-200 overflow-hidden" role="progressbar" aria-valuenow={Math.round(pct*100)} aria-valuemin="0" aria-valuemax="100">
+        <div
+          className="h-full bg-gradient-to-r from-green-500 via-orange-500 to-red-500"
+          style={{ width }}
+        ></div>
+      </div>
+    </div>
+  )
+}

--- a/src/components/__tests__/CareCard.test.jsx
+++ b/src/components/__tests__/CareCard.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { Drop } from 'phosphor-react'
+import CareCard from '../CareCard.jsx'
+
+test('renders label, status and progress width', () => {
+  render(<CareCard label="Water" Icon={Drop} progress={0.5} status="Due in 3 days" />)
+  expect(screen.getByText('Water')).toBeInTheDocument()
+  expect(screen.getByText(/due in 3 days/i)).toBeInTheDocument()
+  const bar = screen.getByRole('progressbar').firstChild
+  expect(bar).toHaveStyle('width: 50%')
+})
+
+test('calls handler when done', () => {
+  const onDone = jest.fn()
+  render(<CareCard label="Water" Icon={Drop} progress={0} status="Today" onDone={onDone} />)
+  fireEvent.click(screen.getByRole('button', { name: /mark as done/i }))
+  expect(onDone).toHaveBeenCalled()
+})

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -27,7 +27,7 @@ import actionIcons from '../components/ActionIcons.jsx'
 import NoteModal from '../components/NoteModal.jsx'
 import { useMenu, defaultMenu } from '../MenuContext.jsx'
 import LegendModal from '../components/LegendModal.jsx'
-import CareStats from '../components/CareStats.jsx'
+import CareCard from '../components/CareCard.jsx'
 import PlantDetailFab from '../components/PlantDetailFab.jsx'
 import DetailTabs from '../components/DetailTabs.jsx'
 import BaseCard from '../components/BaseCard.jsx'
@@ -87,32 +87,25 @@ export default function PlantDetail() {
   const [offsetY, setOffsetY] = useState(0)
   const [expandedNotes, setExpandedNotes] = useState({})
 
-  const progressPct = getWateringProgress(plant?.lastWatered, plant?.nextWater)
-  const waterTotal = 3
-  const waterCompleted = Math.round(progressPct * waterTotal)
-
-  const waterDays = daysUntil(plant?.nextWater)
-  let waterDisplay = null
-  if (waterDays != null) {
-    if (waterDays <= 0) waterDisplay = 'Today'
-    else if (waterDays === 1) waterDisplay = '1 day left'
-    else waterDisplay = `${waterDays} days left`
-  }
-
-  const fertPct = getWateringProgress(
+  const waterProgress = getWateringProgress(plant?.lastWatered, plant?.nextWater)
+  const fertProgress = getWateringProgress(
     plant?.lastFertilized,
     plant?.nextFertilize
   )
-  const fertTotal = 3
-  const fertCompleted = Math.round(fertPct * fertTotal)
 
+  const waterDays = daysUntil(plant?.nextWater)
   const fertDays = daysUntil(plant?.nextFertilize)
-  let fertDisplay = null
-  if (fertDays != null) {
-    if (fertDays <= 0) fertDisplay = 'Today'
-    else if (fertDays === 1) fertDisplay = '1 day left'
-    else fertDisplay = `${fertDays} days left`
+
+  const getStatus = days => {
+    if (days == null) return 'Not scheduled'
+    if (days < 0) return 'Overdue'
+    if (days === 0) return 'Due Today'
+    if (days === 1) return 'Due Tomorrow'
+    return `Due in ${days} days`
   }
+
+  const waterStatus = getStatus(waterDays)
+  const fertStatus = getStatus(fertDays)
 
   const todayIso = new Date().toISOString().slice(0, 10)
   const dueWater = plant?.nextWater && plant.nextWater <= todayIso
@@ -498,15 +491,22 @@ export default function PlantDetail() {
         <Toast />
 
         <div className="flex flex-col items-center mt-4" aria-label="Care progress">
-
-          <CareStats
-            waterCompleted={waterCompleted}
-            waterTotal={waterTotal}
-            fertCompleted={fertCompleted}
-            fertTotal={fertTotal}
-            waterDisplay={waterDisplay}
-            fertDisplay={fertDisplay}
-          />
+          <div className="w-full max-w-xs space-y-3">
+            <CareCard
+              label="Water"
+              Icon={Drop}
+              progress={waterProgress}
+              status={waterStatus}
+              onDone={handleWatered}
+            />
+            <CareCard
+              label="Fertilize"
+              Icon={Sun}
+              progress={fertProgress}
+              status={fertStatus}
+              onDone={handleFertilized}
+            />
+          </div>
           <p className="text-xs text-gray-500 dark:text-gray-400" data-testid="progress-hint">
             Progress toward next scheduled care
           </p>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -50,7 +50,7 @@ test('shows watering progress indicator', () => {
   expect(screen.getByLabelText(/care progress/i)).toBeInTheDocument()
 })
 
-test('shows countdown text inside care rings', () => {
+test('shows countdown text inside care cards', () => {
   const plant = plants[0]
   jest.useFakeTimers().setSystemTime(new Date('2025-07-20'))
   render(
@@ -65,8 +65,8 @@ test('shows countdown text inside care rings', () => {
     </MenuProvider>
   )
 
-  expect(screen.getByTestId('stat-water')).toHaveTextContent(/5 days left/i)
-  expect(screen.getByTestId('stat-fertilize')).toHaveTextContent(/28 days left/i)
+  expect(screen.getByText(/due in 5 days/i)).toBeInTheDocument()
+  expect(screen.getByText(/due in 28 days/i)).toBeInTheDocument()
   jest.useRealTimers()
 })
 


### PR DESCRIPTION
## Summary
- add `CareCard` component for clear progress visualization
- show care cards on plant detail page instead of progress rings
- update plant detail tests for new countdown text
- test `CareCard` component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c7b035ce48324990f944638cb7438