### PR TITLE
Add size prop to PageContainer

### DIFF
--- a/src/components/PageContainer.jsx
+++ b/src/components/PageContainer.jsx
@@ -1,9 +1,22 @@
 import React from 'react'
 
-export default function PageContainer({ children, className = '', ...rest }) {
+const SIZE_CLASSES = {
+  md: 'max-w-md',
+  lg: 'max-w-lg',
+  xl: 'max-w-xl',
+  '2xl': 'max-w-2xl',
+}
+
+export default function PageContainer({
+  children,
+  className = '',
+  size = 'md',
+  ...rest
+}) {
+  const maxWidth = SIZE_CLASSES[size] || SIZE_CLASSES.md
   return (
     <div
-      className={`max-w-md mx-auto px-4 py-4 space-y-8 ${className}`.trim()}
+      className={`${maxWidth} mx-auto px-4 py-4 space-y-8 ${className}`.trim()}
       {...rest}
     >
       {children}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -498,7 +498,7 @@ export default function PlantDetail() {
           </div>
         </div>
       </div>
-      <PageContainer className="relative text-left pt-0 space-y-3">
+      <PageContainer size="xl" className="relative text-left pt-0 space-y-3">
         <Toast />
 
         <div className="space-y-3">


### PR DESCRIPTION
## Summary
- allow PageContainer to accept an optional `size` prop with Tailwind max-width mapping
- widen the PlantDetail page by passing `size="xl"`

## Testing
- `npm test` *(fails: 2 failed, 36 passed)*

------
https://chatgpt.com/codex/tasks/task_e_687c8922d3b483248488da75abda9a64