### PR TITLE
Fix service worker fetch for external requests

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -37,7 +37,11 @@ self.addEventListener('activate', (event) => {
 
 self.addEventListener('fetch', (event) => {
   if (event.request.method !== 'GET') return
+  const url = new URL(event.request.url)
+  if (url.origin !== self.location.origin) return // skip external requests
   event.respondWith(
-    caches.match(event.request).then((resp) => resp || fetch(event.request))
+    caches.match(event.request)
+      .then((resp) => resp || fetch(event.request))
+      .catch(() => caches.match('/index.html'))
   )
 })


### PR DESCRIPTION
## Summary
- skip caching for external GET requests
- handle offline fallback with `/index.html`

## Testing
- `npm test --silent` *(fails: Cannot destructure property 'enabled' ...)*
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687d6f6480448324b7355a10c06643a3