### PR TITLE
Add iNat taxon autocomplete

### DIFF
--- a/src/components/BalconyPlantCard.jsx
+++ b/src/components/BalconyPlantCard.jsx
@@ -37,6 +37,9 @@ export default function BalconyPlantCard({ plant }) {
         <h3 className="font-headline font-extrabold text-xl leading-none text-left">
           {plant.name}
         </h3>
+        {plant.scientificName && (
+          <p className="text-sm italic leading-none">{plant.scientificName}</p>
+        )}
         <p className="text-sm text-left">Last watered {formatDaysAgo(plant.lastWatered)}</p>
         {plant.lastFertilized && (
           <p className="text-sm text-left">

--- a/src/components/PlantCard.jsx
+++ b/src/components/PlantCard.jsx
@@ -219,17 +219,22 @@ export default function PlantCard({ plant }) {
         className={overdue ? 'ring-2 ring-yellow-300' : ''}
         imgSrc={plant.image}
         title={
-          <Link
-            to={
-              plant.room
-                ? `/room/${encodeURIComponent(plant.room)}/plant/${plant.id}`
-                : `/plant/${plant.id}`
-            }
-            state={{ from: location.pathname }}
-            className="focus:outline-none"
-          >
-            {plant.name}
-          </Link>
+          <>
+            <Link
+              to={
+                plant.room
+                  ? `/room/${encodeURIComponent(plant.room)}/plant/${plant.id}`
+                  : `/plant/${plant.id}`
+              }
+              state={{ from: location.pathname }}
+              className="focus:outline-none"
+            >
+              {plant.name}
+            </Link>
+            {plant.scientificName && (
+              <div className="text-sm italic leading-tight">{plant.scientificName}</div>
+            )}
+          </>
         }
       >
         <p className="text-sm text-green-700 font-medium font-body">Next: {plant.nextWater}</p>

--- a/src/hooks/__tests__/usePlantTaxon.test.js
+++ b/src/hooks/__tests__/usePlantTaxon.test.js
@@ -1,0 +1,46 @@
+import { render, screen, waitFor } from '@testing-library/react'
+import usePlantTaxon from '../usePlantTaxon.js'
+
+function Test({ query }) {
+  const results = usePlantTaxon(query)
+  return (
+    <div>
+      {results.map(r => (
+        <span key={r.id}>{r.commonName}:{r.scientificName}</span>
+      ))}
+    </div>
+  )
+}
+
+afterEach(() => {
+  global.fetch && (global.fetch = undefined)
+  localStorage.clear()
+})
+
+test('fetches taxon suggestions', async () => {
+  const data = {
+    results: [
+      { id: 1, name: 'Aloe vera', preferred_common_name: 'Aloe' },
+    ],
+  }
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ json: () => Promise.resolve(data) })
+  )
+  render(<Test query="aloe" />)
+  await waitFor(() => screen.getByText('Aloe:Aloe vera'))
+  expect(global.fetch).toHaveBeenCalledWith(
+    expect.stringContaining('taxa/autocomplete?q=aloe'),
+    expect.any(Object)
+  )
+})
+
+test('aborts fetch on unmount', async () => {
+  const abortMock = jest.fn()
+  global.AbortController = jest.fn(() => ({ signal: 's', abort: abortMock }))
+  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({ results: [] }) }))
+  const { unmount } = render(<Test query="al" />)
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+  unmount()
+  expect(abortMock).toHaveBeenCalled()
+  global.AbortController = undefined
+})

