### PR TITLE
Add OpenAI feature toggle

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,8 @@ home screen.
 Provide an OpenAI API key in `.env` as `VITE_OPENAI_API_KEY` (or `OPENAI_API_KEY`) to display a short
 fact about the featured plant. The same key is required for the Coach and Care Plan endpoints. If the key is missing or the request fails,
 Lisa falls back to a brief summary from Wikipedia.
+You can enable or disable these features from the **Settings → Preferences** page.
+Requests to the OpenAI API may incur charges.
 
 ## Running Tests
 

--- a/src/OpenAIContext.jsx
+++ b/src/OpenAIContext.jsx
@@ -1,0 +1,35 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const OpenAIContext = createContext()
+
+export function OpenAIProvider({ children }) {
+  const [enabled, setEnabled] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('openai_enabled')
+      if (stored != null) return stored === 'true'
+    }
+    return !!process.env.VITE_OPENAI_API_KEY
+  })
+
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('openai_enabled', enabled)
+    }
+  }, [enabled])
+
+  return (
+    <OpenAIContext.Provider value={{ enabled, setEnabled }}>
+      {children}
+    </OpenAIContext.Provider>
+  )
+}
+
+export const useOpenAI = () => useContext(OpenAIContext)
+
+export function getOpenAIEnabled() {
+  if (typeof localStorage !== 'undefined') {
+    const stored = localStorage.getItem('openai_enabled')
+    if (stored != null) return stored === 'true'
+  }
+  return !!process.env.VITE_OPENAI_API_KEY
+}

--- a/src/hooks/useCarePlan.js
+++ b/src/hooks/useCarePlan.js
@@ -1,11 +1,17 @@
 import { useState } from 'react'
