### PR TITLE
Fix aborted request handling in weather context

### DIFF
--- a/src/WeatherContext.jsx
+++ b/src/WeatherContext.jsx
@@ -50,8 +50,10 @@ export function WeatherProvider({ children }) {
         }
       })
       .catch(err => {
-        console.error(err)
-        setError('Failed to load weather data')
+        if (err.name !== 'AbortError') {
+          console.error(err)
+          setError('Failed to load weather data')
+        }
       })
       .finally(() => {
         setLoading(false)


### PR DESCRIPTION
## Summary
- avoid logging and setting error state for aborted weather API requests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687c982513d88324b801063b775f1b7d