### PR TITLE
Fix missing closing brace in waterCalculator test

### DIFF
--- a/src/utils/__tests__/waterCalculator.test.js
+++ b/src/utils/__tests__/waterCalculator.test.js
@@ -71,6 +71,7 @@ test('adjusts interval based on late watering logs', () => {
   ]
   const plan = getSmartWaterPlan(plant, { date: '2025-04-10' }, logs)
   expect(plan.interval).toBe(10)
+})
 
 test('smart plan shortens interval for hot weather', () => {
   const { interval, reason } = getSmartWaterPlan('Pothos', 4, { temp: '90°F', rainfall: 0 })


### PR DESCRIPTION
## Summary
- close `adjusts interval based on late watering logs` test block

## Testing
- `npm test` *(fails: SyntaxError in waterCalculator.js)*

------
https://chatgpt.com/codex/tasks/task_e_687d8561ad3c832491847de00fef8e4f