### PR TITLE
Update smart watering plan when watering or forecast changes

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -1,155 +1,193 @@
-import { createContext, useContext, useEffect, useState } from 'react'
-import initialPlants from './plants.json'
-import { useWeather } from './WeatherContext.jsx'
-import { getNextWateringDate } from './utils/watering.js'
-import { getWaterPlan } from './utils/waterCalculator.js'
-import autoTag from './utils/autoTag.js'
+import { createContext, useContext, useEffect, useState } from "react";
+import initialPlants from "./plants.json";
+import { useWeather } from "./WeatherContext.jsx";
+import { getNextWateringDate } from "./utils/watering.js";
+import { getWaterPlan, getSmartWaterPlan } from "./utils/waterCalculator.js";
+import autoTag from "./utils/autoTag.js";
 
-const PlantContext = createContext()
+const PlantContext = createContext();
 
-export const addBase = url => {
-  if (!url) return url
-  if (/^https?:/.test(url) || url.startsWith('data:')) return url
-  const base = (process.env.VITE_BASE_PATH || '/').replace(/\/$/, '')
-  if (url.startsWith(base)) return url
-  return `${base}${url.startsWith('/') ? '' : '/'}${url}`
-}
+export const addBase = (url) => {
+  if (!url) return url;
+  if (/^https?:/.test(url) || url.startsWith("data:")) return url;
+  const base = (process.env.VITE_BASE_PATH || "/").replace(/\/$/, "");
+  if (url.startsWith(base)) return url;
+  return `${base}${url.startsWith("/") ? "" : "/"}${url}`;
+};
 
-const mapPhoto = photo => {
-  if (!photo) return photo
-  if (typeof photo === 'string') {
-    return { src: addBase(photo), caption: '', tags: [] }
+const mapPhoto = (photo) => {
+  if (!photo) return photo;
+  if (typeof photo === "string") {
+    return { src: addBase(photo), caption: "", tags: [] };
   }
-  return { ...photo, src: addBase(photo.src), tags: photo.tags || [] }
-}
+  return { ...photo, src: addBase(photo.src), tags: photo.tags || [] };
+};
 
 export function PlantProvider({ children }) {
-
   const [plants, setPlants] = useState(() => {
-    const mapPlant = p => ({
+    const mapPlant = (p) => ({
       ...p,
       image: addBase(p.image),
       photos: (p.photos || p.gallery || []).map(mapPhoto),
-      careLog: (p.careLog || []).map(ev => ({ ...ev, tags: ev.tags || [] })),
+      careLog: (p.careLog || []).map((ev) => ({ ...ev, tags: ev.tags || [] })),
       diameter: p.diameter || 0,
 
       waterPlan: p.waterPlan || { volume: 0, interval: 0 },
 
       smartWaterPlan: p.smartWaterPlan || null,
 
-    })
+      lastEvaluated: p.lastEvaluated || null,
+    });
 
-    if (typeof localStorage !== 'undefined') {
-      const stored = localStorage.getItem('plants')
+    if (typeof localStorage !== "undefined") {
+      const stored = localStorage.getItem("plants");
       if (stored) {
         try {
-          return JSON.parse(stored).map(mapPlant)
+          return JSON.parse(stored).map(mapPlant);
         } catch {
           // fall through to initial plants
         }
       }
     }
-    return initialPlants.map(mapPlant)
-  })
+    return initialPlants.map(mapPlant);
+  });
 
-  const weatherCtx = useWeather()
-  const weather = { rainTomorrow: weatherCtx?.forecast?.rainfall || 0 }
+  const weatherCtx = useWeather();
+  const weather = { rainTomorrow: weatherCtx?.forecast?.rainfall || 0 };
 
   useEffect(() => {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('plants', JSON.stringify(plants))
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("plants", JSON.stringify(plants));
     }
-  }, [plants])
+  }, [plants]);
+
+  const evaluatePlans = (forecast) => {
+    if (!forecast) return;
+    setPlants((prev) =>
+      prev.map((p) => {
+        if (!p.name || !p.diameter) return p;
+        const logs = (p.careLog || []).filter((l) => l.type === "Watered");
+        const plan = getSmartWaterPlan(
+          { name: p.name, diameter: p.diameter },
+          forecast,
+          logs,
+        );
+        return {
+          ...p,
+          smartWaterPlan: plan,
+          lastEvaluated: new Date().toISOString(),
+        };
+      }),
+    );
+  };
+
+  useEffect(() => {
+    const handler = (e) => evaluatePlans(e.detail);
+    window.addEventListener("weather-updated", handler);
+    return () => window.removeEventListener("weather-updated", handler);
+  }, []);
 
   const [timelineNotes, setTimelineNotes] = useState(() => {
-    if (typeof localStorage !== 'undefined') {
-      const stored = localStorage.getItem('timelineNotes')
+    if (typeof localStorage !== "undefined") {
+      const stored = localStorage.getItem("timelineNotes");
       if (stored) {
         try {
-          return JSON.parse(stored).map(n => ({ ...n, tags: n.tags || [] }))
+          return JSON.parse(stored).map((n) => ({ ...n, tags: n.tags || [] }));
         } catch {
           // ignore
         }
       }
     }
-    return []
-  })
+    return [];
+  });
 
   useEffect(() => {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('timelineNotes', JSON.stringify(timelineNotes))
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("timelineNotes", JSON.stringify(timelineNotes));
     }
-  }, [timelineNotes])
+  }, [timelineNotes]);
 
