### PR TITLE
Add plant fact snippet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_WEATHER_API_KEY=your_key_here
+VITE_OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Visit `/gallery` to see all of your photos in one place. This page currently onl
 Lisa can display local weather data and suggest when to water
 your plants. The app retrieves current conditions from OpenWeather
 using an API key you provide.
-A `.env.example` file is included at the project root and lists the required environment variable.
+A `.env.example` file is included at the project root and lists the environment variables.
 You can change the city and switch between Fahrenheit and Celsius from the **Settings** page.
 
 ### Get an API Key
@@ -60,6 +60,7 @@ You can change the city and switch between Fahrenheit and Celsius from the **Set
 1. Sign up at [OpenWeather](https://openweathermap.org/api) and create a key.
 2. Copy `.env.example` to `.env` in the project root and replace `your_key_here`
    with your actual API key.
+3. (Optional) Add `VITE_OPENAI_API_KEY` to enable featured plant facts.
 
 ### How It Works
 
@@ -72,6 +73,12 @@ temperature and conditions.
 Run the dev server with `npm run dev` after adding your key. Open the
 app in your browser to see weather info and watering suggestions on the
 home screen.
+
+## Plant Facts (Optional)
+
+Provide an OpenAI API key in `.env` as `VITE_OPENAI_API_KEY` to display a short
+fact about the featured plant. If the key is missing or the request fails,
+Lisa falls back to a brief summary from Wikipedia.
 
 ## Running Tests
 

--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -14,6 +14,7 @@ import {
 
 
 import useINatPhoto from '../hooks/useINatPhoto.js'
+import usePlantFact from '../hooks/usePlantFact.js'
 import { createRipple } from '../utils/interactions.js'
 
 
@@ -69,6 +70,7 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
     (plant.photos && plant.photos[0]?.src) ||
     plant.image ||
     placeholder?.src
+  const { fact } = usePlantFact(name)
 
   return (
     <Link
@@ -110,6 +112,9 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
               />
             )}
           </div>
+        )}
+        {fact && (
+          <p className="text-sm italic text-white/90 max-w-prose">{fact}</p>
         )}
         {/* Action buttons were removed to keep the card minimal */}
 

--- a/src/components/__tests__/FeaturedCard.test.jsx
+++ b/src/components/__tests__/FeaturedCard.test.jsx
@@ -54,3 +54,24 @@ test('arrow keys change plant', () => {
   fireEvent.keyDown(card, { key: 'ArrowLeft' })
   expect(screen.getByText('Aloe')).toBeInTheDocument()
 })
+
+test('displays plant fact when loaded', async () => {
+  process.env.VITE_OPENAI_API_KEY = 'key'
+  global.fetch = jest.fn(url => {
+    if (url.includes('openai')) {
+      return Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({ choices: [{ message: { content: 'fun fact' } }] }),
+      })
+    }
+    return Promise.resolve({ json: () => Promise.resolve({ results: [] }) })
+  })
+  render(
+    <MemoryRouter>
+      <FeaturedCard plants={plants} />
+    </MemoryRouter>
+  )
+  await screen.findByText('fun fact')
+  global.fetch = undefined
+  delete process.env.VITE_OPENAI_API_KEY
+})

