### PR TITLE
Improve Plant detail hero and care card UI

### DIFF
--- a/src/components/CareCard.jsx
+++ b/src/components/CareCard.jsx
@@ -1,10 +1,19 @@
-import React from 'react'
+import React, { useState } from 'react'
 
 export default function CareCard({ label, Icon, progress = 0, status, onDone }) {
+  const [completed, setCompleted] = useState(false)
   const pct = Math.min(Math.max(progress, 0), 1)
   const width = `${pct * 100}%`
+  const handleDone = () => {
+    if (!onDone) return
+    setCompleted(true)
+    setTimeout(() => {
+      onDone()
+      setCompleted(false)
+    }, 200)
+  }
   return (
-    <div className="bg-white dark:bg-gray-700 rounded-2xl shadow p-4 space-y-2" data-testid="care-card">
+    <div className={`bg-white dark:bg-gray-700 rounded-2xl shadow p-4 space-y-2 ${completed ? 'swipe-left-out' : ''}`} data-testid="care-card">
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           {Icon && <Icon className="w-5 h-5" aria-hidden="true" />}
@@ -13,8 +22,8 @@ export default function CareCard({ label, Icon, progress = 0, status, onDone }) 
         {onDone && (
           <button
             type="button"
-            onClick={onDone}
-            className="text-sm font-medium text-green-700 bg-green-100 hover:bg-green-200 rounded px-2 py-1"
+            onClick={handleDone}
+            className="text-sm font-semibold text-white bg-green-600 hover:bg-green-700 rounded shadow px-3 py-1 transition"
           >
             Mark as Done
           </button>

--- a/src/components/DetailTabs.jsx
+++ b/src/components/DetailTabs.jsx
@@ -27,10 +27,10 @@ export default function DetailTabs({ tabs = [], value, onChange, className = '' 
               role="tab"
               aria-selected={isActive}
               onClick={() => handleClick(tab.id)}
-              className={`px-3 py-1 text-sm border-b-2 focus:outline-none ${
+              className={`px-3 py-1 border-b-2 focus:outline-none ${
                 isActive
-                  ? 'border-green-600 font-semibold'
-                  : 'border-transparent text-gray-500'
+                  ? 'border-green-600 font-semibold text-base'
+                  : 'border-transparent text-gray-500 text-sm'
               }`}
             >
               {tab.label}

--- a/src/index.css
+++ b/src/index.css
@@ -292,6 +292,11 @@ body {
   @apply absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent;
 }
 
+/* Gradient backdrop for hero text */
+.hero-name-bg {
+  @apply bg-gradient-to-r from-black/70 via-black/40 to-transparent rounded-xl p-2;
+}
+
 @layer utilities {
   .text-heading {
     @apply text-2xl;

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -32,6 +32,7 @@ import PlantDetailFab from '../components/PlantDetailFab.jsx'
 import DetailTabs from '../components/DetailTabs.jsx'
 import BaseCard from '../components/BaseCard.jsx'
 import UnifiedTaskCard from '../components/UnifiedTaskCard.jsx'
+import usePlantFact from '../hooks/usePlantFact.js'
 
 import useToast from "../hooks/useToast.jsx"
 import confetti from 'canvas-confetti'
@@ -64,6 +65,7 @@ export default function PlantDetail() {
     updatePlant,
   } = usePlants()
   const plant = plants.find(p => p.id === Number(id))
+  const { fact } = usePlantFact(plant?.name)
   const navigate = useNavigate()
   const location = useLocation()
   const from = location.state?.from
@@ -363,7 +365,7 @@ export default function PlantDetail() {
       content: (
         <div className="space-y-4 p-4">
           {(plant.photos || []).length > 0 && (
-            <h3 className="text-heading font-semibold">Recent Photos</h3>
+            <h3 className="text-heading font-semibold mb-2">Recent Photos</h3>
           )}
           {(plant.photos || []).length === 0 && (
             <p className="py-10 text-center text-sm text-gray-500 dark:text-gray-400">
@@ -480,11 +482,16 @@ export default function PlantDetail() {
             </button>
           </div>
           <div className="absolute bottom-2 left-3 right-3 flex flex-col sm:flex-row justify-between text-white drop-shadow space-y-1 sm:space-y-0">
-            <div>
-              <h2 className="text-heading font-extrabold font-headline animate-fade-in-down">{plant.name}</h2>
+            <div className="hero-name-bg">
+              <h2 className="text-3xl font-extrabold font-headline animate-fade-in-down">{plant.name}</h2>
               {plant.nickname && (
                 <p className="text-sm text-gray-200 animate-fade-in-down" style={{ animationDelay: '100ms' }}>
                   {plant.nickname}
+                </p>
+              )}
+              {fact && (
+                <p className="text-sm italic text-gray-100 animate-fade-in-down" style={{ animationDelay: '200ms' }}>
+                  {fact}
                 </p>
               )}
             </div>


### PR DESCRIPTION
## Summary
- add hero overlay for plant name with factoid and larger text
- make `Mark as Done` button bolder and animate care card away
- enlarge active detail tab font
- tweak gallery heading spacing
- add CSS utility for hero name gradient

## Testing
- `npm test` *(fails: `npm` not found)*

------
https://chatgpt.com/codex/tasks/task_e_687c829e679483249d9bce77bd589591