### PR TITLE
Add sample questions to Coach page

### DIFF
--- a/src/pages/Coach.jsx
+++ b/src/pages/Coach.jsx
@@ -27,6 +27,11 @@ export default function Coach() {
           setSubmitted(false)
         }}
         placeholder="Type your plant question" />
+      <ul className="text-sm italic text-gray-600 mb-2 space-y-1">
+        <li>“How often should I water my plant?”</li>
+        <li>“What fertilizer should I use for succulents?”</li>
+        <li>“Why are my orchid’s leaves turning yellow?”</li>
+      </ul>
       <button
         className="px-4 py-1 bg-green-600 text-white rounded"
         onClick={ask}


### PR DESCRIPTION
## Summary
- show three example questions under the Coach textarea
- style guidance text in a subtle font

## Testing
- `npm test --silent` *(fails: cannot destructure 'enabled' from OpenAIContext)*

------
https://chatgpt.com/codex/tasks/task_e_687d714bcf888324983e541fa8af8d1d