### PR TITLE
Add outdoor humidity option

### DIFF
--- a/src/WeatherContext.jsx
+++ b/src/WeatherContext.jsx
@@ -45,6 +45,7 @@ export function WeatherProvider({ children }) {
             temp: Math.round(next.main.temp) + symbol,
             condition: next.weather?.[0]?.main,
             rainfall,
+            humidity: next.main.humidity,
           });
           setError("");
         }

--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -2,6 +2,7 @@ import { useState } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
 import { useRooms } from '../RoomContext.jsx'
+import { useWeather } from '../WeatherContext.jsx'
 import PageContainer from "../components/PageContainer.jsx"
 import useCarePlan from '../hooks/useCarePlan.js'
 import { getWaterPlan } from '../utils/waterCalculator.js'
@@ -10,6 +11,7 @@ export default function Onboard() {
   const { addPlant } = usePlants()
   const { rooms } = useRooms()
   const navigate = useNavigate()
+  const { forecast } = useWeather() || {}
   const [form, setForm] = useState({
     name: '',
     diameter: '',
@@ -21,6 +23,12 @@ export default function Onboard() {
   })
   const [water, setWater] = useState(null)
   const { plan, loading, error, generate } = useCarePlan()
+
+  const handleUseOutdoorHumidity = () => {
+    if (forecast?.humidity !== undefined) {
+      setForm(f => ({ ...f, humidity: forecast.humidity }))
+    }
+  }
 
   const handleChange = e => {
     const { name, value } = e.target
@@ -82,7 +90,12 @@ export default function Onboard() {
         </div>
         <div className="grid gap-1">
           <label htmlFor="humidity" className="font-medium">Humidity (%)</label>
-          <input id="humidity" name="humidity" type="number" value={form.humidity} onChange={handleChange} className="border rounded p-2" />
+          <div className="flex gap-2">
+            <input id="humidity" name="humidity" type="number" value={form.humidity} onChange={handleChange} className="border rounded p-2 flex-grow" />
+            {forecast?.humidity !== undefined && (
+              <button type="button" onClick={handleUseOutdoorHumidity} className="px-2 text-sm underline whitespace-nowrap">Use outdoor</button>
+            )}
+          </div>
         </div>
         <div className="grid gap-1">
           <label htmlFor="experience" className="font-medium">Experience</label>

--- a/src/pages/__tests__/Onboard.test.jsx
+++ b/src/pages/__tests__/Onboard.test.jsx
@@ -23,6 +23,10 @@ jest.mock('../../OpenAIContext.jsx', () => ({
   useOpenAI: () => ({ enabled: true }),
 }))
 
+jest.mock('../../WeatherContext.jsx', () => ({
+  useWeather: () => ({ forecast: { humidity: 55 } }),
+}))
+
 
 afterEach(() => {
   addPlant.mockClear()


### PR DESCRIPTION
## Summary
- capture `humidity` when fetching weather data
- show a 'Use outdoor' button on Onboard form to fill humidity from the forecast
- mock new `useWeather` call in Onboard page tests

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d91964c3083249468baaa0fddabb2