### PR TITLE
Configure Jest for JSX

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -5,4 +5,8 @@ module.exports = {
   moduleNameMapper: {
     '\\.(svg)$': '<rootDir>/__mocks__/fileMock.js',
   },
+  transform: {
+    '^.+\\.jsx?$': 'babel-jest',
+  },
+  transformIgnorePatterns: ['/node_modules/'],
 };

--- a/src/components/PageContainer.jsx
+++ b/src/components/PageContainer.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-<
 /**
  * Wraps page content with consistent padding and a configurable max width.
  *
@@ -19,25 +18,6 @@ export default function PageContainer({
   return (
     <div
       className={`${widthClass} mx-auto px-4 py-4 space-y-8 ${className}`.trim()}
-
-const SIZE_CLASSES = {
-  md: 'max-w-md',
-  lg: 'max-w-lg',
-  xl: 'max-w-xl',
-  '2xl': 'max-w-2xl',
-}
-
-export default function PageContainer({
-  children,
-  className = '',
-  size = 'md',
-  ...rest
-}) {
-  const maxWidth = SIZE_CLASSES[size] || SIZE_CLASSES.md
-  return (
-    <div
-      className={`${maxWidth} mx-auto px-4 py-4 space-y-8 ${className}`.trim()}
-
       {...rest}
     >
       {children}


### PR DESCRIPTION
## Summary
- add `babel-jest` transform
- restore `PageContainer` component after merge conflict

## Testing
- `npm test --silent` *(fails: Home.test.jsx getsByRole)*

------
https://chatgpt.com/codex/tasks/task_e_687c8e09a9f4832493a9e60e5026db29