### PR TITLE
Add timeline summary hook

### DIFF
--- a/src/hooks/__tests__/useTimelineSummary.test.js
+++ b/src/hooks/__tests__/useTimelineSummary.test.js
@@ -1,0 +1,42 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import useTimelineSummary from '../useTimelineSummary.js'
+
+function Test({ events }) {
+  const { summary, error, loading } = useTimelineSummary(events)
+  return (
+    <div>
+      {loading && 'loading'}
+      {summary}
+      {error}
+    </div>
+  )
+}
+
+afterEach(() => {
+  global.fetch && (global.fetch = undefined)
+  delete process.env.VITE_OPENAI_API_KEY
+})
+
+test('fetches summary from OpenAI', async () => {
+  process.env.VITE_OPENAI_API_KEY = 'key'
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({ choices: [{ message: { content: 'hello summary' } }] }),
+    })
+  )
+  render(<Test events={[{ date: '2025-07-01', label: 'Watered', type: 'water' }]} />)
+  await waitFor(() => screen.getByText('hello summary'))
+  expect(global.fetch).toHaveBeenCalledWith(
+    'https://api.openai.com/v1/chat/completions',
+    expect.any(Object)
+  )
+})
+
+test('sets error on failure', async () => {
+  process.env.VITE_OPENAI_API_KEY = 'key'
+  global.fetch = jest.fn(() => Promise.resolve({ ok: false }))
+  render(<Test events={[{ date: '2025-07-01', label: 'Watered', type: 'water' }]} />)
+  await waitFor(() => screen.getByText('Failed to load summary'))
+})

--- a/src/hooks/useTimelineSummary.js
+++ b/src/hooks/useTimelineSummary.js
@@ -1,0 +1,64 @@
+import { useEffect, useState } from 'react'
+
+export default function useTimelineSummary(events) {
+  const [summary, setSummary] = useState('')
+  const [error, setError] = useState('')
+  const [loading, setLoading] = useState(false)
+
+  useEffect(() => {
+    if (!events || events.length === 0) return
+    if (typeof fetch !== 'function') return
+
+    let aborted = false
+    async function fetchSummary() {
+      setLoading(true)
+      setError('')
+      const openaiKey = process.env.VITE_OPENAI_API_KEY
+      if (!openaiKey) {
+        setLoading(false)
+        setError('Missing API key')
+        return
+      }
+      const cutoff = new Date()
+      cutoff.setMonth(cutoff.getMonth() - 1)
+      const recent = events.filter(e => new Date(e.date) >= cutoff)
+      try {
+        const res = await fetch('https://api.openai.com/v1/chat/completions', {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            Authorization: `Bearer ${openaiKey}`,
+          },
+          body: JSON.stringify({
+            model: 'gpt-4o',
+            messages: [
+              {
+                role: 'system',
+                content:
+                  'Summarize the recent plant care events in a friendly tone, for example: "Your Snake Plant has been thriving..."',
+              },
+              { role: 'user', content: JSON.stringify(recent) },
+            ],
+            temperature: 0.7,
+          }),
+        })
+        if (!res.ok) throw new Error('openai failed')
+        const data = await res.json()
+        const text = data?.choices?.[0]?.message?.content?.trim()
+        if (!aborted && text) setSummary(text)
+      } catch (err) {
+        console.error('OpenAI error', err)
+        if (!aborted) setError('Failed to load summary')
+      } finally {
+        if (!aborted) setLoading(false)
+      }
+    }
+
+    fetchSummary()
+    return () => {
+      aborted = true
+    }
+  }, [events])
+
+  return { summary, error, loading }
+}

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -11,6 +11,7 @@ import { buildEvents, groupEventsByMonth } from '../utils/events.js'
 import NoteModal from '../components/NoteModal.jsx'
 import NoteFab from '../components/NoteFab.jsx'
 import SectionCard from '../components/SectionCard.jsx'
+import useTimelineSummary from '../hooks/useTimelineSummary.js'
 
 export default function Timeline() {
   const { plants, timelineNotes = [], addTimelineNote = () => {} } = usePlants()
@@ -38,6 +39,8 @@ export default function Timeline() {
     () => [...plantEvents, ...noteEvents].sort((a, b) => new Date(a.date) - new Date(b.date)),
     [plantEvents, noteEvents]
   )
+
+  const { summary, loading: summaryLoading, error: summaryError } = useTimelineSummary(events)
 
   const filteredEvents = useMemo(
     () =>
@@ -113,6 +116,15 @@ export default function Timeline() {
 
   return (
     <div className="relative overflow-y-auto max-h-full max-w-md mx-auto space-y-8 py-4 px-4 text-gray-700 dark:text-gray-200">
+      {(summaryLoading || summary || summaryError) && (
+        <SectionCard className="border border-gray-100 text-sm">
+          {summaryLoading && <p>Loading summary…</p>}
+          {summary && <p>{summary}</p>}
+          {summaryError && (
+            <p role="alert" className="text-red-600">{summaryError}</p>
+          )}
+        </SectionCard>
+      )}
       <SectionCard className="border border-gray-100">
         <div className="flex items-center justify-between px-1 gap-2">
           <label htmlFor="timeline-filter" className="flex items-center gap-1 text-sm">


### PR DESCRIPTION
## Summary
- create `useTimelineSummary` hook to fetch OpenAI generated recap of recent events
- display summary on Timeline page
- cover new hook with tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687c92d7a1508324b04ecf4c275f5c41