### PR TITLE
Add maxWidth prop to PageContainer

### DIFF
--- a/src/components/PageContainer.jsx
+++ b/src/components/PageContainer.jsx
@@ -1,9 +1,23 @@
 import React from 'react'
 
-export default function PageContainer({ children, className = '', ...rest }) {
+/**
+ * Wraps page content with consistent padding and a configurable max width.
+ *
+ * @param {object} props
+ * @param {React.ReactNode} props.children - Content to render inside the container
+ * @param {string} [props.maxWidth='xl'] - Tailwind max-w size (e.g. `md`, `lg`)
+ * @param {string} [props.className] - Additional classes
+ */
+export default function PageContainer({
+  children,
+  className = '',
+  maxWidth = 'xl',
+  ...rest
+}) {
+  const widthClass = maxWidth ? `max-w-${maxWidth}` : ''
   return (
     <div
-      className={`max-w-md mx-auto px-4 py-4 space-y-8 ${className}`.trim()}
+      className={`${widthClass} mx-auto px-4 py-4 space-y-8 ${className}`.trim()}
       {...rest}
     >
       {children}

--- a/src/pages/AddRoom.jsx
+++ b/src/pages/AddRoom.jsx
@@ -16,7 +16,7 @@ export default function AddRoom() {
   }
 
   return (
-    <PageContainer>
+    <PageContainer maxWidth="md">
     <form onSubmit={handleSubmit} className="space-y-4">
       <h1 className="text-heading font-bold font-headline">Add Room</h1>
       <div className="grid gap-1">

--- a/src/pages/EditPlant.jsx
+++ b/src/pages/EditPlant.jsx
@@ -49,7 +49,7 @@ export default function EditPlant() {
   }
 
   return (
-    <PageContainer>
+    <PageContainer maxWidth="md">
     <form onSubmit={handleSubmit} className="space-y-4">
       <h1 className="text-heading font-bold font-headline">Edit Plant</h1>
       <div className="grid gap-1">

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -42,7 +42,7 @@ export default function Settings() {
     : ''
 
   return (
-    <PageContainer className="space-y-6 text-gray-700 dark:text-gray-200">
+    <PageContainer maxWidth="md" className="space-y-6 text-gray-700 dark:text-gray-200">
       <Toast />
       <h1 className="text-heading font-semibold font-headline">Settings</h1>
 

--- a/src/pages/add/ImageStep.jsx
+++ b/src/pages/add/ImageStep.jsx
@@ -13,7 +13,7 @@ export default function ImageStep({ image, placeholder, dispatch, onNext, onBack
   }
 
   return (
-    <PageContainer>
+    <PageContainer maxWidth="md">
     <form onSubmit={e => {e.preventDefault(); onNext();}} className="space-y-4">
       <h1 className="text-heading font-bold font-headline">Add Plant</h1>
       <div className="grid gap-1">

--- a/src/pages/add/NameStep.jsx
+++ b/src/pages/add/NameStep.jsx
@@ -8,7 +8,7 @@ export default function NameStep({ name, dispatch, onNext }) {
   }, [])
 
   return (
-    <PageContainer>
+    <PageContainer maxWidth="md">
     <form onSubmit={e => {e.preventDefault(); onNext();}} className="space-y-4">
       <h1 className="text-heading font-bold font-headline">Add Plant</h1>
       <div className="grid gap-1">

--- a/src/pages/add/OptionalInfoStep.jsx
+++ b/src/pages/add/OptionalInfoStep.jsx
@@ -3,7 +3,7 @@ import PageContainer from "../../components/PageContainer.jsx"
 
 export default function OptionalInfoStep({ room, notes, careLevel, dispatch, onBack, onSubmit }) {
   return (
-    <PageContainer>
+    <PageContainer maxWidth="md">
     <form onSubmit={e => { e.preventDefault(); onSubmit(); }} className="space-y-4">
       <h1 className="text-heading font-bold font-headline">Add Plant</h1>
       <div className="grid gap-1">

--- a/src/pages/add/ScheduleStep.jsx
+++ b/src/pages/add/ScheduleStep.jsx
@@ -1,7 +1,7 @@
 import PageContainer from "../../components/PageContainer.jsx"
 export default function ScheduleStep({ lastWatered, nextWater, dispatch, onBack, onSubmit }) {
   return (
-    <PageContainer>
+    <PageContainer maxWidth="md">
     <form onSubmit={e => {e.preventDefault(); onSubmit();}} className="space-y-4">
       <h1 className="text-heading font-bold font-headline">Add Plant</h1>
       <div className="grid gap-1">


### PR DESCRIPTION
## Summary
- add a `maxWidth` prop to `PageContainer` and document it
- keep Settings and wizard pages narrow using `maxWidth="md"`
- adjust Add Room and Edit Plant pages to match

## Testing
- `npm test` *(fails: Wiki error fetch is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_687c892d65bc8324952c26968df17486