### PR TITLE
Add plant fact snippet

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,1 +1,2 @@
 VITE_WEATHER_API_KEY=your_key_here
+VITE_OPENAI_API_KEY=

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Visit `/gallery` to see all of your photos in one place. This page currently onl
 Lisa can display local weather data and suggest when to water
 your plants. The app retrieves current conditions from OpenWeather
 using an API key you provide.
-A `.env.example` file is included at the project root and lists the required environment variable.
+A `.env.example` file is included at the project root and lists the environment variables.
 You can change the city and switch between Fahrenheit and Celsius from the **Settings** page.
 
 ### Get an API Key
@@ -60,6 +60,7 @@ You can change the city and switch between Fahrenheit and Celsius from the **Set
 1. Sign up at [OpenWeather](https://openweathermap.org/api) and create a key.
 2. Copy `.env.example` to `.env` in the project root and replace `your_key_here`
    with your actual API key.
+3. (Optional) Add `VITE_OPENAI_API_KEY` to enable featured plant facts.
 
 ### How It Works
 
@@ -69,9 +70,22 @@ temperature and conditions.
 
 ### Viewing Suggestions
 
-Run the dev server with `npm run dev` after adding your key. Open the
-app in your browser to see weather info and watering suggestions on the
+Run the dev server with `npm run dev` after adding your key. For the optional
+plant facts feature you'll also need a small API server:
+
+```bash
+npm run server
+```
+
+Open the app in your browser to see weather info and watering suggestions on the
 home screen.
+
+## Plant Facts (Optional)
+
+Provide an OpenAI API key in `.env` as `VITE_OPENAI_API_KEY` to display a short
+fact about the featured plant. The app calls `/api/plant-fact?name=<plant>` which
+uses GPT with a Wikipedia fallback. If the key is missing or the request fails,
+the server returns a short summary from Wikipedia instead.
 
 ## Running Tests
 

--- a/api/__tests__/plantFact.test.js
+++ b/api/__tests__/plantFact.test.js
@@ -1,0 +1,26 @@
+let getPlantFact
+
+beforeEach(() => {
+  jest.resetModules()
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ extract: 'Test fact. Second' }) })
+  )
+  ;({ getPlantFact } = require('../plantFact.js'))
+})
+
+afterEach(() => {
+  global.fetch.mockClear()
+})
+
+test('returns fact from wikipedia when OpenAI key missing', async () => {
+  const fact = await getPlantFact('Rose')
+  expect(fact).toBe('Test fact')
+  expect(global.fetch).toHaveBeenCalled()
+})
+
+test('caches repeated lookups', async () => {
+  global.fetch.mockClear()
+  await getPlantFact('Rose')
+  await getPlantFact('Rose')
+  expect(global.fetch).toHaveBeenCalledTimes(1)
+})

--- a/api/plantFact.js
+++ b/api/plantFact.js
@@ -1,0 +1,61 @@
+const cache = new Map()
+
+export async function getPlantFact(name) {
+  const key = name.toLowerCase()
+  if (cache.has(key)) return cache.get(key)
+
+  let fact = ''
+  const openaiKey = process.env.VITE_OPENAI_API_KEY || process.env.OPENAI_API_KEY
+  if (openaiKey) {
+    try {
+      const prompt = `Give me a short fun or cultural fact about the plant "${name}". One sentence.`
+      const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          Authorization: `Bearer ${openaiKey}`,
+        },
+        body: JSON.stringify({
+          model: 'gpt-4o',
+          messages: [{ role: 'user', content: prompt }],
+          temperature: 0.7,
+        }),
+      })
+      if (res.ok) {
+        const data = await res.json()
+        fact = data?.choices?.[0]?.message?.content?.trim() || ''
+      }
+    } catch (err) {
+      console.error('OpenAI error', err)
+    }
+  }
+
+  if (!fact) {
+    try {
+      const url = `https://en.wikipedia.org/api/rest_v1/page/summary/${encodeURIComponent(name)}`
+      const res = await fetch(url)
+      if (res.ok) {
+        const data = await res.json()
+        fact = data.extract?.split(/\.\s/)[0]?.trim() || ''
+      }
+    } catch (err) {
+      console.error('Wiki error', err)
+    }
+  }
+
+  if (fact) {
+    cache.set(key, fact)
+  }
+  return fact
+}
+
+export default async function plantFactHandler(req, res) {
+  const name = req.query.name
+  if (!name) return res.status(400).json({ error: 'name required' })
+  const fact = await getPlantFact(name)
+  if (fact) {
+    res.json({ fact })
+  } else {
+    res.status(500).json({ error: 'Failed to fetch fact' })
+  }
+}

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build",
     "preview": "vite preview",
     "test": "jest",
