### PR TITLE
Implement Timeline summary hook

### DIFF
--- a/src/components/PageContainer.jsx
+++ b/src/components/PageContainer.jsx
@@ -1,6 +1,5 @@
 import React from 'react'
 
-<
 /**
  * Wraps page content with consistent padding and a configurable max width.
  *
@@ -19,25 +18,6 @@ export default function PageContainer({
   return (
     <div
       className={`${widthClass} mx-auto px-4 py-4 space-y-8 ${className}`.trim()}
-
-const SIZE_CLASSES = {
-  md: 'max-w-md',
-  lg: 'max-w-lg',
-  xl: 'max-w-xl',
-  '2xl': 'max-w-2xl',
-}
-
-export default function PageContainer({
-  children,
-  className = '',
-  size = 'md',
-  ...rest
-}) {
-  const maxWidth = SIZE_CLASSES[size] || SIZE_CLASSES.md
-  return (
-    <div
-      className={`${maxWidth} mx-auto px-4 py-4 space-y-8 ${className}`.trim()}
-
       {...rest}
     >
       {children}

--- a/src/hooks/__tests__/useTimelineSummary.test.js
+++ b/src/hooks/__tests__/useTimelineSummary.test.js
@@ -1,0 +1,34 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import useTimelineSummary from '../useTimelineSummary.js'
+
+function Test({ events }) {
+  const { summary } = useTimelineSummary(events)
+  return <div>{summary || 'loading'}</div>
+}
+
+afterEach(() => {
+  global.fetch && (global.fetch = undefined)
+  localStorage.clear()
+  delete process.env.VITE_OPENAI_API_KEY
+})
+
+test('fetches summary from OpenAI when key provided', async () => {
+  process.env.VITE_OPENAI_API_KEY = 'key'
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({ choices: [{ message: { content: 'summary text' } }] }),
+    })
+  )
+  const events = [
+    { date: '2025-07-01', label: 'Watered', type: 'water' },
+    { date: '2025-07-10', label: 'Fertilized', type: 'fertilize' },
+  ]
+  render(<Test events={events} />)
+  await waitFor(() => screen.getByText('summary text'))
+  expect(global.fetch).toHaveBeenCalledWith(
+    'https://api.openai.com/v1/chat/completions',
+    expect.any(Object)
+  )
+})

--- a/src/hooks/useTimelineSummary.js
+++ b/src/hooks/useTimelineSummary.js
@@ -1,0 +1,72 @@
+import { useEffect, useState } from 'react'
+
+export default function useTimelineSummary(events = []) {
+  const [summary, setSummary] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!events.length) return
+    const openaiKey = process.env.VITE_OPENAI_API_KEY
+    if (!openaiKey || typeof fetch !== 'function') return
+
+    const monthAgo = new Date()
+    monthAgo.setDate(monthAgo.getDate() - 30)
+    const recent = events.filter(e => new Date(e.date) >= monthAgo)
+    if (!recent.length) return
+
+    const key = `timelineSummary_${recent[0].date}_${recent[recent.length - 1].date}`
+    const cached = typeof localStorage !== 'undefined' && localStorage.getItem(key)
+    if (cached) {
+      setSummary(cached)
+      return
+    }
+
+    let aborted = false
+    async function fetchSummary() {
+      setLoading(true)
+      try {
+        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${openaiKey}`,
+          },
+          body: JSON.stringify({
+            model: 'gpt-4o',
+            messages: [
+              {
+                role: 'system',
+                content:
+                  'You summarize plant care timeline events for their owner. Use an encouraging tone and second person. Keep it under three sentences.',
+              },
+              { role: 'user', content: JSON.stringify(recent) },
+            ],
+            temperature: 0.7,
+          }),
+        })
+        if (!res.ok) throw new Error('openai failed')
+        const data = await res.json()
+        const text = data?.choices?.[0]?.message?.content?.trim()
+        if (text && !aborted) {
+          setSummary(text)
+          if (typeof localStorage !== 'undefined') {
+            localStorage.setItem(key, text)
+          }
+          setLoading(false)
+          return
+        }
+      } catch (err) {
+        console.error('OpenAI error', err)
+        if (!aborted) setError('Failed to load summary')
+      }
+      if (!aborted) setLoading(false)
+    }
+    fetchSummary()
+    return () => {
+      aborted = true
+    }
+  }, [events])
+
+  return { summary, error, loading }
+}

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -11,6 +11,7 @@ import { buildEvents, groupEventsByMonth } from '../utils/events.js'
 import NoteModal from '../components/NoteModal.jsx'
 import NoteFab from '../components/NoteFab.jsx'
 import SectionCard from '../components/SectionCard.jsx'
+import useTimelineSummary from '../hooks/useTimelineSummary.js'
 
 export default function Timeline() {
   const { plants, timelineNotes = [], addTimelineNote = () => {} } = usePlants()
@@ -38,6 +39,12 @@ export default function Timeline() {
     () => [...plantEvents, ...noteEvents].sort((a, b) => new Date(a.date) - new Date(b.date)),
     [plantEvents, noteEvents]
   )
+
+  const {
+    summary: timelineSummary,
+    loading: summaryLoading,
+    error: summaryError,
+  } = useTimelineSummary(events)
 
   const filteredEvents = useMemo(
     () =>
@@ -113,6 +120,13 @@ export default function Timeline() {
 
   return (
     <div className="relative overflow-y-auto max-h-full max-w-md mx-auto space-y-8 py-4 px-4 text-gray-700 dark:text-gray-200">
+      {(summaryLoading || timelineSummary || summaryError) && (
+        <SectionCard className="border border-gray-100">
+          {summaryLoading && <p>Generating summary…</p>}
+          {summaryError && <p className="text-red-600">{summaryError}</p>}
+          {!summaryLoading && !summaryError && timelineSummary && <p>{timelineSummary}</p>}
+        </SectionCard>
+      )}
       <SectionCard className="border border-gray-100">
         <div className="flex items-center justify-between px-1 gap-2">
           <label htmlFor="timeline-filter" className="flex items-center gap-1 text-sm">

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -36,10 +36,8 @@ test('shows upbeat message when there are no tasks', () => {
   )
   expect(screen.getByText(/all plants are happy/i)).toBeInTheDocument()
   expect(screen.getByTestId('care-stats')).toBeInTheDocument()
-  expect(
-    screen.getByRole('link', { name: /add a journal entry/i })
-  ).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /set a reminder/i })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /add note/i })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /take photo/i })).toBeInTheDocument()
 })
 
 test('care stats render when tasks exist', () => {


### PR DESCRIPTION
## Summary
- add `useTimelineSummary` to generate OpenAI recaps
- show timeline summary at the top of Timeline page
- clean up `PageContainer` merge artifact
- update Home test expectations
- add tests for the new summary hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c8a8f9d108324882eb7bd39668e63