-  const addTimelineNote = async text => {
-    const date = new Date().toISOString().slice(0, 10)
-    const tags = await autoTag(text)
-    setTimelineNotes(prev => [...prev, { date, text, tags }])
-  }
+  const addTimelineNote = async (text) => {
+    const date = new Date().toISOString().slice(0, 10);
+    const tags = await autoTag(text);
+    setTimelineNotes((prev) => [...prev, { date, text, tags }]);
+  };
 
-  const logEvent = async (id, type, note = '') => {
-    const date = new Date().toISOString().slice(0, 10)
-    const tags = await autoTag(note)
-    setPlants(prev =>
-      prev.map(p =>
+  const logEvent = async (id, type, note = "") => {
+    const date = new Date().toISOString().slice(0, 10);
+    const tags = await autoTag(note);
+    setPlants((prev) =>
+      prev.map((p) =>
         p.id === id
           ? {
               ...p,
               careLog: [...(p.careLog || []), { date, type, note, tags }],
             }
-          : p
-      )
-    )
-  }
+          : p,
+      ),
+    );
+  };
 
-  const markWatered = (id, note) => {
-    setPlants(prev =>
-      prev.map(p => {
+  const markWatered = async (id, note) => {
+    const tags = await autoTag(note);
+    const today = new Date().toISOString().slice(0, 10);
+    setPlants((prev) =>
+      prev.map((p) => {
         if (p.id === id) {
-          const today = new Date().toISOString().slice(0, 10)
-          const { date: nextStr, reason } = getNextWateringDate(today, weather)
+          const { date: nextStr, reason } = getNextWateringDate(today, weather);
+          const newLog = [
+            ...(p.careLog || []),
+            { date: today, type: "Watered", note, tags },
+          ];
+          const plan = getSmartWaterPlan(
+            { name: p.name, diameter: p.diameter },
+            weatherCtx?.forecast,
+            newLog.filter((l) => l.type === "Watered"),
+          );
           return {
             ...p,
+            careLog: newLog,
             lastWatered: today,
             nextWater: nextStr,
             nextWaterReason: reason,
-          }
+            smartWaterPlan: plan,
+            lastEvaluated: new Date().toISOString(),
+          };
         }
-        return p
-      })
-    )
-    logEvent(id, 'Watered', note)
-  }
+        return p;
+      }),
+    );
+  };
 
   const markFertilized = (id, note) => {
-    setPlants(prev =>
-      prev.map(p => {
+    setPlants((prev) =>
+      prev.map((p) => {
         if (p.id === id) {
-          const today = new Date().toISOString().slice(0, 10)
-          let nextDate = new Date(today)
+          const today = new Date().toISOString().slice(0, 10);
+          let nextDate = new Date(today);
           if (p.lastFertilized && p.nextFertilize) {
-            const last = new Date(p.lastFertilized)
-            const next = new Date(p.nextFertilize)
-            const diff = Math.round((next - last) / 86400000) || 30
-            nextDate.setDate(nextDate.getDate() + diff)
+            const last = new Date(p.lastFertilized);
+            const next = new Date(p.nextFertilize);
+            const diff = Math.round((next - last) / 86400000) || 30;
+            nextDate.setDate(nextDate.getDate() + diff);
           } else {
-            nextDate.setMonth(nextDate.getMonth() + 1)
+            nextDate.setMonth(nextDate.getMonth() + 1);
           }
           return {
             ...p,
             lastFertilized: today,
             nextFertilize: nextDate.toISOString().slice(0, 10),
-          }
+          };
         }
-        return p
-      })
-    )
-    logEvent(id, 'Fertilized', note)
-  }
+        return p;
+      }),
+    );
+    logEvent(id, "Fertilized", note);
+  };
 