-    "lint": "eslint -c .eslintrc.json src"
+    "lint": "eslint -c .eslintrc.json src",
+    "server": "node server.js"
   },
   "dependencies": {
     "canvas-confetti": "^1.9.3",

--- a/server.js
+++ b/server.js
@@ -1,0 +1,13 @@
+import express from 'express'
+import plantFactHandler from './api/plantFact.js'
+
+const app = express()
+
+app.get('/api/plant-fact', (req, res) => {
+  plantFactHandler(req, res)
+})
+
+const port = process.env.PORT || 3000
+app.listen(port, () => {
+  console.log(`Server running on port ${port}`)
+})

--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -14,6 +14,7 @@ import {
 
 
 import useINatPhoto from '../hooks/useINatPhoto.js'
+import usePlantFact from '../hooks/usePlantFact.js'
 import { createRipple } from '../utils/interactions.js'
 
 
@@ -69,6 +70,7 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
     (plant.photos && plant.photos[0]?.src) ||
     plant.image ||
     placeholder?.src
+  const { fact } = usePlantFact(name)
 
   return (
     <Link
@@ -110,6 +112,9 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
               />
             )}
           </div>
+        )}
+        {fact && (
+          <p className="text-sm italic text-white/90 max-w-prose">{fact}</p>
         )}
         {/* Action buttons were removed to keep the card minimal */}
 

--- a/src/components/__tests__/FeaturedCard.test.jsx
+++ b/src/components/__tests__/FeaturedCard.test.jsx
@@ -54,3 +54,17 @@ test('arrow keys change plant', () => {
   fireEvent.keyDown(card, { key: 'ArrowLeft' })
   expect(screen.getByText('Aloe')).toBeInTheDocument()
 })
+
+test('displays plant fact when loaded', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ fact: 'fun fact' }) })
+  )
+  render(
+    <MemoryRouter>
+      <FeaturedCard plants={plants} />
+    </MemoryRouter>
+  )
+  await screen.findByText('fun fact')
+  expect(global.fetch).toHaveBeenCalledWith('/api/plant-fact?name=Aloe')
+  global.fetch = undefined
+})

--- a/src/hooks/__tests__/usePlantFact.test.js
+++ b/src/hooks/__tests__/usePlantFact.test.js
@@ -1,0 +1,27 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import usePlantFact from '../usePlantFact.js'
+
+function Test({ name }) {
+  const { fact } = usePlantFact(name)
+  return <div>{fact || 'loading'}</div>
+}
+
+afterEach(() => {
+  global.fetch && (global.fetch = undefined)
+  localStorage.clear()
+})
+
+test('fetches fact from api and caches it', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve({ fact: 'fact' }) })
+  )
+  const { unmount } = render(<Test name="Aloe" />)
+  await waitFor(() => screen.getByText('fact'))
+  expect(global.fetch).toHaveBeenCalledWith('/api/plant-fact?name=Aloe')
+  // second call should use cache
+  global.fetch.mockClear()
+  unmount()
+  render(<Test name="Aloe" />)
+  await waitFor(() => screen.getByText('fact'))
+  expect(global.fetch).not.toHaveBeenCalled()
+})

--- a/src/hooks/usePlantFact.js
+++ b/src/hooks/usePlantFact.js
@@ -1,0 +1,46 @@
+import { useEffect, useState } from 'react'
+
+export default function usePlantFact(name) {
+  const [fact, setFact] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!name) return
+    const key = `plantFact_${name.toLowerCase()}`
+    const cached =
+      typeof localStorage !== 'undefined' && localStorage.getItem(key)
+    if (cached) {
+      setFact(cached)
+      return
+    }
+
+    let aborted = false
+    async function fetchFact() {
+      setLoading(true)
+      try {
+        const res = await fetch(`/api/plant-fact?name=${encodeURIComponent(name)}`)
+        if (!res.ok) throw new Error('fact fetch failed')
+        const data = await res.json()
+        const text = data.fact
+        if (text && !aborted) {
+          setFact(text)
+          if (typeof localStorage !== 'undefined') {
+            localStorage.setItem(key, text)
+          }
+        }
+      } catch (err) {
+        console.error(err)
+        if (!aborted) setError('Failed to load fact')
+      } finally {
+        if (!aborted) setLoading(false)
+      }
+    }
+    fetchFact()
+    return () => {
+      aborted = true
+    }
+  }, [name])
+
+  return { fact, error, loading }
+}

--- a/vite.config.js
+++ b/vite.config.js
@@ -9,6 +9,7 @@ export default defineConfig(({ mode }) => {
     base: basePath,
     define: {
       'process.env.VITE_WEATHER_API_KEY': JSON.stringify(env.VITE_WEATHER_API_KEY),
+      'process.env.VITE_OPENAI_API_KEY': JSON.stringify(env.VITE_OPENAI_API_KEY),
       'process.env.VITE_BASE_PATH': JSON.stringify(basePath),
       'import.meta.env.VITE_BASE_PATH': JSON.stringify(basePath),
     },


### PR DESCRIPTION
## Summary
- expose `VITE_OPENAI_API_KEY` in vite config and `.env.example`
- fetch plant facts from `/api/plant-fact` with GPT then Wikipedia fallback
- display fact snippet in `FeaturedCard`
- document optional plant facts feature and server setup
- test new API and hook

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687c7e28b3e083249bd032bfc09e49bf