### PR TITLE
Add smart watering plan with forecast

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -30,6 +30,8 @@ export function PlantProvider({ children }) {
       image: addBase(p.image),
       photos: (p.photos || p.gallery || []).map(mapPhoto),
       careLog: (p.careLog || []).map(ev => ({ ...ev, tags: ev.tags || [] })),
+      diameter: p.diameter || 0,
+      smartWaterPlan: p.smartWaterPlan || null,
     })
 
     if (typeof localStorage !== 'undefined') {

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -42,6 +42,8 @@ import { formatDaysAgo, formatTimeOfDay } from '../utils/dateFormat.js'
 import { getWateringProgress } from '../utils/watering.js'
 
 import { buildEvents, groupEventsByMonth } from '../utils/events.js'
+import { getSmartWaterPlan } from '../utils/waterCalculator.js'
+import { useWeather } from '../WeatherContext.jsx'
 
 const bulletColors = {
   water: 'bg-blue-500',
@@ -65,6 +67,7 @@ export default function PlantDetail() {
     updatePlant,
   } = usePlants()
   const plant = plants.find(p => p.id === Number(id))
+  const { forecast } = useWeather() || {}
   const { fact } = usePlantFact(plant?.name)
   const navigate = useNavigate()
   const location = useLocation()
@@ -88,6 +91,19 @@ export default function PlantDetail() {
   const [latestFirst, setLatestFirst] = useState(true)
   const [offsetY, setOffsetY] = useState(0)
   const [expandedNotes, setExpandedNotes] = useState({})
+
+  useEffect(() => {
+    if (!plant || !plant.diameter) return
+    const plan = getSmartWaterPlan(plant.name, plant.diameter, forecast)
+    const current = plant.smartWaterPlan || {}
+    if (
+      plan.volume !== current.volume ||
+      plan.interval !== current.interval ||
+      plan.reason !== current.reason
+    ) {
+      updatePlant(plant.id, { smartWaterPlan: plan })
+    }
+  }, [forecast, plant?.diameter])
 
   const waterProgress = getWateringProgress(plant?.lastWatered, plant?.nextWater)
   const fertProgress = getWateringProgress(
@@ -265,6 +281,11 @@ export default function PlantDetail() {
               Progress toward next scheduled care
             </p>
           </div>
+          {plant.smartWaterPlan && (
+            <p className="text-xs text-gray-500 dark:text-gray-400" data-testid="smart-water-plan">
+              {plant.smartWaterPlan.volume} in³ every {plant.smartWaterPlan.interval} days — {plant.smartWaterPlan.reason}
+            </p>
+          )}
         </div>
       ),
     },

--- a/src/utils/__tests__/waterCalculator.test.js
+++ b/src/utils/__tests__/waterCalculator.test.js
@@ -1,4 +1,4 @@
-import { getWaterPlan } from '../waterCalculator.js'
+import { getWaterPlan, getSmartWaterPlan } from '../waterCalculator.js'
 
 test('calculates pot volume from diameter', () => {
   const { volume } = getWaterPlan('Pothos', 4)
@@ -13,4 +13,16 @@ test('returns longer interval for cactus', () => {
 test('returns short interval for fern', () => {
   const { interval } = getWaterPlan('Boston Fern', 6)
   expect(interval).toBe(3)
+})
+
+test('smart plan shortens interval for hot weather', () => {
+  const { interval, reason } = getSmartWaterPlan('Pothos', 4, { temp: '90°F', rainfall: 0 })
+  expect(interval).toBe(getWaterPlan('Pothos', 4).interval - 1)
+  expect(reason).toMatch(/hot weather/i)
+})
+
+test('smart plan extends interval when rain expected', () => {
+  const { interval, reason } = getSmartWaterPlan('Pothos', 4, { rainfall: 80 })
+  expect(interval).toBe(getWaterPlan('Pothos', 4).interval + 1)
+  expect(reason).toMatch(/rain/i)
 })

--- a/src/utils/waterCalculator.js
+++ b/src/utils/waterCalculator.js
@@ -10,3 +10,18 @@ export function getWaterPlan(plantName = '', diameter = 0) {
   else if (/orchid/.test(name)) interval = 10
   return { volume, interval }
 }
+
+export function getSmartWaterPlan(plantName = '', diameter = 0, forecast = {}) {
+  const base = getWaterPlan(plantName, diameter)
+  let interval = base.interval
+  let reason = 'standard recommendation'
+  const temp = parseFloat(forecast?.temp)
+  if (!isNaN(temp) && temp > 85) {
+    interval = Math.max(1, interval - 1)
+    reason = 'adjusted for hot weather'
+  } else if (forecast?.rainfall > 60) {
+    interval += 1
+    reason = 'rain expected'
+  }
+  return { volume: base.volume, interval, reason }
+}


### PR DESCRIPTION
## Summary
- compute smart watering plan based on forecast
- persist smart water plan and pot diameter in `PlantContext`
- show the plan in plant detail care tab
- test smart water plan behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d7db372a483248bc64166f1e1a078