### PR TITLE
Add fertilize completion sprout animation

### DIFF
--- a/src/components/CareCard.jsx
+++ b/src/components/CareCard.jsx
@@ -1,19 +1,31 @@
 import React, { useState } from 'react'
+import Sprout from './icons/Sprout.jsx'
 
-export default function CareCard({ label, Icon, progress = 0, status, onDone }) {
-  const [completed, setCompleted] = useState(false)
+export default function CareCard({
+  label,
+  Icon,
+  progress = 0,
+  status,
+  onDone,
+  completed = false,
+}) {
+  const [internalCompleted, setInternalCompleted] = useState(false)
   const pct = Math.min(Math.max(progress, 0), 1)
   const width = `${pct * 100}%`
   const handleDone = () => {
     if (!onDone) return
-    setCompleted(true)
+    setInternalCompleted(true)
     setTimeout(() => {
       onDone()
-      setCompleted(false)
+      setInternalCompleted(false)
     }, 200)
   }
+  const showComplete = internalCompleted || completed
   return (
-    <div className={`bg-white dark:bg-gray-700 rounded-2xl shadow p-4 space-y-2 ${completed ? 'swipe-left-out' : ''}`} data-testid="care-card">
+    <div
+      className={`relative bg-white dark:bg-gray-700 rounded-2xl shadow p-4 space-y-2 ${internalCompleted ? 'swipe-left-out' : ''}`}
+      data-testid="care-card"
+    >
       <div className="flex items-center justify-between">
         <div className="flex items-center gap-2">
           {Icon && <Icon className="w-5 h-5" aria-hidden="true" />}
@@ -30,12 +42,37 @@ export default function CareCard({ label, Icon, progress = 0, status, onDone }) 
         )}
       </div>
       {status && <p className="text-sm text-gray-500">{status}</p>}
-      <div className="h-2 rounded bg-gray-200 overflow-hidden" role="progressbar" aria-valuenow={Math.round(pct*100)} aria-valuemin="0" aria-valuemax="100">
+      <div
+        className="h-2 rounded bg-gray-200 overflow-hidden"
+        role="progressbar"
+        aria-valuenow={Math.round(pct * 100)}
+        aria-valuemin="0"
+        aria-valuemax="100"
+      >
         <div
           className="h-full bg-gradient-to-r from-green-500 via-orange-500 to-red-500"
           style={{ width }}
         ></div>
       </div>
+      {showComplete && (
+        <div className="absolute inset-0 flex items-center justify-center pointer-events-none task-complete-fade">
+          {label === 'Fertilize' ? (
+            <Sprout className="w-8 h-8 text-healthy-600 sprout-bounce swipe-check fade-in" />
+          ) : (
+            <svg
+              className="w-8 h-8 text-healthy-600 check-pop swipe-check fade-in"
+              xmlns="http://www.w3.org/2000/svg"
+              fill="none"
+              viewBox="0 0 24 24"
+              strokeWidth="1.5"
+              stroke="currentColor"
+              aria-hidden="true"
+            >
+              <path strokeLinecap="round" strokeLinejoin="round" d="M4.5 12.75l6 6 9-13.5" />
+            </svg>
+          )}
+        </div>
+      )}
     </div>
   )
 }

--- a/src/components/__tests__/CareCard.test.jsx
+++ b/src/components/__tests__/CareCard.test.jsx
@@ -1,5 +1,5 @@
 import { render, screen, fireEvent } from '@testing-library/react'
-import { Drop } from 'phosphor-react'
+import { Drop, Sun } from 'phosphor-react'
 import CareCard from '../CareCard.jsx'
 
 test('renders label, status and progress width', () => {
@@ -21,5 +21,16 @@ test('calls handler when done', () => {
   jest.runAllTimers()
 
   expect(onDone).toHaveBeenCalled()
+  jest.useRealTimers()
+})
+
+test('shows sprout icon for fertilize card when completed', () => {
+  jest.useFakeTimers()
+  const { container } = render(
+    <CareCard label="Fertilize" Icon={Sun} progress={0} status="Today" onDone={() => {}} />
+  )
+  fireEvent.click(screen.getByRole('button', { name: /mark as done/i }))
+  expect(container.querySelector('.sprout-bounce')).toBeInTheDocument()
+  jest.runAllTimers()
   jest.useRealTimers()
 })

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -88,6 +88,7 @@ export default function PlantDetail() {
   const [offsetY, setOffsetY] = useState(0);
   const [expandedNotes, setExpandedNotes] = useState({});
   const [showDiameterModal, setShowDiameterModal] = useState(false);
+  const [fertilizeDone, setFertilizeDone] = useState(false);
 
   const waterProgress = getWateringProgress(
     plant?.lastWatered,
@@ -174,8 +175,10 @@ export default function PlantDetail() {
   };
 
   const handleFertilized = () => {
+    setFertilizeDone(true);
     markFertilized(plant.id, "");
     showToast("Fertilized");
+    setTimeout(() => setFertilizeDone(false), 200);
   };
 
   const handleLogEvent = () => {
@@ -269,6 +272,7 @@ export default function PlantDetail() {
                 Icon={Sun}
                 progress={fertProgress}
                 status={fertStatus}
+                completed={fertilizeDone}
                 onDone={handleFertilized}
               />
             </div>


### PR DESCRIPTION
## Summary
- animate fertilize completion with sprout icon
- trigger completion animation from PlantDetail
- test CareCard fertilize completion

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d98bc970083249edcb4f7683a24c9