### PR TITLE
Set Needs Love as default plant view

### DIFF
--- a/src/components/__tests__/CareCard.test.jsx
+++ b/src/components/__tests__/CareCard.test.jsx
@@ -11,8 +11,11 @@ test('renders label, status and progress width', () => {
 })
 
 test('calls handler when done', () => {
+  jest.useFakeTimers()
   const onDone = jest.fn()
   render(<CareCard label="Water" Icon={Drop} progress={0} status="Today" onDone={onDone} />)
   fireEvent.click(screen.getByRole('button', { name: /mark as done/i }))
+  jest.advanceTimersByTime(250)
   expect(onDone).toHaveBeenCalled()
+  jest.useRealTimers()
 })

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -19,7 +19,7 @@ export default function MyPlants() {
   const { rooms } = useRooms()
   const { plants } = usePlants()
 
-  const [filter, setFilter] = useState('all')
+  const [filter, setFilter] = useState('love')
   const [query, setQuery] = useState('')
 
   const search = query.trim().toLowerCase()


### PR DESCRIPTION
## Summary
- default to the **Needs Love** filter when viewing all plants
- adjust `CareCard` test to use fake timers

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c88c3f1cc8324be900aeaaa5d0af2