### PR TITLE
Add fertilizing status to room view

### DIFF
--- a/src/components/BalconyPlantCard.jsx
+++ b/src/components/BalconyPlantCard.jsx
@@ -38,6 +38,11 @@ export default function BalconyPlantCard({ plant }) {
           {plant.name}
         </h3>
         <p className="text-sm text-left">Last watered {formatDaysAgo(plant.lastWatered)}</p>
+        {plant.lastFertilized && (
+          <p className="text-sm text-left">
+            Last fertilized {formatDaysAgo(plant.lastFertilized)}
+          </p>
+        )}
         <div className="flex gap-1 flex-wrap">
           {plant.light && (
             <Badge

--- a/src/components/__tests__/BalconyPlantCard.test.jsx
+++ b/src/components/__tests__/BalconyPlantCard.test.jsx
@@ -1,0 +1,18 @@
+import { render, screen } from '@testing-library/react'
+import BalconyPlantCard from '../BalconyPlantCard.jsx'
+
+test('shows last fertilized info', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
+  const plant = {
+    id: 1,
+    name: 'Rose',
+    image: 'rose.jpg',
+    placeholderSrc: 'rose.jpg',
+    lastWatered: '2025-07-08',
+    nextWater: '2025-07-15',
+    lastFertilized: '2025-07-05'
+  }
+  render(<BalconyPlantCard plant={plant} />)
+  expect(screen.getByText(/last fertilized 5 days ago/i)).toBeInTheDocument()
+  jest.useRealTimers()
+})

--- a/src/components/__tests__/CareCard.test.jsx
+++ b/src/components/__tests__/CareCard.test.jsx
@@ -11,8 +11,13 @@ test('renders label, status and progress width', () => {
 })
 
 test('calls handler when done', () => {
+  jest.useFakeTimers()
   const onDone = jest.fn()
-  render(<CareCard label="Water" Icon={Drop} progress={0} status="Today" onDone={onDone} />)
+  render(
+    <CareCard label="Water" Icon={Drop} progress={0} status="Today" onDone={onDone} />
+  )
   fireEvent.click(screen.getByRole('button', { name: /mark as done/i }))
+  jest.runAllTimers()
   expect(onDone).toHaveBeenCalled()
+  jest.useRealTimers()
 })

--- a/src/pages/__tests__/RoomList.test.jsx
+++ b/src/pages/__tests__/RoomList.test.jsx
@@ -27,3 +27,22 @@ test('shows back link to All Plants', () => {
   const items = within(nav).getAllByRole('listitem')
   expect(items).toHaveLength(2)
 })
+
+test('displays last fertilized info for plants', () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
+  mockPlants = [
+    {
+      id: 1,
+      name: 'Rose',
+      room: 'Balcony',
+      image: 'rose.jpg',
+      placeholderSrc: 'rose.jpg',
+      lastWatered: '2025-07-08',
+      nextWater: '2025-07-15',
+      lastFertilized: '2025-07-05'
+    }
+  ]
+  renderWithRoute('/room/Balcony')
+  expect(screen.getByText(/last fertilized 5 days ago/i)).toBeInTheDocument()
+  jest.useRealTimers()
+})


### PR DESCRIPTION
## Summary
- show last fertilized date on plant cards in room view
- test BalconyPlantCard component rendering new fertilizing info
- verify fertilizing info appears in RoomList page
- adjust CareCard test to use fake timers for async handler

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c88e1599c8324afbbd9ef6d0a7eb4