### PR TITLE
Add diameter editing and water plan update

### DIFF
--- a/src/__tests__/PlantContext.test.jsx
+++ b/src/__tests__/PlantContext.test.jsx
@@ -102,3 +102,25 @@ test('logEvent stores tags', async () => {
   fireEvent.click(screen.getByText('add'))
   await screen.findByText('t')
 })
+
+function DiameterTest() {
+  const { plants, updatePlant } = usePlants()
+  const plant = plants[0]
+  return (
+    <div>
+      <span>{plant.waterPlan ? plant.waterPlan.volume : 'none'}</span>
+      <button onClick={() => updatePlant(plant.id, { diameter: 5 })}>set</button>
+    </div>
+  )
+}
+
+test('updating diameter recalculates water plan', async () => {
+  render(
+    <PlantProvider>
+      <DiameterTest />
+    </PlantProvider>
+  )
+  expect(screen.getByText('none')).toBeInTheDocument()
+  fireEvent.click(screen.getByText('set'))
+  await screen.findByText('74')
+})

--- a/src/components/InputModal.jsx
+++ b/src/components/InputModal.jsx
@@ -1,0 +1,37 @@
+import { useEffect, useRef, useState } from 'react'
+
+export default function InputModal({ label = 'Edit', initialValue = '', onSave, onCancel }) {
+  const [value, setValue] = useState(initialValue)
+  const inputRef = useRef(null)
+
+  useEffect(() => {
+    inputRef.current?.focus()
+    const handleKey = e => {
+      if (e.key === 'Escape') {
+        onCancel?.()
+      }
+    }
+    window.addEventListener('keydown', handleKey)
+    return () => window.removeEventListener('keydown', handleKey)
+  }, [onCancel])
+
+  return (
+    <div role="dialog" aria-modal="true" aria-label={label} className="modal-overlay bg-black bg-opacity-70 z-50">
+      <div className="modal-box p-4 w-72 max-w-full">
+        <label className="block mb-2 font-headline" htmlFor="input-modal">{label}</label>
+        <input
+          id="input-modal"
+          ref={inputRef}
+          type="number"
+          value={value}
+          onChange={e => setValue(e.target.value)}
+          className="w-full border rounded p-2 dark:bg-gray-600"
+        />
+        <div className="flex justify-end gap-2 mt-2">
+          <button onClick={() => onCancel?.()} className="px-3 py-1 bg-gray-200 dark:bg-gray-600 rounded">Cancel</button>
+          <button onClick={() => onSave(value)} className="px-3 py-1 bg-green-600 text-white rounded">Save</button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -39,6 +39,7 @@ export default function Onboard() {
       name: form.name,
       room: form.room,
       notes: plan?.text || '',
+      diameter: form.diameter,
     })
     navigate('/')
   }

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -32,6 +32,7 @@ import PlantDetailFab from '../components/PlantDetailFab.jsx'
 import DetailTabs from '../components/DetailTabs.jsx'
 import BaseCard from '../components/BaseCard.jsx'
 import UnifiedTaskCard from '../components/UnifiedTaskCard.jsx'
+import InputModal from '../components/InputModal.jsx'
 import usePlantFact from '../hooks/usePlantFact.js'
 
 import useToast from "../hooks/useToast.jsx"
@@ -88,6 +89,7 @@ export default function PlantDetail() {
   const [latestFirst, setLatestFirst] = useState(true)
   const [offsetY, setOffsetY] = useState(0)
   const [expandedNotes, setExpandedNotes] = useState({})
+  const [showDiameterModal, setShowDiameterModal] = useState(false)
 
   const waterProgress = getWateringProgress(plant?.lastWatered, plant?.nextWater)
   const fertProgress = getWateringProgress(
@@ -182,6 +184,14 @@ export default function PlantDetail() {
 
   const openFileInput = () => {
     fileInputRef.current?.click()
+  }
+
+  const handleSaveDiameter = value => {
+    const num = Number(value)
+    if (num > 0) {
+      updatePlant(plant.id, { diameter: num })
+    }
+    setShowDiameterModal(false)
   }
 
   const handleEdit = () => {
@@ -506,6 +516,10 @@ export default function PlantDetail() {
       </div>
       <PageContainer size="xl" className="relative text-left pt-0 space-y-3">
         <Toast />
+        <div className="flex justify-between items-center px-2">
+          <p className="text-sm">Pot diameter: {plant.diameter ? `${plant.diameter} in` : 'N/A'}</p>
+          <button type="button" onClick={() => setShowDiameterModal(true)} className="text-green-600 text-sm">Edit</button>
+        </div>
 
         <div className="space-y-3">
           <DetailTabs tabs={tabs} />
@@ -522,6 +536,14 @@ export default function PlantDetail() {
         )}
         {showLegend && (
           <LegendModal onClose={() => setShowLegend(false)} />
+        )}
+        {showDiameterModal && (
+          <InputModal
+            label="Pot diameter (inches)"
+            initialValue={plant.diameter || ''}
+            onSave={handleSaveDiameter}
+            onCancel={() => setShowDiameterModal(false)}
+          />
         )}
       </PageContainer>
     </>


### PR DESCRIPTION
## Summary
- add a generic `InputModal` component
- compute water plan when plants are created or updated
- allow editing pot diameter in Plant Detail
- store diameter when adding a plant via onboarding
- test updating diameter recalculates water plan

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d7db85cf883248d5082e32774563a