### PR TITLE
Fix fertilize log events

### DIFF
--- a/src/pages/__tests__/__snapshots__/PlantDetailCareLog.test.jsx.snap
+++ b/src/pages/__tests__/__snapshots__/PlantDetailCareLog.test.jsx.snap
@@ -8,7 +8,7 @@ exports[`timeline bullet markup matches snapshot 1`] = `
     class="relative text-xs sm:text-sm"
   >
     <div
-      class="absolute -left-5 top-[0.25rem] w-4 h-4 flex items-center justify-center rounded-full bg-green-500 z-10"
+      class="absolute -left-5 top-[0.25rem] w-4 h-4 flex items-center justify-center rounded-full bg-blue-500 z-10"
     >
       <svg
         aria-hidden="true"
@@ -24,50 +24,21 @@ exports[`timeline bullet markup matches snapshot 1`] = `
           height="256"
           width="256"
         />
-        <line
+        <path
+          d="M208,144c0-72-80-128-80-128S48,72,48,144a80,80,0,0,0,160,0Z"
           fill="none"
           stroke="currentColor"
           stroke-linecap="round"
           stroke-linejoin="round"
           stroke-width="16"
-          x1="112"
-          x2="176"
-          y1="112"
-          y2="112"
         />
-        <line
+        <path
+          d="M136.1,191.2a47.9,47.9,0,0,0,39.2-39.1"
           fill="none"
           stroke="currentColor"
           stroke-linecap="round"
           stroke-linejoin="round"
           stroke-width="16"
-          x1="112"
-          x2="176"
-          y1="144"
-          y2="144"
-        />
-        <rect
-          fill="none"
-          height="176"
-          rx="8"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-          width="176"
-          x="40"
-          y="40"
-        />
-        <line
-          fill="none"
-          stroke="currentColor"
-          stroke-linecap="round"
-          stroke-linejoin="round"
-          stroke-width="16"
-          x1="80"
-          x2="80"
-          y1="40"
-          y2="216"
         />
       </svg>
     </div>

--- a/src/utils/__tests__/events.test.js
+++ b/src/utils/__tests__/events.test.js
@@ -12,7 +12,7 @@ test('buildEvents returns sorted events for a single plant', () => {
   const events = buildEvents(plant)
   expect(events).toEqual([
     { date: '2025-07-01', label: 'Fertilized', type: 'fertilize' },
-    { date: '2025-07-02', label: 'Watered', note: 'deep soak', type: 'log' },
+    { date: '2025-07-02', label: 'Watered', note: 'deep soak', type: 'water' },
     { date: '2025-07-09', label: 'Watered', type: 'water' },
     { date: '2025-07-11', label: 'Watered', type: 'water' },
   ])

--- a/src/utils/events.js
+++ b/src/utils/events.js
@@ -44,11 +44,14 @@ export function buildEvents(source, { includePlantName = false } = {}) {
       const lowerType = (ev.type || '').toLowerCase()
       if (lowerType.includes('water')) waterDates.add(ev.date)
       if (lowerType.includes('fertilize')) fertilizeDates.add(ev.date)
+      let type = 'log'
+      if (lowerType.includes('water')) type = 'water'
+      else if (lowerType.includes('fertilize')) type = 'fertilize'
       addEvent({
         date: ev.date,
         label: includePlantName ? `${ev.type} ${p.name}` : ev.type,
         note: ev.note,
-        type: 'log',
+        type,
       })
     })
 


### PR DESCRIPTION
## Summary
- mark fertilize care log events as `fertilize`
- update expectations in events tests
- update PlantDetailCareLog snapshot

## Testing
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_687c7d59efbc8324ad48061f947fcfc4