--- a/src/hooks/__tests__/usePlantFact.test.js
+++ b/src/hooks/__tests__/usePlantFact.test.js
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import usePlantFact from '../usePlantFact.js'
+
+function Test({ name }) {
+  const { fact } = usePlantFact(name)
+  return <div>{fact || 'loading'}</div>
+}
+
+afterEach(() => {
+  global.fetch && (global.fetch = undefined)
+  delete process.env.VITE_OPENAI_API_KEY
+  localStorage.clear()
+})
+
+test('fetches fact from OpenAI when key provided', async () => {
+  process.env.VITE_OPENAI_API_KEY = 'key'
+  global.fetch = jest.fn(url =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({ choices: [{ message: { content: 'gpt fact' } }] }),
+    })
+  )
+  render(<Test name="Aloe" />)
+  await waitFor(() => screen.getByText('gpt fact'))
+  expect(global.fetch).toHaveBeenCalledWith(
+    'https://api.openai.com/v1/chat/completions',
+    expect.any(Object)
+  )
+})
+
+test('falls back to wikipedia summary', async () => {
+  process.env.VITE_OPENAI_API_KEY = 'key'
+  global.fetch = jest.fn(url => {
+    if (url.includes('openai')) {
+      return Promise.resolve({ ok: false })
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ extract: 'Rose is a plant. Second.' }),
+    })
+  })
+  render(<Test name="Rose" />)
+  await waitFor(() => screen.getByText('Rose is a plant'))
+  expect(global.fetch).toHaveBeenCalledTimes(2)
+})

--- a/src/hooks/usePlantFact.js
+++ b/src/hooks/usePlantFact.js
@@ -1,0 +1,81 @@
+import { useEffect, useState } from 'react'
+
+export default function usePlantFact(name) {
+  const [fact, setFact] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!name) return
+    const key = `plantFact_${name.toLowerCase()}`
+    const cached =
+      typeof localStorage !== 'undefined' && localStorage.getItem(key)
+    if (cached) {
+      setFact(cached)
+      return
+    }
+
+    let aborted = false
+    async function fetchFact() {
+      setLoading(true)
+      const openaiKey = process.env.VITE_OPENAI_API_KEY
+      try {
+        if (openaiKey) {
+          const prompt = `Give me a short fun or cultural fact about the plant "${name}". One sentence.`
+          const res = await fetch('https://api.openai.com/v1/chat/completions', {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              Authorization: `Bearer ${openaiKey}`,
+            },
+            body: JSON.stringify({
+              model: 'gpt-4o',
+              messages: [{ role: 'user', content: prompt }],
+              temperature: 0.7,
+            }),
+          })
+          if (!res.ok) throw new Error('openai failed')
+          const data = await res.json()
+          const text = data?.choices?.[0]?.message?.content?.trim()
+          if (text && !aborted) {
+            setFact(text)
+            if (typeof localStorage !== 'undefined') {
+              localStorage.setItem(key, text)
+            }
+            setLoading(false)
+            return
+          }
+        }
+      } catch (err) {
+        console.error('OpenAI error', err)
+      }
+
+      try {
+        const url = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(
+          name
+        )}`
+        const res = await fetch(url)
+        if (!res.ok) throw new Error('wiki failed')
+        const data = await res.json()
+        const sentence = data.extract?.split(/\.\s/)[0]?.trim()
+        if (sentence && !aborted) {
+          setFact(sentence)
+          if (typeof localStorage !== 'undefined') {
+            localStorage.setItem(key, sentence)
+          }
+        }
+      } catch (err) {
+        console.error('Wiki error', err)
+        if (!aborted) setError('Failed to load fact')
+      } finally {
+        if (!aborted) setLoading(false)
+      }
+    }
+    fetchFact()
+    return () => {
+      aborted = true
+    }
+  }, [name])
+
+  return { fact, error, loading }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => {
     base: basePath,
     define: {
       'process.env.VITE_WEATHER_API_KEY': JSON.stringify(env.VITE_WEATHER_API_KEY),
+      'process.env.VITE_OPENAI_API_KEY': JSON.stringify(env.VITE_OPENAI_API_KEY),
       'process.env.VITE_BASE_PATH': JSON.stringify(basePath),
       'import.meta.env.VITE_BASE_PATH': JSON.stringify(basePath),
     },


### PR DESCRIPTION
## Summary
- expose `VITE_OPENAI_API_KEY` in vite config and `.env.example`
- fetch plant facts from OpenAI with a Wikipedia fallback
- show fact snippet in `FeaturedCard`
- document optional plant facts feature
- test new hook and UI

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c7e28b3e083249bd032bfc09e49bf