### PR TITLE
Adjust timeline summary to scientific tone

### DIFF
--- a/src/hooks/useTimelineSummary.js
+++ b/src/hooks/useTimelineSummary.js
@@ -37,7 +37,7 @@ export default function useTimelineSummary(events) {
               {
                 role: 'system',
                 content:
-                  'Summarize the recent plant care events in a friendly tone, for example: "Your Snake Plant has been thriving..."',
+                  'Summarize the recent plant care events in a scientific tone as if written by a plant expert, for example: "The specimen Sansevieria trifasciata exhibits robust growth..."',
               },
               { role: 'user', content: JSON.stringify(recent) },
             ],


### PR DESCRIPTION
## Summary
- update the system prompt in `useTimelineSummary` to request a scientific tone from a plant expert

## Testing
- `npm test` *(fails: Cannot destructure property 'enabled' ...)*

------
https://chatgpt.com/codex/tasks/task_e_687d713d04c08324801317811846dc7c