### PR TITLE
Render FAB menus via portals

### DIFF
--- a/src/components/CreateFab.jsx
+++ b/src/components/CreateFab.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { NavLink } from 'react-router-dom'
 import { Plus, Leaf, Door, MagicWand } from 'phosphor-react'
 
@@ -27,45 +28,47 @@ export default function CreateFab() {
   }
 
   return (
-    <div className="fixed bottom-24 right-20 z-30">
-      {open && (
-        <div
-          className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Add menu"
-          onClick={() => setOpen(false)}
-        >
-          <ul
-            className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 grid grid-cols-2 gap-2 animate-fade-in-up"
-            onClick={e => e.stopPropagation()}
+    <>
+      {open &&
+        createPortal(
+          <div
+            className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Add menu"
+            onClick={() => setOpen(false)}
           >
-            <button
-              type="button"
-              aria-label="Close menu"
-              onClick={() => setOpen(false)}
-              className="absolute top-2 right-2 text-gray-500"
+            <ul
+              className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 grid grid-cols-2 gap-2 animate-fade-in-up"
+              onClick={e => e.stopPropagation()}
             >
-              &times;
-            </button>
-            {items.map(({ to, label, Icon, color }) => (
-              <li key={label}>
-                <NavLink
-                  to={to}
-                  onClick={() => setOpen(false)}
-                  title={label}
-                  className="flex items-center gap-4 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
-                >
-                  <span className={`p-2 rounded-full ${colorClasses[color].bg}`}>
-                    <Icon className={`w-5 h-5 ${colorClasses[color].text}`} aria-hidden="true" />
-                  </span>
-                  <span className="text-sm text-gray-800 dark:text-gray-200">{label}</span>
-                </NavLink>
-              </li>
-            ))}
-          </ul>
-        </div>
-      )}
+              <button
+                type="button"
+                aria-label="Close menu"
+                onClick={() => setOpen(false)}
+                className="absolute top-2 right-2 text-gray-500"
+              >
+                &times;
+              </button>
+              {items.map(({ to, label, Icon, color }) => (
+                <li key={label}>
+                  <NavLink
+                    to={to}
+                    onClick={() => setOpen(false)}
+                    title={label}
+                    className="flex items-center gap-4 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
+                  >
+                    <span className={`p-2 rounded-full ${colorClasses[color].bg}`}>
+                      <Icon className={`w-5 h-5 ${colorClasses[color].text}`} aria-hidden="true" />
+                    </span>
+                    <span className="text-sm text-gray-800 dark:text-gray-200">{label}</span>
+                  </NavLink>
+                </li>
+              ))}
+            </ul>
+          </div>,
+          document.body
+        )}
       <button
         type="button"
         onClick={() => setOpen(v => !v)}
@@ -73,10 +76,10 @@ export default function CreateFab() {
         title="Open create menu"
         aria-expanded={open}
         aria-haspopup="menu"
-        className={`bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
+        className={`fixed bottom-24 right-20 z-30 bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
       >
         <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
       </button>
-    </div>
+    </>
   )
 }

--- a/src/components/NoteFab.jsx
+++ b/src/components/NoteFab.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { Plus, Note } from 'phosphor-react'
 
 export default function NoteFab({ onAddNote }) {
@@ -14,46 +15,48 @@ export default function NoteFab({ onAddNote }) {
   }, [open])
 
   return (
-    <div className="absolute bottom-4 right-4 z-30">
-      {open && (
-        <div
-          className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
-          role="dialog"
-          aria-modal="true"
-          aria-label="Add menu"
-          onClick={() => setOpen(false)}
-        >
-          <ul
-            className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-4 animate-fade-in-up"
-            onClick={e => e.stopPropagation()}
+    <>
+      {open &&
+        createPortal(
+          <div
+            className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
+            role="dialog"
+            aria-modal="true"
+            aria-label="Add menu"
+            onClick={() => setOpen(false)}
           >
-            <button
-              type="button"
-              aria-label="Close menu"
-              onClick={() => setOpen(false)}
-              className="absolute top-2 right-2 text-gray-500"
+            <ul
+              className="modal-box relative bg-white/80 dark:bg-gray-800/80 backdrop-blur-lg rounded-2xl shadow-xl p-4 w-52 space-y-4 animate-fade-in-up"
+              onClick={e => e.stopPropagation()}
             >
-              &times;
-            </button>
-            <li>
               <button
                 type="button"
-                onClick={() => {
-                  setOpen(false)
-                  onAddNote?.()
-                }}
-                title="Add Note"
-                className="flex items-center gap-4 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
+                aria-label="Close menu"
+                onClick={() => setOpen(false)}
+                className="absolute top-2 right-2 text-gray-500"
               >
-                <span className="p-2 rounded-full bg-violet-100">
-                  <Note className="w-5 h-5 text-violet-600" aria-hidden="true" />
-                </span>
-                <span className="text-sm text-gray-800 dark:text-gray-200">Add Note</span>
+                &times;
               </button>
-            </li>
-          </ul>
-        </div>
-      )}
+              <li>
+                <button
+                  type="button"
+                  onClick={() => {
+                    setOpen(false)
+                    onAddNote?.()
+                  }}
+                  title="Add Note"
+                  className="flex items-center gap-4 w-full rounded-lg p-2 hover:bg-green-50 dark:hover:bg-gray-600 transition"
+                >
+                  <span className="p-2 rounded-full bg-violet-100">
+                    <Note className="w-5 h-5 text-violet-600" aria-hidden="true" />
+                  </span>
+                  <span className="text-sm text-gray-800 dark:text-gray-200">Add Note</span>
+                </button>
+              </li>
+            </ul>
+          </div>,
+          document.body
+        )}
       <button
         type="button"
         onClick={() => setOpen(v => !v)}
@@ -61,10 +64,10 @@ export default function NoteFab({ onAddNote }) {
         title="Open create menu"
         aria-expanded={open}
         aria-haspopup="menu"
-        className={`bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
+        className={`absolute bottom-4 right-4 z-30 bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
       >
         <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
       </button>
-    </div>
+    </>
   )
 }

--- a/src/components/PlantDetailFab.jsx
+++ b/src/components/PlantDetailFab.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react'
+import { createPortal } from 'react-dom'
 import { Plus, Image as ImageIcon, Note, Drop, Flower } from 'phosphor-react'
 
 export default function PlantDetailFab({
@@ -41,57 +42,59 @@ export default function PlantDetailFab({
   const labelText = plantName ? `Add to ${plantName}'s Journal` : 'Add to Journal'
 
   return (
-    <div className="absolute bottom-2 right-4 z-30 drop-shadow-md">
-      {open && (
-        <div
-          className="modal-overlay bg-black/50 z-30"
-          role="dialog"
-          aria-modal="true"
-          aria-label={labelText}
-          onClick={() => setOpen(false)}
-        >
+    <>
+      {open &&
+        createPortal(
           <div
-            className="modal-box relative p-4 w-80 max-w-full"
-            onClick={e => e.stopPropagation()}
+            className="modal-overlay bg-black/50 z-30"
+            role="dialog"
+            aria-modal="true"
+            aria-label={labelText}
+            onClick={() => setOpen(false)}
           >
-            <div className="flex items-center justify-between mb-3">
-              <span className="flex-1 text-center font-headline text-heading">
-                {labelText}
-              </span>
-              <button
-                type="button"
-                aria-label="Close menu"
-                onClick={() => setOpen(false)}
-                className="text-gray-500"
-              >
-                &times;
-              </button>
+            <div
+              className="modal-box relative p-4 w-80 max-w-full"
+              onClick={e => e.stopPropagation()}
+            >
+              <div className="flex items-center justify-between mb-3">
+                <span className="flex-1 text-center font-headline text-heading">
+                  {labelText}
+                </span>
+                <button
+                  type="button"
+                  aria-label="Close menu"
+                  onClick={() => setOpen(false)}
+                  className="text-gray-500"
+                >
+                  &times;
+                </button>
+              </div>
+              <ul className="grid grid-cols-2 gap-2">
+                {items.map(({ label, Icon, action, color }) => (
+                  <li key={label} className="list-none">
+                    <button
+                      type="button"
+                      onClick={() => {
+                        setOpen(false)
+                        action?.()
+                      }}
+                      title={label}
+                      className="flex flex-col items-center gap-2 w-full rounded-md px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-600 transition"
+                    >
+                      <span className={`p-2 rounded-full ${colorClasses[color].bg}`}>
+                        <Icon className={`w-5 h-5 ${colorClasses[color].text}`} aria-hidden="true" />
+                      </span>
+                      <span className="text-sm text-gray-800 dark:text-gray-200 text-center">
+                        {label}
+                      </span>
+                    </button>
+                  </li>
+                ))}
+              </ul>
             </div>
-            <ul className="grid grid-cols-2 gap-2">
-              {items.map(({ label, Icon, action, color }) => (
-                <li key={label} className="list-none">
-                  <button
-                    type="button"
-                    onClick={() => {
-                      setOpen(false)
-                      action?.()
-                    }}
-                    title={label}
-                    className="flex flex-col items-center gap-2 w-full rounded-md px-4 py-3 hover:bg-gray-100 dark:hover:bg-gray-600 transition"
-                  >
-                    <span className={`p-2 rounded-full ${colorClasses[color].bg}`}>
-                      <Icon className={`w-5 h-5 ${colorClasses[color].text}`} aria-hidden="true" />
-                    </span>
-                    <span className="text-sm text-gray-800 dark:text-gray-200 text-center">
-                      {label}
-                    </span>
-                  </button>
-                </li>
-              ))}
-            </ul>
-          </div>
-        </div>
-      )}
+          </div>,
+          document.body
+        )}
       <button
         type="button"
         onClick={() => setOpen(v => !v)}
@@ -99,10 +102,10 @@ export default function PlantDetailFab({
         title="Add to Journal"
         aria-expanded={open}
         aria-haspopup="menu"
-        className={`bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
+        className={`absolute bottom-2 right-4 z-30 drop-shadow-md bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
       >
         <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
       </button>
-    </div>
+    </>
   )
 }


### PR DESCRIPTION
## Summary
- import `createPortal` for CreateFab, NoteFab and PlantDetailFab
- render each FAB menu using a portal and position the button directly

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687c9637187c83248849d9ded1b215f3