### PR TITLE
Add plant-specific coach prompts

### DIFF
--- a/src/pages/Coach.jsx
+++ b/src/pages/Coach.jsx
@@ -12,7 +12,23 @@ export default function Coach() {
   const [question, setQuestion] = useState('')
   const [submitted, setSubmitted] = useState(false)
 
-  const { answer, loading, error } = usePlantCoach(submitted ? question : '', plant)
+  const { answer, loading, error } = usePlantCoach(
+    submitted ? question : '',
+    plant
+  )
+
+  const defaultSamples = [
+    'How often should I water my plant?',
+    'What fertilizer should I use for succulents?',
+    "Why are my orchid’s leaves turning yellow?",
+  ]
+  const sampleQuestions = plant
+    ? [
+        `How often should I water my ${plant.name}?`,
+        `What fertilizer should I use for ${plant.name}?`,
+        `Why are my ${plant.name}'s leaves turning yellow?`,
+      ]
+    : defaultSamples
 
   const ask = () => setSubmitted(true)
 
@@ -28,9 +44,9 @@ export default function Coach() {
         }}
         placeholder="Type your plant question" />
       <ul className="text-sm italic text-gray-600 mb-2 space-y-1">
-        <li>“How often should I water my plant?”</li>
-        <li>“What fertilizer should I use for succulents?”</li>
-        <li>“Why are my orchid’s leaves turning yellow?”</li>
+        {sampleQuestions.map(q => (
+          <li key={q}>“{q}”</li>
+        ))}
       </ul>
       <button
         className="px-4 py-1 bg-green-600 text-white rounded"

--- a/src/pages/__tests__/Coach.test.jsx
+++ b/src/pages/__tests__/Coach.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import Coach from '../Coach.jsx'
+import { usePlants } from '../../PlantContext.jsx'
+
+jest.mock('../../hooks/usePlantCoach.js', () => ({
+  __esModule: true,
+  default: () => ({ answer: '', loading: false, error: '' }),
+}))
+
+jest.mock('../../PlantContext.jsx', () => ({
+  usePlants: jest.fn(),
+}))
+
+const usePlantsMock = usePlants
+
+test('shows plant specific sample questions', () => {
+  usePlantsMock.mockReturnValue({
+    plants: [{ id: 1, name: 'Aloe', lastWatered: '2025-07-01' }],
+  })
+  render(
+    <MemoryRouter initialEntries={['/plant/1/coach']}>
+      <Routes>
+        <Route path="/plant/:id/coach" element={<Coach />} />
+      </Routes>
+    </MemoryRouter>
+  )
+  expect(
+    screen.getByText(/How often should I water my Aloe/i)
+  ).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- adjust Coach page to show sample questions for the selected plant
- test Coach page rendering with plant-specific questions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d752c6fc0832483117023ddd4fe64