### PR TITLE
Add care badges to SimpleTaskCard

### DIFF
--- a/src/components/SimpleTaskCard.jsx
+++ b/src/components/SimpleTaskCard.jsx
@@ -1,6 +1,12 @@
 import { Link } from 'react-router-dom'
-
-export default function SimpleTaskCard({ plant, label }) {
+import { Drop, Sun } from 'phosphor-react'
+import Badge from './Badge.jsx'
+export default function SimpleTaskCard({
+  plant,
+  label,
+  dueWater = false,
+  dueFertilize = false,
+}) {
   if (!plant) return null
   return (
     <Link
@@ -18,6 +24,20 @@ export default function SimpleTaskCard({ plant, label }) {
           {plant.name}
         </h3>
         {label && <p className="text-xs text-gray-500">{label}</p>}
+        {(dueWater || dueFertilize) && (
+          <div className="flex flex-col gap-1 mt-1">
+            {dueWater && (
+              <Badge colorClass="bg-sky-100 text-sky-700" size="sm" Icon={Drop}>
+                Water
+              </Badge>
+            )}
+            {dueFertilize && (
+              <Badge colorClass="bg-amber-100 text-amber-700" size="sm" Icon={Sun}>
+                Fertilize
+              </Badge>
+            )}
+          </div>
+        )}
       </div>
     </Link>
   )

--- a/src/components/TasksContainer.jsx
+++ b/src/components/TasksContainer.jsx
@@ -28,7 +28,12 @@ export default function TasksContainer({ visibleTasks = [], happyPlant }) {
                   className="animate-fade-in-up"
                   style={{ animationDelay: `${i * 50}ms` }}
                 >
-                  <SimpleTaskCard plant={group.plant} label={label} />
+                  <SimpleTaskCard
+                    plant={group.plant}
+                    label={label}
+                    dueWater={group.dueWater}
+                    dueFertilize={group.dueFertilize}
+                  />
                 </BaseCard>
               )
             })

--- a/src/components/__tests__/SimpleTaskCard.test.jsx
+++ b/src/components/__tests__/SimpleTaskCard.test.jsx
@@ -1,0 +1,29 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import SimpleTaskCard from '../SimpleTaskCard.jsx'
+
+const plant = {
+  id: 1,
+  name: 'Fern',
+  image: 'fern.jpg',
+}
+
+test('shows badges when due for water and fertilize', () => {
+  render(
+    <MemoryRouter>
+      <SimpleTaskCard plant={plant} label="Needs care" dueWater dueFertilize />
+    </MemoryRouter>
+  )
+  expect(screen.getByText('Water')).toBeInTheDocument()
+  expect(screen.getByText('Fertilize')).toBeInTheDocument()
+})
+
+test('omits badges when not due', () => {
+  render(
+    <MemoryRouter>
+      <SimpleTaskCard plant={plant} label="None" />
+    </MemoryRouter>
+  )
+  expect(screen.queryByText('Water')).toBeNull()
+  expect(screen.queryByText('Fertilize')).toBeNull()
+})


### PR DESCRIPTION
## Summary
- show water and fertilize badges on home page task cards
- pass dueWater and dueFertilize flags from `TasksContainer`
- test new badge rendering behaviour

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d7689892c8324a1b2c7b6caa290e8