### PR TITLE
Add dotenv for server

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ Visit `/gallery` to see all of your photos in one place. This page currently onl
 Lisa can display local weather data and suggest when to water
 your plants. The app retrieves current conditions from OpenWeather
 using an API key you provide.
-A `.env.example` file is included at the project root and lists the environment variables.
+A `.env.example` file is included at the project root and lists the environment variables. The Express API automatically loads `.env` when you run `npm run server`.
 You can change the city and switch between Fahrenheit and Celsius from the **Settings** page.
 
 ### Get an API Key
@@ -60,7 +60,7 @@ You can change the city and switch between Fahrenheit and Celsius from the **Set
 1. Sign up at [OpenWeather](https://openweathermap.org/api) and create a key.
 2. Copy `.env.example` to `.env` in the project root and replace `your_key_here`
    with your actual API key.
-3. (Optional) Add `VITE_OPENAI_API_KEY` to enable featured plant facts.
+3. (Optional) Add `VITE_OPENAI_API_KEY` (or `OPENAI_API_KEY`) to enable featured plant facts, Coach, and Care Plan features.
 
 ### How It Works
 
@@ -76,8 +76,8 @@ home screen.
 
 ## Plant Facts (Optional)
 
-Provide an OpenAI API key in `.env` as `VITE_OPENAI_API_KEY` to display a short
-fact about the featured plant. If the key is missing or the request fails,
+Provide an OpenAI API key in `.env` as `VITE_OPENAI_API_KEY` (or `OPENAI_API_KEY`) to display a short
+fact about the featured plant. The same key is required for the Coach and Care Plan endpoints. If the key is missing or the request fails,
 Lisa falls back to a brief summary from Wikipedia.
 
 ## Running Tests
@@ -101,6 +101,7 @@ Start the Express API in one terminal:
 ```bash
 npm run server
 ```
+The server automatically loads environment variables from `.env`.
 Then run Vite in another terminal:
 ```bash
 npm run dev

--- a/api/server.js
+++ b/api/server.js
@@ -1,3 +1,4 @@
+import 'dotenv/config'
 import express from 'express'
 
 const app = express()

--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
       "dependencies": {
         "canvas-confetti": "^1.9.3",
         "clsx": "^2.1.1",
+        "dotenv": "^16.3.1",
         "express": "^4.21.2",
         "framer-motion": "^12.23.6",
         "phosphor-react": "^1.4.1",
@@ -5690,6 +5691,17 @@
       },
       "engines": {
         "node": ">=12"
+      }
+    },
+    "node_modules/dotenv": {
+      "version": "16.6.1",
+      "resolved": "https://registry.npmjs.org/dotenv/-/dotenv-16.6.1.tgz",
+      "integrity": "sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://dotenvx.com"
       }
     },
     "node_modules/dunder-proto": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^6.22.3",
-    "react-transition-group": "^4.4.5"
+    "react-transition-group": "^4.4.5",
+    "dotenv": "^16.3.1"
   },
   "devDependencies": {
     "@babel/preset-env": "^7.23.9",


### PR DESCRIPTION
## Summary
- add `dotenv` runtime dependency
- load `.env` automatically in `api/server.js`
- document OpenAI key requirements and auto `.env` loading in README

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687d5734ebe08324ac7baaa5d5be0546