### PR TITLE
Simplify Today's Tasks cards

### DIFF
--- a/src/components/SimpleTaskCard.jsx
+++ b/src/components/SimpleTaskCard.jsx
@@ -1,0 +1,24 @@
+import { Link } from 'react-router-dom'
+
+export default function SimpleTaskCard({ plant, label }) {
+  if (!plant) return null
+  return (
+    <Link
+      to={`/plant/${plant.id}`}
+      className="flex items-center gap-4 bg-white dark:bg-gray-700 border border-neutral-200 dark:border-gray-600 rounded-xl px-4 py-3 hover:bg-gray-50 dark:hover:bg-gray-600 transition"
+      data-testid="simple-task-card"
+    >
+      <img
+        src={plant.image}
+        alt={plant.name}
+        className="w-12 h-12 rounded-full object-cover"
+      />
+      <div className="min-w-0">
+        <h3 className="text-sm font-semibold text-gray-900 dark:text-gray-100 truncate">
+          {plant.name}
+        </h3>
+        {label && <p className="text-xs text-gray-500">{label}</p>}
+      </div>
+    </Link>
+  )
+}

--- a/src/components/TasksContainer.jsx
+++ b/src/components/TasksContainer.jsx
@@ -1,7 +1,7 @@
 import { Link } from 'react-router-dom'
 import { Note, Camera } from 'phosphor-react'
 import BaseCard from './BaseCard.jsx'
-import UnifiedTaskCard from './UnifiedTaskCard.jsx'
+import SimpleTaskCard from './SimpleTaskCard.jsx'
 
 export default function TasksContainer({ visibleTasks = [], happyPlant }) {
   return (
@@ -15,26 +15,23 @@ export default function TasksContainer({ visibleTasks = [], happyPlant }) {
         </div>
         <div className="space-y-2">
           {visibleTasks.length > 0 ? (
-            visibleTasks.map((group, i) => (
-              <BaseCard
-                key={group.plant.id}
-                variant="task"
-                className="animate-fade-in-up"
-                style={{ animationDelay: `${i * 50}ms` }}
-              >
-                <UnifiedTaskCard
-                  plant={{
-                    ...group.plant,
-                    dueWater: group.dueWater,
-                    dueFertilize: group.dueFertilize,
-                    lastCared: group.lastCared,
-                  }}
-                  urgent={group.urgent}
-                  overdue={group.overdue}
-                  showMenuButton={false}
-                />
-              </BaseCard>
-            ))
+            visibleTasks.map((group, i) => {
+              const label = group.overdue
+                ? 'Care overdue'
+                : group.urgent
+                ? 'Needs care today'
+                : 'Care due this week'
+              return (
+                <BaseCard
+                  key={group.plant.id}
+                  variant="task"
+                  className="animate-fade-in-up"
+                  style={{ animationDelay: `${i * 50}ms` }}
+                >
+                  <SimpleTaskCard plant={group.plant} label={label} />
+                </BaseCard>
+              )
+            })
           ) : (
             <div className="p-6 border border-[#E5ECE6] shadow-sm rounded-2xl text-center space-y-4">
               <div className="flex justify-center">

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -103,7 +103,7 @@ test('earliest due task appears first', () => {
       <Home />
   )
 
-  const tasks = screen.getAllByTestId('unified-task-card')
+  const tasks = screen.getAllByTestId('simple-task-card')
   expect(tasks[0]).toHaveTextContent('Plant A')
   expect(tasks[1]).toHaveTextContent('Plant B')
 })


### PR DESCRIPTION
## Summary
- add `SimpleTaskCard` for lightweight task display
- update `TasksContainer` to use the new card
- adjust homepage test for new task card element

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d6719898c8324b64d2f91561c9920