### PR TITLE
Fix fetch reset logic in tests

### DIFF
--- a/src/__tests__/WeatherContext.test.jsx
+++ b/src/__tests__/WeatherContext.test.jsx
@@ -1,13 +1,18 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import { WeatherProvider } from '../WeatherContext.jsx'
 
+const originalFetch = global.fetch
+
 // Basic consumer component
 function Dummy() {
   return <div>child</div>
 }
 
+afterEach(() => {
+  global.fetch = originalFetch
+})
+
 test('shows error banner when fetch fails', async () => {
-  const origFetch = global.fetch
   const origKey = process.env.VITE_WEATHER_API_KEY
   process.env.VITE_WEATHER_API_KEY = 'key'
   global.fetch = jest.fn(() => Promise.reject(new Error('fail')))
@@ -24,6 +29,5 @@ test('shows error banner when fetch fails', async () => {
   expect(screen.getByRole('alert')).toHaveTextContent(/failed to load weather data/i)
   expect(screen.queryByText(/loading weather/i)).not.toBeInTheDocument()
 
-  global.fetch = origFetch
   process.env.VITE_WEATHER_API_KEY = origKey
 })

--- a/src/components/__tests__/CareCard.test.jsx
+++ b/src/components/__tests__/CareCard.test.jsx
@@ -11,8 +11,11 @@ test('renders label, status and progress width', () => {
 })
 
 test('calls handler when done', () => {
+  jest.useFakeTimers()
   const onDone = jest.fn()
   render(<CareCard label="Water" Icon={Drop} progress={0} status="Today" onDone={onDone} />)
   fireEvent.click(screen.getByRole('button', { name: /mark as done/i }))
+  jest.runAllTimers()
   expect(onDone).toHaveBeenCalled()
+  jest.useRealTimers()
 })

--- a/src/components/__tests__/FeaturedCard.test.jsx
+++ b/src/components/__tests__/FeaturedCard.test.jsx
@@ -2,6 +2,8 @@ import { render, screen, fireEvent } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import FeaturedCard from '../FeaturedCard.jsx'
 
+const originalFetch = global.fetch
+
 beforeAll(() => {
   if (typeof PointerEvent === 'undefined') {
     window.PointerEvent = window.MouseEvent
@@ -14,6 +16,10 @@ const plants = [
   { id: 1, name: 'Aloe', image: 'test.jpg', lastWatered: '2025-07-07', nextWater: '2025-07-10' },
   { id: 2, name: 'Pothos', image: 'test2.jpg', lastWatered: '2025-07-08', nextWater: '2025-07-11' },
 ]
+
+afterEach(() => {
+  global.fetch = originalFetch
+})
 
 test('shows featured label and care summary', () => {
   render(
@@ -72,6 +78,5 @@ test('displays plant fact when loaded', async () => {
     </MemoryRouter>
   )
   await screen.findByText('fun fact')
-  global.fetch = undefined
   delete process.env.VITE_OPENAI_API_KEY
 })

--- a/src/hooks/__tests__/useINatPhoto.test.js
+++ b/src/hooks/__tests__/useINatPhoto.test.js
@@ -1,10 +1,16 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import useINatPhoto from '../useINatPhoto.js'
 
+const originalFetch = global.fetch
+
 function Test() {
   const photo = useINatPhoto('aloe')
   return <div>{photo ? photo.src : 'loading'}</div>
 }
+
+afterEach(() => {
+  global.fetch = originalFetch
+})
 
 test('skips photos that fail to load', async () => {
   const searchData = {
@@ -24,7 +30,6 @@ test('skips photos that fail to load', async () => {
     ],
   }
   let call = 0
-  const origFetch = global.fetch
   global.fetch = jest.fn(() =>
     Promise.resolve({
       json: () =>
@@ -46,7 +51,6 @@ test('skips photos that fail to load', async () => {
   render(<Test />)
   await waitFor(() => screen.getByText('good.jpg'))
 
-  global.fetch = origFetch
   global.Image = origImage
 })
 
@@ -55,7 +59,6 @@ test('aborts fetch on unmount', async () => {
   const origAbortController = global.AbortController
   global.AbortController = jest.fn(() => ({ signal: 'sig', abort: abortMock }))
 
-  const origFetch = global.fetch
   global.fetch = jest.fn(() =>
     Promise.resolve({ json: () => Promise.resolve({ results: [] }) })
   )
@@ -75,6 +78,5 @@ test('aborts fetch on unmount', async () => {
   unmount()
   expect(abortMock).toHaveBeenCalled()
 
-  global.fetch = origFetch
   global.AbortController = origAbortController
 })

--- a/src/hooks/__tests__/usePlantFact.test.js
+++ b/src/hooks/__tests__/usePlantFact.test.js
@@ -1,13 +1,15 @@
 import { render, screen, waitFor } from '@testing-library/react'
 import usePlantFact from '../usePlantFact.js'
 
+const originalFetch = global.fetch
+
 function Test({ name }) {
   const { fact } = usePlantFact(name)
   return <div>{fact || 'loading'}</div>
 }
 
 afterEach(() => {
-  global.fetch && (global.fetch = undefined)
+  global.fetch = originalFetch
   delete process.env.VITE_OPENAI_API_KEY
   localStorage.clear()
 })


### PR DESCRIPTION
## Summary
- store the original `global.fetch` in tests that override it
- reset `global.fetch` back to the stored value after each test
- update `CareCard` test to use fake timers when verifying the done handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c8886379083249824983d6c19c71e