### PR TITLE
Add water plan calculation

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ Includes:
 - Badge indicator on the All Plants tab for overdue tasks
 - Watering and fertilizing progress overlays on plant photos
 - Customizable weather location and units from the Settings page
+- Guided onboarding asks for pot diameter and auto-calculates watering volume and interval
 
 ## Using the UI
 

--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -4,6 +4,7 @@ import { usePlants } from '../PlantContext.jsx'
 import { useRooms } from '../RoomContext.jsx'
 import PageContainer from "../components/PageContainer.jsx"
 import useCarePlan from '../hooks/useCarePlan.js'
+import { getWaterPlan } from '../utils/waterCalculator.js'
 
 export default function Onboard() {
   const { addPlant } = usePlants()
@@ -12,12 +13,14 @@ export default function Onboard() {
   const [form, setForm] = useState({
     name: '',
     pot: 'M',
+    diameter: '',
     soil: 'potting mix',
     light: 'Medium',
     room: '',
     humidity: '',
     experience: 'Beginner',
   })
+  const [water, setWater] = useState(null)
   const { plan, loading, error, generate } = useCarePlan()
 
   const handleChange = e => {
@@ -27,6 +30,7 @@ export default function Onboard() {
 
   const handleSubmit = e => {
     e.preventDefault()
+    setWater(getWaterPlan(form.name, form.diameter))
     generate(form)
   }
 
@@ -56,6 +60,10 @@ export default function Onboard() {
             <option value="L">L</option>
             <option value="XL">XL</option>
           </select>
+        </div>
+        <div className="grid gap-1">
+          <label htmlFor="diameter" className="font-medium">Pot diameter (inches)</label>
+          <input id="diameter" name="diameter" type="number" value={form.diameter} onChange={handleChange} className="border rounded p-2" />
         </div>
         <div className="grid gap-1">
           <label htmlFor="soil" className="font-medium">Soil type</label>
@@ -101,6 +109,11 @@ export default function Onboard() {
       {plan && (
         <div className="mt-6 space-y-4" data-testid="care-plan">
           <pre className="whitespace-pre-wrap p-4 bg-green-50 rounded">{plan.text}</pre>
+          {water && (
+            <p className="font-medium" data-testid="water-plan">
+              Suggested water: {water.volume} in³ every {water.interval} days
+            </p>
+          )}
           <button className="px-4 py-2 bg-green-600 text-white rounded" onClick={handleAdd}>Add Plant</button>
         </div>
       )}

--- a/src/utils/__tests__/waterCalculator.test.js
+++ b/src/utils/__tests__/waterCalculator.test.js
@@ -1,0 +1,16 @@
+import { getWaterPlan } from '../waterCalculator.js'
+
+test('calculates pot volume from diameter', () => {
+  const { volume } = getWaterPlan('Pothos', 4)
+  expect(volume).toBe(Math.round(Math.PI * 2 * 2 * 3))
+})
+
+test('returns longer interval for cactus', () => {
+  const { interval } = getWaterPlan('Bunny Ear Cactus', 6)
+  expect(interval).toBe(14)
+})
+
+test('returns short interval for fern', () => {
+  const { interval } = getWaterPlan('Boston Fern', 6)
+  expect(interval).toBe(3)
+})

--- a/src/utils/waterCalculator.js
+++ b/src/utils/waterCalculator.js
@@ -1,0 +1,12 @@
+export function getWaterPlan(plantName = '', diameter = 0) {
+  const d = Number(diameter) || 0
+  const depth = d * 0.75
+  const radius = d / 2
+  const volume = Math.round(Math.PI * radius * radius * depth)
+  const name = plantName.toLowerCase()
+  let interval = 7
+  if (/cactus|succulent|jade|aloe|snake/.test(name)) interval = 14
+  else if (/fern/.test(name)) interval = 3
+  else if (/orchid/.test(name)) interval = 10
+  return { volume, interval }
+}


### PR DESCRIPTION
## Summary
- extend onboarding form to include diameter field
- add new water calculator utility and tests
- compute watering plan when generating a care plan
- document pot diameter in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d77291efc8324a24fafc2e44d55a7