### PR TITLE
Include light level in watering plan

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -68,7 +68,7 @@ export function PlantProvider({ children }) {
         if (!p.name || !p.diameter) return p;
         const logs = (p.careLog || []).filter((l) => l.type === "Watered");
         const plan = getSmartWaterPlan(
-          { name: p.name, diameter: p.diameter },
+          { name: p.name, diameter: p.diameter, light: p.light },
           forecast,
           logs,
         );
@@ -140,7 +140,7 @@ export function PlantProvider({ children }) {
             { date: today, type: "Watered", note, tags },
           ];
           const plan = getSmartWaterPlan(
-            { name: p.name, diameter: p.diameter },
+            { name: p.name, diameter: p.diameter, light: p.light },
             weatherCtx?.forecast,
             newLog.filter((l) => l.type === "Watered"),
           );
@@ -207,7 +207,7 @@ export function PlantProvider({ children }) {
         if (p.id !== id) return p;
         const next = { ...p, ...updates };
         if (Object.prototype.hasOwnProperty.call(updates, "diameter")) {
-          next.waterPlan = getWaterPlan(next.name, updates.diameter);
+          next.waterPlan = getWaterPlan(next.name, updates.diameter, next.light);
         }
         return next;
       }),

--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -38,7 +38,7 @@ export default function Onboard() {
 
   const handleSubmit = e => {
     e.preventDefault()
-    setWater(getWaterPlan(form.name, form.diameter))
+    setWater(getWaterPlan(form.name, form.diameter, form.light))
     generate(form)
   }
 
@@ -48,6 +48,7 @@ export default function Onboard() {
       ...(form.scientificName && { scientificName: form.scientificName }),
       room: form.room,
       diameter: Number(form.diameter) || 0,
+      light: form.light,
       waterPlan: water,
       notes: plan?.text || '',
     })

--- a/src/pages/__tests__/Onboard.test.jsx
+++ b/src/pages/__tests__/Onboard.test.jsx
@@ -56,9 +56,9 @@ test('generates plan and adds plant then navigates home', async () => {
 
   fireEvent.click(screen.getByRole('button', { name: /add plant/i }))
 
-  const expected = getWaterPlan('Aloe', '4')
+  const expected = getWaterPlan('Aloe', '4', 'Medium')
   expect(addPlant).toHaveBeenCalledWith(
-    expect.objectContaining({ waterPlan: expected })
+    expect.objectContaining({ waterPlan: expected, light: 'Medium' })
   )
   expect(screen.getByText('Home')).toBeInTheDocument()
 })

--- a/src/utils/__tests__/waterCalculator.test.js
+++ b/src/utils/__tests__/waterCalculator.test.js
@@ -15,6 +15,11 @@ test('returns short interval for fern', () => {
   expect(interval).toBe(3)
 })
 
+test('light level adjusts interval', () => {
+  expect(getWaterPlan('Pothos', 4, 'Low').interval).toBe(9)
+  expect(getWaterPlan('Pothos', 4, 'Bright Direct').interval).toBe(5)
+})
+
 
 test('smart plan matches baseline without context', () => {
   const plant = { name: 'Pothos', diameter: 4 }

--- a/src/utils/waterCalculator.js
+++ b/src/utils/waterCalculator.js
@@ -1,6 +1,6 @@
 export const MS_PER_DAY = 86400000
 
-export function getWaterPlan(plantName = '', diameter = 0) {
+export function getWaterPlan(plantName = '', diameter = 0, light = 'Medium') {
   const d = Number(diameter) || 0
   const depth = d * 0.75
   const radius = d / 2
@@ -10,6 +10,11 @@ export function getWaterPlan(plantName = '', diameter = 0) {
   if (/cactus|succulent|jade|aloe|snake/.test(name)) interval = 14
   else if (/fern/.test(name)) interval = 3
   else if (/orchid/.test(name)) interval = 10
+  const lvl = String(light).toLowerCase()
+  if (lvl === 'low') interval += 2
+  else if (lvl === 'bright indirect') interval -= 1
+  else if (lvl === 'bright direct') interval -= 2
+  interval = Math.max(1, interval)
   return { volume, interval }
 }
 
@@ -34,7 +39,7 @@ export function getSmartWaterPlan(arg1 = {}, arg2 = {}, arg3 = {}, arg4 = []) {
     returnReason = true
   }
 
-  const base = getWaterPlan(plant.name, plant.diameter)
+  const base = getWaterPlan(plant.name, plant.diameter, plant.light)
   let interval = base.interval
 
   if (returnReason) {


### PR DESCRIPTION
## Summary
- incorporate `light` parameter in `getWaterPlan` and adjust interval
- use `light` when computing smart plan
- store light on new plants from onboarding and use it in plan recalculations
- update onboarding and plant context tests
- add unit tests verifying light level effect

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687d93f6fc5083248f73f0371acdd09a