-  const addPlant = plant => {
-    setPlants(prev => {
-      const nextId = prev.reduce((m, p) => Math.max(m, p.id), 0) + 1
+  const addPlant = (plant) => {
+    setPlants((prev) => {
+      const nextId = prev.reduce((m, p) => Math.max(m, p.id), 0) + 1;
 
       const newPlant = {
         id: nextId,
@@ -158,62 +196,59 @@ export function PlantProvider({ children }) {
         diameter: 0,
         waterPlan: { volume: 0, interval: 0 },
         ...plant,
-      }
-      return [...prev, newPlant]
-
-    })
-  }
+      };
+      return [...prev, newPlant];
+    });
+  };
 
   const updatePlant = (id, updates) => {
-    setPlants(prev =>
-      prev.map(p => {
-        if (p.id !== id) return p
-        const next = { ...p, ...updates }
-        if (Object.prototype.hasOwnProperty.call(updates, 'diameter')) {
-          next.waterPlan = getWaterPlan(next.name, updates.diameter)
+    setPlants((prev) =>
+      prev.map((p) => {
+        if (p.id !== id) return p;
+        const next = { ...p, ...updates };
+        if (Object.prototype.hasOwnProperty.call(updates, "diameter")) {
+          next.waterPlan = getWaterPlan(next.name, updates.diameter);
         }
-        return next
-      })
-    )
-  }
+        return next;
+      }),
+    );
+  };
 
-  const removePlant = id => {
-    setPlants(prev => prev.filter(p => p.id !== id))
-  }
+  const removePlant = (id) => {
+    setPlants((prev) => prev.filter((p) => p.id !== id));
+  };
 
   const restorePlant = (plant, index) => {
-    setPlants(prev => {
-      const arr = [...prev]
-      const pos = index != null ? index : arr.length
-      arr.splice(pos, 0, plant)
-      return arr
-    })
-  }
+    setPlants((prev) => {
+      const arr = [...prev];
+      const pos = index != null ? index : arr.length;
+      arr.splice(pos, 0, plant);
+      return arr;
+    });
+  };
 
   const addPhoto = async (id, photo) => {
-    const newPhoto = mapPhoto(photo)
-    const tags = await autoTag(newPhoto.caption || '')
-    newPhoto.tags = tags
-    setPlants(prev =>
-      prev.map(p =>
-        p.id === id
-          ? { ...p, photos: [...(p.photos || []), newPhoto] }
-          : p
-      )
-    )
-  }
+    const newPhoto = mapPhoto(photo);
+    const tags = await autoTag(newPhoto.caption || "");
+    newPhoto.tags = tags;
+    setPlants((prev) =>
+      prev.map((p) =>
+        p.id === id ? { ...p, photos: [...(p.photos || []), newPhoto] } : p,
+      ),
+    );
+  };
 
   const removePhoto = (id, index) => {
-    setPlants(prev =>
-      prev.map(p => {
+    setPlants((prev) =>
+      prev.map((p) => {
         if (p.id === id) {
-          const updated = (p.photos || []).filter((_, i) => i !== index)
-          return { ...p, photos: updated }
+          const updated = (p.photos || []).filter((_, i) => i !== index);
+          return { ...p, photos: updated };
         }
-        return p
-      })
-    )
-  }
+        return p;
+      }),
+    );
+  };
 
   return (
     <PlantContext.Provider
@@ -234,7 +269,7 @@ export function PlantProvider({ children }) {
     >
       {children}
     </PlantContext.Provider>
-  )
+  );
 }
 
