### PR TITLE
Add API proxy config and update dev docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,11 +97,17 @@ npm install
 ```
 
 ## Running the Dev Server
+Start the Express API in one terminal:
+```bash
+npm run server
+```
+Then run Vite in another terminal:
 ```bash
 npm run dev
 ```
-This command prints a local development URL (usually `http://localhost:5173/`).
-Open that URL in your browser to view the app.
+The dev server prints a local URL (usually `http://localhost:5173/`). Requests to
+`/api/plant-fact` are automatically forwarded to the Express server running on
+`http://localhost:3000`.
 
 ## Building for Production
 

--- a/src/hooks/__tests__/usePlantFact.test.js
+++ b/src/hooks/__tests__/usePlantFact.test.js
@@ -14,7 +14,7 @@ afterEach(() => {
 
 test('fetches fact from OpenAI when key provided', async () => {
   process.env.VITE_OPENAI_API_KEY = 'key'
-  global.fetch = jest.fn(url =>
+  global.fetch = jest.fn(() =>
     Promise.resolve({
       ok: true,
       json: () =>
@@ -31,8 +31,8 @@ test('fetches fact from OpenAI when key provided', async () => {
 
 test('falls back to wikipedia summary', async () => {
   process.env.VITE_OPENAI_API_KEY = 'key'
-  global.fetch = jest.fn(url => {
-    if (url.includes('openai')) {
+  global.fetch = jest.fn(requestUrl => {
+    if (requestUrl.includes('openai')) {
       return Promise.resolve({ ok: false })
     }
     return Promise.resolve({

--- a/vite.config.js
+++ b/vite.config.js
@@ -14,5 +14,10 @@ export default defineConfig(({ mode }) => {
       'import.meta.env.VITE_BASE_PATH': JSON.stringify(basePath),
     },
     plugins: [react()],
+    server: {
+      proxy: {
+        '/api': 'http://localhost:3000',
+      },
+    },
   }
 })


### PR DESCRIPTION
## Summary
- forward `/api` requests to the Express backend via Vite
- clarify that both Express and Vite servers should run during development
- fix lint warning in `usePlantFact` test

## Testing
- `npm test --silent` *(fails: CareCard test)*
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_687c888591a8832492954bba37018f5a