### PR TITLE
Add automatic tagging for notes and photos

### DIFF
--- a/src/pages/Gallery.jsx
+++ b/src/pages/Gallery.jsx
@@ -53,6 +53,15 @@ export default function Gallery() {
               alt={photo.caption || `${photo.plant} photo ${i + 1}`}
               className="w-full aspect-[4/3] object-cover rounded-2xl"
             />
+            {photo.tags && photo.tags.length > 0 && (
+              <div className="flex flex-wrap gap-1 mt-1">
+                {photo.tags.map((t, idx) => (
+                  <span key={idx} className="inline-flex bg-gray-200 text-gray-800 rounded px-2 py-0.5 text-[10px]">
+                    {t}
+                  </span>
+                ))}
+              </div>
+            )}
           </button>
         ))}
       </div>

--- a/src/pages/Timeline.jsx
+++ b/src/pages/Timeline.jsx
@@ -30,6 +30,7 @@ export default function Timeline() {
         label: 'Note',
         note: n.text,
         type: 'log',
+        tags: n.tags || [],
       })),
     [timelineNotes]
   )
@@ -178,6 +179,15 @@ export default function Timeline() {
                           <span className="font-medium">— {e.label}</span>
                           {e.note && (
                             <div className="text-xs italic text-green-700 mt-1">{e.note}</div>
+                          )}
+                          {e.tags && e.tags.length > 0 && (
+                            <div className="flex flex-wrap gap-1 mt-1">
+                              {e.tags.map((t, idx) => (
+                                <span key={idx} className="inline-flex bg-gray-200 text-gray-800 rounded px-2 py-0.5 text-[10px]">
+                                  {t}
+                                </span>
+                              ))}
+                            </div>
                           )}
                         </div>
                       </button>

--- a/src/utils/__tests__/autoTag.test.js
+++ b/src/utils/__tests__/autoTag.test.js
@@ -1,0 +1,28 @@
+import autoTag from '../autoTag.js'
+
+afterEach(() => {
+  global.fetch && (global.fetch = undefined)
+  delete process.env.VITE_OPENAI_API_KEY
+})
+
+test('fetches tags from OpenAI', async () => {
+  process.env.VITE_OPENAI_API_KEY = 'key'
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({ choices: [{ message: { content: 'cat, plant' } }] }),
+    })
+  )
+  const tags = await autoTag('my note')
+  expect(global.fetch).toHaveBeenCalledWith(
+    'https://api.openai.com/v1/chat/completions',
+    expect.any(Object)
+  )
+  expect(tags).toEqual(['cat', 'plant'])
+})
+
+test('returns empty array when key missing', async () => {
+  const tags = await autoTag('text')
+  expect(tags).toEqual([])
+})

--- a/src/utils/autoTag.js
+++ b/src/utils/autoTag.js
@@ -1,0 +1,33 @@
+export default async function autoTag(text = '') {
+  const apiKey = process.env.VITE_OPENAI_API_KEY
+  if (!apiKey || !text) return []
+  try {
+    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: 'gpt-4o',
+        messages: [
+          {
+            role: 'user',
+            content: `Provide 3 short tags for: "${text}". Respond with a comma-separated list.`,
+          },
+        ],
+        temperature: 0.5,
+      }),
+    })
+    if (!res.ok) throw new Error('openai failed')
+    const data = await res.json()
+    const raw = data?.choices?.[0]?.message?.content || ''
+    return raw
+      .split(/[,\n]+/)
+      .map(t => t.trim().replace(/^#/, ''))
+      .filter(Boolean)
+  } catch (err) {
+    console.error('autoTag error', err)
+    return []
+  }
+}


### PR DESCRIPTION
## Summary
- create `autoTag` utility to fetch tags from OpenAI
- persist tags on timeline notes, care log entries and photos
- call autoTag when adding notes, logging events or uploading photos
- show tags in Timeline and Gallery views
- test the new utility and updated PlantContext logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c92897ba88324b7a4b3c8a937f1fe