### PR TITLE
Remove experience field

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -46,12 +46,12 @@ app.post('/api/care-plan', async (req, res) => {
     return
   }
 
-  const { name, soil, light, humidity, experience } = req.body || {}
+  const { name, soil, light, humidity } = req.body || {}
   const messages = [
     { role: 'system', content: 'You are a plant care assistant. Respond in JSON.' },
     {
       role: 'user',
-      content: `Plant: ${name}\nLight: ${light}\nSoil: ${soil}\nHumidity: ${humidity}\nExperience: ${experience}\nGive watering interval in days, fertilizing interval in days, and short light description. Respond with JSON {"water":<days>,"fertilize":<days>,"light":"label"}.`,
+      content: `Plant: ${name}\nLight: ${light}\nSoil: ${soil}\nHumidity: ${humidity}\nGive watering interval in days, fertilizing interval in days, and short light description. Respond with JSON {"water":<days>,"fertilize":<days>,"light":"label"}.`,
     },
   ]
 

--- a/src/hooks/usePlantTaxon.js
+++ b/src/hooks/usePlantTaxon.js
@@ -11,7 +11,9 @@ export default function usePlantTaxon(query) {
       try {
         setResults(JSON.parse(cached))
         return
-      } catch {}
+      } catch (err) {
+        // ignore invalid cached data
+      }
     }
     if (typeof fetch !== 'function') return
 

--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -19,7 +19,6 @@ export default function Onboard() {
     light: 'Medium',
     room: '',
     humidity: '',
-    experience: 'Beginner',
   })
   const [water, setWater] = useState(null)
   const { plan, loading, error, generate } = useCarePlan()
@@ -99,14 +98,7 @@ export default function Onboard() {
           <label htmlFor="humidity" className="font-medium">Humidity (%)</label>
           <input id="humidity" name="humidity" type="number" value={form.humidity} onChange={handleChange} className="border rounded p-2" />
         </div>
-        <div className="grid gap-1">
-          <label htmlFor="experience" className="font-medium">Experience</label>
-          <select id="experience" name="experience" value={form.experience} onChange={handleChange} className="border rounded p-2">
-            <option>Beginner</option>
-            <option>Intermediate</option>
-            <option>Expert</option>
-          </select>
-        </div>
+        
         <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded" disabled={loading}>Generate Care Plan</button>
       </form>
 


### PR DESCRIPTION
## Summary
- drop experience field from onboarding
- remove experience from care-plan API
- fix linter warning in `usePlantTaxon`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d94103ea08324932389445a995fe9