+import { useOpenAI } from '../OpenAIContext.jsx'
 
 export default function useCarePlan() {
   const [plan, setPlan] = useState(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState('')
+  const { enabled } = useOpenAI()
 
   const generate = async details => {
+    if (!enabled) {
+      setError('Missing API key')
+      return
+    }
     setLoading(true)
     setError('')
     try {

--- a/src/hooks/usePlantCoach.js
+++ b/src/hooks/usePlantCoach.js
@@ -1,4 +1,5 @@
 import { useEffect, useState } from 'react'
+import { useOpenAI } from '../OpenAIContext.jsx'
 import { usePlants } from '../PlantContext.jsx'
 import { useWeather } from '../WeatherContext.jsx'
 
@@ -14,9 +15,14 @@ export default function usePlantCoach(question, plantId) {
   const [answer, setAnswer] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const { enabled } = useOpenAI()
 
   useEffect(() => {
     if (!question || !plant) return
+    if (!enabled) {
+      setError('Missing API key')
+      return
+    }
     let aborted = false
 
     async function fetchAnswer() {
@@ -46,7 +52,7 @@ export default function usePlantCoach(question, plantId) {
     return () => {
       aborted = true
     }
-  }, [question, plant, forecast])
+  }, [question, plant, forecast, enabled])
 
   return { answer, error, loading }
 }

--- a/src/hooks/usePlantFact.js
+++ b/src/hooks/usePlantFact.js
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react'
+import { useOpenAI } from '../OpenAIContext.jsx'
 
 export default function usePlantFact(name) {
   const [fact, setFact] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const { enabled } = useOpenAI()
 
   useEffect(() => {
     if (!name) return
@@ -23,7 +25,7 @@ export default function usePlantFact(name) {
         setError('Failed to load fact')
         return
       }
-      const openaiKey = process.env.VITE_OPENAI_API_KEY
+      const openaiKey = enabled ? process.env.VITE_OPENAI_API_KEY : null
       try {
         if (openaiKey) {
           const prompt = `Give me a short fun or cultural fact about the plant "${name}". One sentence.`
@@ -80,7 +82,7 @@ export default function usePlantFact(name) {
     return () => {
       aborted = true
     }
-  }, [name])
+  }, [name, enabled])
 
   return { fact, error, loading }
 }

--- a/src/hooks/useTimelineSummary.js
+++ b/src/hooks/useTimelineSummary.js
@@ -1,9 +1,11 @@
 import { useEffect, useState } from 'react'
+import { useOpenAI } from '../OpenAIContext.jsx'
 
 export default function useTimelineSummary(events) {
   const [summary, setSummary] = useState('')
   const [error, setError] = useState('')
   const [loading, setLoading] = useState(false)
+  const { enabled } = useOpenAI()
 
   useEffect(() => {
     if (!events || events.length === 0) return
@@ -13,7 +15,7 @@ export default function useTimelineSummary(events) {
     async function fetchSummary() {
       setLoading(true)
       setError('')
-      const openaiKey = process.env.VITE_OPENAI_API_KEY
+      const openaiKey = enabled ? process.env.VITE_OPENAI_API_KEY : null
       if (!openaiKey) {
         setLoading(false)
         setError('Missing API key')
@@ -58,7 +60,7 @@ export default function useTimelineSummary(events) {
     return () => {
       aborted = true
     }
-  }, [events])
+  }, [events, enabled])
 
   return { summary, error, loading }
 }

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -7,6 +7,7 @@ import { RoomProvider } from './RoomContext.jsx'
 import { ThemeProvider } from './ThemeContext.jsx'
 import { WeatherProvider } from './WeatherContext.jsx'
 import { UserProvider } from './UserContext.jsx'
+import { OpenAIProvider } from './OpenAIContext.jsx'
 import SnackbarProvider, { Snackbar } from './hooks/SnackbarProvider.jsx'
 import './index.css'
 
@@ -14,18 +15,20 @@ ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
     <SnackbarProvider>
       <UserProvider>
-        <ThemeProvider>
-          <WeatherProvider>
-            <PlantProvider>
-              <RoomProvider>
-                <BrowserRouter basename={import.meta.env.VITE_BASE_PATH}>
-                  <App />
-                </BrowserRouter>
-              </RoomProvider>
-            </PlantProvider>
-            <Snackbar />
-          </WeatherProvider>
-        </ThemeProvider>
+        <OpenAIProvider>
+          <ThemeProvider>
+            <WeatherProvider>
+              <PlantProvider>
+                <RoomProvider>
+                  <BrowserRouter basename={import.meta.env.VITE_BASE_PATH}>
+                    <App />
+                  </BrowserRouter>
+                </RoomProvider>
+              </PlantProvider>
+              <Snackbar />
+            </WeatherProvider>
+          </ThemeProvider>
+        </OpenAIProvider>
       </UserProvider>
     </SnackbarProvider>
   </React.StrictMode>

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -1,6 +1,7 @@
 import { useTheme } from '../ThemeContext.jsx'
 import { useWeather } from '../WeatherContext.jsx'
 import { useUser } from '../UserContext.jsx'
+import { useOpenAI } from '../OpenAIContext.jsx'
 
 import { User, MapPin, Clock } from 'phosphor-react'
 import Panel from '../components/Panel.jsx'
@@ -15,11 +16,17 @@ export default function Settings() {
   const { theme, toggleTheme } = useTheme()
   const { location, setLocation, units, setUnits, forecast } = useWeather()
   const { username, setUsername, timeZone, setTimeZone } = useUser()
+  const { enabled, setEnabled } = useOpenAI()
   const { Toast, showToast } = useToast()
 
   const handleThemeToggle = checked => {
     toggleTheme()
     showToast(checked ? 'Dark mode enabled' : 'Light mode enabled')
+  }
+
+  const handleOpenAIToggle = checked => {
+    setEnabled(checked)
+    showToast(checked ? 'AI features enabled' : 'AI features disabled')
   }
 
   const handleReset = () => {
@@ -125,6 +132,11 @@ export default function Settings() {
               checked={theme === 'dark'}
               onChange={handleThemeToggle}
               label="🌙 Enable Dark Mode for a softer nighttime experience"
+            />
+            <ToggleSwitch
+              checked={enabled}
+              onChange={handleOpenAIToggle}
+              label="🤖 Enable AI-powered features"
             />
           </div>
           <button

--- a/src/utils/autoTag.js
+++ b/src/utils/autoTag.js
@@ -1,5 +1,8 @@
+import { getOpenAIEnabled } from '../OpenAIContext.jsx'
+
 export default async function autoTag(text = '') {
-  const apiKey = process.env.VITE_OPENAI_API_KEY
+  const enabled = getOpenAIEnabled()
+  const apiKey = enabled ? process.env.VITE_OPENAI_API_KEY : null
   if (!apiKey || !text) return []
   try {
     const res = await fetch('https://api.openai.com/v1/chat/completions', {


### PR DESCRIPTION
## Summary
- add OpenAIContext for enabling/disabling AI features
- wrap the app in OpenAIProvider
- provide a toggle in Settings for AI features
- skip OpenAI calls when disabled
- update README with instructions about the toggle and potential costs

## Testing
- `apt-get update`
- `apt-get install -y nodejs npm` *(fails: npm not installed yet)*

------
https://chatgpt.com/codex/tasks/task_e_687d672e13ec8324a29d5f0fe3d4ecaa