--- a/src/hooks/usePlantTaxon.js
+++ b/src/hooks/usePlantTaxon.js
@@ -1,0 +1,50 @@
+import { useState, useEffect } from 'react'
+
+export default function usePlantTaxon(query) {
+  const [results, setResults] = useState([])
+
+  useEffect(() => {
+    if (!query || query.length < 2) return
+    const key = `taxon_${query.toLowerCase()}`
+    const cached = typeof localStorage !== 'undefined' && localStorage.getItem(key)
+    if (cached) {
+      try {
+        setResults(JSON.parse(cached))
+        return
+      } catch {}
+    }
+    if (typeof fetch !== 'function') return
+
+    let aborted = false
+    const controller = new AbortController()
+    const { signal } = controller
+
+    async function fetchTaxa() {
+      try {
+        const url = `https://api.inaturalist.org/v1/taxa/autocomplete?q=${encodeURIComponent(query)}`
+        const res = await fetch(url, { signal })
+        const data = await res.json()
+        const list = (data?.results || []).map(t => ({
+          id: t.id,
+          commonName: t.preferred_common_name || t.name,
+          scientificName: t.name,
+        }))
+        if (!aborted) {
+          setResults(list)
+          if (typeof localStorage !== 'undefined') {
+            localStorage.setItem(key, JSON.stringify(list))
+          }
+        }
+      } catch (err) {
+        console.error('Failed to load iNaturalist taxon', err)
+      }
+    }
+    fetchTaxa()
+    return () => {
+      aborted = true
+      controller.abort()
+    }
+  }, [query])
+
+  return results
+}

--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -5,6 +5,7 @@ import { useRooms } from '../RoomContext.jsx'
 import PageContainer from "../components/PageContainer.jsx"
 import useCarePlan from '../hooks/useCarePlan.js'
 import { getWaterPlan } from '../utils/waterCalculator.js'
+import usePlantTaxon from '../hooks/usePlantTaxon.js'
 
 export default function Onboard() {
   const { addPlant } = usePlants()
@@ -12,6 +13,7 @@ export default function Onboard() {
   const navigate = useNavigate()
   const [form, setForm] = useState({
     name: '',
+    scientificName: '',
     diameter: '',
     soil: 'potting mix',
     light: 'Medium',
@@ -21,10 +23,17 @@ export default function Onboard() {
   })
   const [water, setWater] = useState(null)
   const { plan, loading, error, generate } = useCarePlan()
+  const taxa = usePlantTaxon(form.name)
 
   const handleChange = e => {
     const { name, value } = e.target
     setForm(f => ({ ...f, [name]: value }))
+  }
+
+  const handleNameChange = e => {
+    const value = e.target.value
+    const match = taxa.find(t => t.commonName.toLowerCase() === value.toLowerCase())
+    setForm(f => ({ ...f, name: value, scientificName: match ? match.scientificName : f.scientificName }))
   }
 
   const handleSubmit = e => {
@@ -36,6 +45,7 @@ export default function Onboard() {
   const handleAdd = () => {
     addPlant({
       name: form.name,
+      ...(form.scientificName && { scientificName: form.scientificName }),
       room: form.room,
       diameter: Number(form.diameter) || 0,
       waterPlan: water,
@@ -50,7 +60,12 @@ export default function Onboard() {
       <form onSubmit={handleSubmit} className="space-y-4">
         <div className="grid gap-1">
           <label htmlFor="name" className="font-medium">Plant type</label>
-          <input id="name" name="name" type="text" value={form.name} onChange={handleChange} className="border rounded p-2" required />
+          <input id="name" name="name" type="text" list="plant-type-list" value={form.name} onChange={handleNameChange} className="border rounded p-2" required />
+          <datalist id="plant-type-list">
+            {taxa.map(t => (
+              <option key={t.id} value={t.commonName}>{t.scientificName}</option>
+            ))}
+          </datalist>
         </div>
         <div className="grid gap-1">
           <label htmlFor="diameter" className="font-medium">Pot diameter (inches)</label>

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -538,6 +538,11 @@ export default function PlantDetail() {
               <h2 className="text-3xl font-extrabold font-headline animate-fade-in-down">
                 {plant.name}
               </h2>
+              {plant.scientificName && (
+                <p className="text-lg italic text-gray-200 animate-fade-in-down" style={{ animationDelay: '50ms' }}>
+                  {plant.scientificName}
+                </p>
+              )}
               {plant.nickname && (
                 <p
                   className="text-sm text-gray-200 animate-fade-in-down"


### PR DESCRIPTION
## Summary
- create `usePlantTaxon` hook for iNaturalist lookups
- add datalist autocomplete to onboarding flow
- show scientific name on plant cards and detail pages
- test new hook and autocomplete behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d957e8900832492366e7557a63b62