-export const usePlants = () => useContext(PlantContext)
+export const usePlants = () => useContext(PlantContext);

--- a/src/WeatherContext.jsx
+++ b/src/WeatherContext.jsx
@@ -1,82 +1,100 @@
-import { createContext, useContext, useEffect, useState } from 'react'
+import { createContext, useContext, useEffect, useState } from "react";
 
-const WeatherContext = createContext()
+const WeatherContext = createContext();
 
 export function WeatherProvider({ children }) {
-  const [forecast, setForecast] = useState(null)
-  const [error, setError] = useState('')
-  const [loading, setLoading] = useState(false)
+  const [forecast, setForecast] = useState(null);
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
   const [location, setLocation] = useState(() => {
-    if (typeof localStorage !== 'undefined') {
-      const stored = localStorage.getItem('weatherLocation')
-      if (stored) return stored
+    if (typeof localStorage !== "undefined") {
+      const stored = localStorage.getItem("weatherLocation");
+      if (stored) return stored;
     }
-    return 'Saint Paul, Minnesota'
-  })
+    return "Saint Paul, Minnesota";
+  });
   const [units, setUnits] = useState(() => {
-    if (typeof localStorage !== 'undefined') {
-      const stored = localStorage.getItem('weatherUnits')
-      if (stored) return stored
+    if (typeof localStorage !== "undefined") {
+      const stored = localStorage.getItem("weatherUnits");
+      if (stored) return stored;
     }
-    return 'imperial'
-  })
+    return "imperial";
+  });
 
   useEffect(() => {
-    const controller = new AbortController()
-    const { signal } = controller
+    const controller = new AbortController();
+    const { signal } = controller;
 
-    const key = process.env.VITE_WEATHER_API_KEY
-    if (!key) return
-    const url = `https://api.openweathermap.org/data/2.5/forecast?q=${encodeURIComponent(location)}&units=${units}&appid=${key}`
-    setLoading(true)
+    const key = process.env.VITE_WEATHER_API_KEY;
+    if (!key) return;
+    const url = `https://api.openweathermap.org/data/2.5/forecast?q=${encodeURIComponent(location)}&units=${units}&appid=${key}`;
+    setLoading(true);
     fetch(url, { signal })
-      .then(res => {
+      .then((res) => {
         if (!res.ok) {
-          throw new Error('Network response was not ok')
+          throw new Error("Network response was not ok");
         }
-        return res.json()
+        return res.json();
       })
-      .then(data => {
+      .then((data) => {
         if (data && data.list && data.list.length > 0) {
-          const next = data.list[0]
-          const rainfall = next.pop ? Math.round(next.pop * 100) : 0
-          const symbol = units === 'imperial' ? '°F' : '°C'
+          const next = data.list[0];
+          const rainfall = next.pop ? Math.round(next.pop * 100) : 0;
+          const symbol = units === "imperial" ? "°F" : "°C";
           setForecast({
             temp: Math.round(next.main.temp) + symbol,
             condition: next.weather?.[0]?.main,
             rainfall,
-          })
-          setError('')
+          });
+          setError("");
         }
       })
-      .catch(err => {
-        if (err.name !== 'AbortError') {
-          console.error(err)
-          setError('Failed to load weather data')
+      .catch((err) => {
+        if (err.name !== "AbortError") {
+          console.error(err);
+          setError("Failed to load weather data");
         }
       })
       .finally(() => {
-        setLoading(false)
-      })
+        setLoading(false);
+      });
     return () => {
-      controller.abort()
-    }
-  }, [location, units])
+      controller.abort();
+    };
+  }, [location, units]);
 
   useEffect(() => {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('weatherLocation', location)
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("weatherLocation", location);
     }
-  }, [location])
+  }, [location]);
 
   useEffect(() => {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.setItem('weatherUnits', units)
+    if (typeof localStorage !== "undefined") {
+      localStorage.setItem("weatherUnits", units);
     }
-  }, [units])
+  }, [units]);
+
+  useEffect(() => {
+    if (forecast) {
+      window.dispatchEvent(
+        new CustomEvent("weather-updated", { detail: forecast }),
+      );
+    }
+  }, [forecast]);
 
   return (
-    <WeatherContext.Provider value={{ forecast, location, setLocation, units, setUnits, error, loading }}>
+    <WeatherContext.Provider
+      value={{
+        forecast,
+        location,
+        setLocation,
+        units,
+        setUnits,
+        error,
+        loading,
+      }}
+    >
       {loading && (
         <div
           role="status"
@@ -95,7 +113,7 @@ export function WeatherProvider({ children }) {
       )}
       {children}
     </WeatherContext.Provider>
-  )
+  );
 }
 
