### PR TITLE
Move care progress inside tab

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -242,23 +242,27 @@ export default function PlantDetail() {
       label: 'Care',
       content: (
         <div className="p-4 space-y-2">
-          {dueWater || dueFertilize ? (
-            <BaseCard variant="task">
-              <UnifiedTaskCard
-                plant={{
-                  ...plant,
-                  dueWater,
-                  dueFertilize,
-                  lastCared,
-                }}
-                urgent={urgent}
-                overdue={overdue}
-                showMenuButton={false}
+          <div className="flex flex-col items-center" aria-label="Care progress">
+            <div className="w-full max-w-xs space-y-3">
+              <CareCard
+                label="Water"
+                Icon={Drop}
+                progress={waterProgress}
+                status={waterStatus}
+                onDone={handleWatered}
               />
-            </BaseCard>
-          ) : (
-            <p className="text-center text-gray-500">No tasks due.</p>
-          )}
+              <CareCard
+                label="Fertilize"
+                Icon={Sun}
+                progress={fertProgress}
+                status={fertStatus}
+                onDone={handleFertilized}
+              />
+            </div>
+            <p className="text-xs text-gray-500 dark:text-gray-400" data-testid="progress-hint">
+              Progress toward next scheduled care
+            </p>
+          </div>
         </div>
       ),
     },
@@ -490,27 +494,6 @@ export default function PlantDetail() {
       <PageContainer className="relative text-left pt-0 space-y-3">
         <Toast />
 
-        <div className="flex flex-col items-center mt-4" aria-label="Care progress">
-          <div className="w-full max-w-xs space-y-3">
-            <CareCard
-              label="Water"
-              Icon={Drop}
-              progress={waterProgress}
-              status={waterStatus}
-              onDone={handleWatered}
-            />
-            <CareCard
-              label="Fertilize"
-              Icon={Sun}
-              progress={fertProgress}
-              status={fertStatus}
-              onDone={handleFertilized}
-            />
-          </div>
-          <p className="text-xs text-gray-500 dark:text-gray-400" data-testid="progress-hint">
-            Progress toward next scheduled care
-          </p>
-        </div>
         <div className="space-y-3">
           <DetailTabs tabs={tabs} />
         </div>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -27,7 +27,9 @@ test('renders plant details without duplicates', () => {
   expect(images).toHaveLength(1)
 
   // Care tab is active by default
-  expect(screen.getByText(/no tasks due/i)).toBeInTheDocument()
+  expect(
+    screen.getByText(/progress toward next scheduled care/i)
+  ).toBeInTheDocument()
 
   const subHeadings = screen.queryAllByRole('heading', { level: 4 })
   expect(subHeadings).toHaveLength(0)
@@ -214,7 +216,6 @@ test('care tab hides kebab menu for due tasks', () => {
     </SnackbarProvider>
   )
 
-  expect(screen.queryByText(/no tasks due/i)).toBeNull()
   expect(screen.queryByRole('button', { name: /open task menu/i })).toBeNull()
   jest.useRealTimers()
 })


### PR DESCRIPTION
## Summary
- move care progress indicators inside the Care tab
- remove due task card from the Care tab
- update PlantDetail tests

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c7f92ad1883248b8db890427a3b7f