### PR TITLE
Add sprout animation for fertilize tasks

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Includes:
 - Organize plants by room and create custom rooms
 - Badge indicator on the All Plants tab for overdue tasks
 - Watering and fertilizing progress overlays on plant photos
+- Sprout bounce animation when fertilize tasks are completed
 - Customizable weather location and units from the Settings page
 - Guided onboarding asks for pot diameter and auto-calculates watering volume and interval
 

--- a/src/components/TaskCard.jsx
+++ b/src/components/TaskCard.jsx
@@ -1,4 +1,5 @@
 import { Drop, Sun, PencilSimpleLine, ClockCounterClockwise, Trash, CheckCircle } from 'phosphor-react'
+import Sprout from './icons/Sprout.jsx'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { useState } from 'react'
 import { getWateringInfo } from '../utils/watering.js'
@@ -211,17 +212,21 @@ export default function TaskCard({
       </div>
           {completed && (
             <div className="absolute inset-0 flex items-center justify-center pointer-events-none task-complete-fade">
-              <svg
-                className="w-8 h-8 text-healthy-600 check-pop swipe-check fade-in"
-                xmlns="http://www.w3.org/2000/svg"
-                fill="none"
-                viewBox="0 0 24 24"
-                strokeWidth="1.5"
-                stroke="currentColor"
-                aria-hidden="true"
-              >
-                <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-              </svg>
+              {task.type === 'Fertilize' ? (
+                <Sprout className="w-8 h-8 text-healthy-600 sprout-bounce swipe-check fade-in" />
+              ) : (
+                <svg
+                  className="w-8 h-8 text-healthy-600 check-pop swipe-check fade-in"
+                  xmlns="http://www.w3.org/2000/svg"
+                  fill="none"
+                  viewBox="0 0 24 24"
+                  strokeWidth="1.5"
+                  stroke="currentColor"
+                  aria-hidden="true"
+                >
+                  <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+                </svg>
+              )}
             </div>
           )}
           {!compact && (

--- a/src/components/UnifiedTaskCard.jsx
+++ b/src/components/UnifiedTaskCard.jsx
@@ -11,6 +11,7 @@ import {
   Trash,
   DotsThreeVertical,
 } from 'phosphor-react'
+import Sprout from './icons/Sprout.jsx'
 import { formatDaysAgo } from '../utils/dateFormat.js'
 import { useNavigate, useLocation } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
@@ -269,17 +270,21 @@ export default function UnifiedTaskCard({
       </div>
       {completed && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none task-complete-fade">
-          <svg
-            className="w-8 h-8 text-healthy-600 check-pop swipe-check fade-in"
-            xmlns="http://www.w3.org/2000/svg"
-            fill="none"
-            viewBox="0 0 24 24"
-            strokeWidth="1.5"
-            stroke="currentColor"
-            aria-hidden="true"
-          >
-            <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
-          </svg>
+          {dueFertilize && !dueWater ? (
+            <Sprout className="w-8 h-8 text-healthy-600 sprout-bounce swipe-check fade-in" />
+          ) : (
+            <svg
+              className="w-8 h-8 text-healthy-600 check-pop swipe-check fade-in"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+            </svg>
+          )}
         </div>
       )}
     </div>

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -93,7 +93,7 @@ test('applies highlight when urgent', () => {
 })
 
 
-test('shows completed state', () => {
+test('shows completed state for watering task', () => {
   const { container } = renderWithSnackbar(
       <BaseCard variant="task">
         <TaskCard task={task} completed />
@@ -103,6 +103,16 @@ test('shows completed state', () => {
   expect(wrapper).toHaveClass('opacity-50')
   expect(wrapper).toHaveClass('bg-green-50')
   expect(container.querySelector('.check-pop')).toBeInTheDocument()
+})
+
+test('shows sprout for completed fertilize task', () => {
+  const fertTask = { ...task, type: 'Fertilize' }
+  const { container } = renderWithSnackbar(
+      <BaseCard variant="task">
+        <TaskCard task={fertTask} completed />
+      </BaseCard>
+  )
+  expect(container.querySelector('.sprout-bounce')).toBeInTheDocument()
 })
 
 test('renders badge icon', () => {

--- a/src/components/icons/Sprout.jsx
+++ b/src/components/icons/Sprout.jsx
@@ -1,0 +1,22 @@
+import React from 'react'
+
+export default function Sprout({ className = '', ...props }) {
+  return (
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      viewBox="0 0 24 24"
+      fill="currentColor"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      className={className}
+      aria-hidden="true"
+      {...props}
+    >
+      <path d="M12 21v-8" />
+      <path d="M12 13c-2-3-5-5-9-5 1 4 4 7 9 7" fill="currentColor" />
+      <path d="M12 13c2-3 5-5 9-5-1 4-4 7-9 7" fill="currentColor" />
+    </svg>
+  )
+}

--- a/src/index.css
+++ b/src/index.css
@@ -150,6 +150,40 @@ body {
   animation: fly-in 0.6s ease-out;
 }
 
+@keyframes sprout-bounce {
+  0%, 100% {
+    transform: translateY(0) scale(1);
+    opacity: 0.9;
+  }
+  50% {
+    transform: translateY(-4px) scale(1.1);
+    opacity: 1;
+  }
+}
+
+.sprout-bounce {
+  animation: sprout-bounce 0.6s ease-out both;
+}
+
+@keyframes sprout-grow {
+  0% {
+    transform: scale(0);
+    opacity: 0;
+  }
+  60% {
+    transform: scale(1.1);
+    opacity: 1;
+  }
+  100% {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.sprout-grow {
+  animation: sprout-grow 0.8s ease-out both;
+}
+
 @keyframes swipe-left-out {
   from {
     transform: translateX(0);


### PR DESCRIPTION
## Summary
- create new `Sprout` icon component
- animate sprout with new keyframes in `index.css`
- use sprout icon for completed fertilize tasks in `TaskCard` and `UnifiedTaskCard`
- update tests for new icon
- document animation in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d9273e9348324b41cfe1915cb6440