-export const useWeather = () => useContext(WeatherContext)
+export const useWeather = () => useContext(WeatherContext);

--- a/src/__tests__/PlantContext.test.jsx
+++ b/src/__tests__/PlantContext.test.jsx
@@ -1,126 +1,142 @@
-import { render, screen, fireEvent, waitFor } from '@testing-library/react'
-import { PlantProvider, usePlants } from '../PlantContext.jsx'
-import autoTag from '../utils/autoTag.js'
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+import { PlantProvider, usePlants } from "../PlantContext.jsx";
+import autoTag from "../utils/autoTag.js";
 
-jest.mock('../utils/autoTag.js')
+jest.mock("../utils/autoTag.js");
 
 function TestComponent() {
-  const { plants, markWatered } = usePlants()
-  const plant = plants[0]
+  const { plants, markWatered } = usePlants();
+  const plant = plants[0];
   return (
     <div>
-      <button onClick={() => markWatered(plant.id, 'test note')}>log</button>
+      <button onClick={() => markWatered(plant.id, "test note")}>log</button>
       <ul>
         {(plant.careLog || []).map((e, i) => (
           <li key={i}>{e.note}</li>
         ))}
       </ul>
+      {plant.smartWaterPlan && (
+        <span data-testid="plan">{plant.smartWaterPlan.interval}</span>
+      )}
     </div>
-  )
+  );
 }
 
 function FertTestComponent() {
-  const { plants, markFertilized } = usePlants()
-  const plant = plants[0]
+  const { plants, markFertilized } = usePlants();
+  const plant = plants[0];
   return (
     <div>
-      <button onClick={() => markFertilized(plant.id, 'fert note')}>log</button>
+      <button onClick={() => markFertilized(plant.id, "fert note")}>log</button>
       <ul>
         {(plant.careLog || []).map((e, i) => (
           <li key={i}>{e.note}</li>
         ))}
       </ul>
     </div>
-  )
+  );
 }
 
-test('markWatered stores notes in careLog', async () => {
+test("markWatered stores notes in careLog", async () => {
   render(
     <PlantProvider>
       <TestComponent />
-    </PlantProvider>
-  )
+    </PlantProvider>,
+  );
 
-  fireEvent.click(screen.getByText('log'))
-  await screen.findByText('test note')
-})
+  fireEvent.click(screen.getByText("log"));
+  await screen.findByText("test note");
+});
 
