### PR TITLE
Fix duplicate key in Onboard

### DIFF
--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -41,7 +41,6 @@ export default function Onboard() {
       diameter: Number(form.diameter) || 0,
       waterPlan: water,
       notes: plan?.text || '',
-      diameter: form.diameter,
     })
     navigate('/')
   }


### PR DESCRIPTION
## Summary
- remove duplicate `diameter` entry when adding a plant

## Testing
- `npm test` *(fails: SyntaxError in waterCalculator.js)*

------
https://chatgpt.com/codex/tasks/task_e_687d8564ba288324b28d2ce3a2074a12