-test('markFertilized stores notes in careLog', async () => {
+test("markWatered updates smart plan", async () => {
+  render(
+    <PlantProvider>
+      <TestComponent />
+    </PlantProvider>,
+  );
+
+  fireEvent.click(screen.getByText("log"));
+  await screen.findByTestId("plan");
+});
+
+test("markFertilized stores notes in careLog", async () => {
   render(
     <PlantProvider>
       <FertTestComponent />
-    </PlantProvider>
-  )
+    </PlantProvider>,
+  );
 
-  fireEvent.click(screen.getByText('log'))
-  await screen.findByText('fert note')
-})
+  fireEvent.click(screen.getByText("log"));
+  await screen.findByText("fert note");
+});
 
 function NoteTest() {
-  const { addTimelineNote, timelineNotes } = usePlants()
+  const { addTimelineNote, timelineNotes } = usePlants();
   return (
     <div>
-      <button onClick={() => addTimelineNote('hi')}>add</button>
+      <button onClick={() => addTimelineNote("hi")}>add</button>
       {timelineNotes.map((n, i) => (
-        <span key={i}>{n.tags.join(',')}</span>
+        <span key={i}>{n.tags.join(",")}</span>
       ))}
     </div>
-  )
+  );
 }
 
 function LogTest() {
-  const { plants, logEvent } = usePlants()
-  const plant = plants[0]
+  const { plants, logEvent } = usePlants();
+  const plant = plants[0];
   return (
     <div>
-      <button onClick={() => logEvent(plant.id, 'Note', 'hello')}>add</button>
+      <button onClick={() => logEvent(plant.id, "Note", "hello")}>add</button>
       {(plant.careLog || []).map((e, i) => (
-        <span key={i}>{e.tags.join(',')}</span>
+        <span key={i}>{e.tags.join(",")}</span>
       ))}
     </div>
-  )
+  );
 }
 
-test('addTimelineNote stores tags', async () => {
-  autoTag.mockResolvedValue(['tag'])
+test("addTimelineNote stores tags", async () => {
+  autoTag.mockResolvedValue(["tag"]);
   render(
     <PlantProvider>
       <NoteTest />
-    </PlantProvider>
-  )
-  fireEvent.click(screen.getByText('add'))
-  await screen.findByText('tag')
-})
+    </PlantProvider>,
+  );
+  fireEvent.click(screen.getByText("add"));
+  await screen.findByText("tag");
+});
 
-test('logEvent stores tags', async () => {
-  autoTag.mockResolvedValue(['t'])
+test("logEvent stores tags", async () => {
+  autoTag.mockResolvedValue(["t"]);
   render(
     <PlantProvider>
       <LogTest />
-    </PlantProvider>
-  )
-  fireEvent.click(screen.getByText('add'))
-  await screen.findByText('t')
-})
+    </PlantProvider>,
+  );
+  fireEvent.click(screen.getByText("add"));
+  await screen.findByText("t");
+});
 
 function DiameterTest() {
-  const { plants, updatePlant } = usePlants()
-  const plant = plants[0]
+  const { plants, updatePlant } = usePlants();
+  const plant = plants[0];
   return (
     <div>
-      <span>{plant.waterPlan ? plant.waterPlan.volume : 'none'}</span>
-      <button onClick={() => updatePlant(plant.id, { diameter: 5 })}>set</button>
+      <span>{plant.waterPlan ? plant.waterPlan.volume : "none"}</span>
+      <button onClick={() => updatePlant(plant.id, { diameter: 5 })}>
+        set
+      </button>
     </div>
-  )
+  );
 }
 
-test('updating diameter recalculates water plan', async () => {
+test("updating diameter recalculates water plan", async () => {
   render(
     <PlantProvider>
       <DiameterTest />
-    </PlantProvider>
-  )
-  expect(screen.getByText('0')).toBeInTheDocument()
-  fireEvent.click(screen.getByText('set'))
-  await screen.findByText('74')
-})
+    </PlantProvider>,
+  );
+  expect(screen.getByText("0")).toBeInTheDocument();
+  fireEvent.click(screen.getByText("set"));
+  await screen.findByText("74");
+});


### PR DESCRIPTION
## Summary
- recalc smart watering plans whenever watering is logged
- save last evaluation time per plant
- broadcast `weather-updated` event and recompute plans on forecast change
- show smart watering plan in plant details
- test that smart plan updates after watering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d894e38088324b191fab1510d8e71