### PR TITLE
Add Care Plan tab to PlantDetail

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -249,7 +249,7 @@ export default function PlantDetail() {
   const tabs = [
     {
       id: "tasks",
-      label: "Care",
+      label: "Tasks",
       content: (
         <div className="p-4 space-y-2">
           <div
@@ -288,6 +288,31 @@ export default function PlantDetail() {
               {plant.smartWaterPlan.interval} days —{" "}
               {plant.smartWaterPlan.reason}
             </p>
+          )}
+        </div>
+      ),
+    },
+    {
+      id: "care-plan",
+      label: "Care Plan",
+      content: (
+        <div className="p-4 space-y-2" data-testid="care-plan-tab">
+          <p>
+            Pot diameter: {plant.diameter ? `${plant.diameter} in` : "N/A"}
+          </p>
+          {plant.waterPlan && (
+            <p>
+              {plant.waterPlan.volume} in³ every {plant.waterPlan.interval} days
+            </p>
+          )}
+          {plant.smartWaterPlan && (
+            <p data-testid="smart-water-plan-details">
+              {plant.smartWaterPlan.volume} in³ every {plant.smartWaterPlan.interval}{" "}
+              days — {plant.smartWaterPlan.reason}
+            </p>
+          )}
+          {plant.notes && (
+            <pre className="whitespace-pre-wrap">{plant.notes}</pre>
           )}
         </div>
       ),

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -96,7 +96,8 @@ test('displays all sections', () => {
     </OpenAIProvider>
   )
 
-  expect(screen.getByRole('tab', { name: /care/i })).toBeInTheDocument()
+  expect(screen.getByRole('tab', { name: /tasks/i })).toBeInTheDocument()
+  expect(screen.getByRole('tab', { name: /care plan/i })).toBeInTheDocument()
   expect(screen.getByRole('tab', { name: /activity/i })).toBeInTheDocument()
   expect(screen.getByRole('tab', { name: /gallery/i })).toBeInTheDocument()
   expect(screen.queryByRole('tab', { name: /overview/i })).toBeNull()
@@ -235,4 +236,51 @@ test('care tab hides kebab menu for due tasks', () => {
 
   expect(screen.queryByRole('button', { name: /open task menu/i })).toBeNull()
   jest.useRealTimers()
+})
+
+test('care plan tab displays stored onboarding values', () => {
+  localStorage.setItem(
+    'plants',
+    JSON.stringify([
+      {
+        id: 1,
+        name: 'Aloe',
+        image: 'a.jpg',
+        diameter: 4,
+        waterPlan: { volume: 10, interval: 7 },
+        smartWaterPlan: { volume: 12, interval: 5, reason: 'test reason' },
+        notes: 'keep soil moist',
+        photos: [],
+        careLog: [],
+      },
+    ])
+  )
+
+  render(
+    <OpenAIProvider>
+      <MenuProvider>
+        <PlantProvider>
+          <MemoryRouter initialEntries={['/plant/1']}>
+            <Routes>
+              <Route path="/plant/:id" element={<PlantDetail />} />
+            </Routes>
+          </MemoryRouter>
+        </PlantProvider>
+      </MenuProvider>
+    </OpenAIProvider>
+  )
+
+  fireEvent.click(screen.getByRole('tab', { name: /care plan/i }))
+
+  const panel = screen.getByTestId('care-plan-tab')
+  expect(within(panel).getByText(/pot diameter/i)).toHaveTextContent('4 in')
+  expect(
+    within(panel).getByText('10 in³ every 7 days')
+  ).toBeInTheDocument()
+  expect(
+    within(panel).getByTestId('smart-water-plan-details')
+  ).toHaveTextContent('12 in³ every 5 days — test reason')
+  expect(within(panel).getByText('keep soil moist')).toBeInTheDocument()
+
+  localStorage.clear()
 })


### PR DESCRIPTION
## Summary
- rename Care tab to Tasks in `PlantDetail`
- add new **Care Plan** tab showing pot size, water plans, smart plan and notes
- update tests for new tab labels
- test that Care Plan tab displays stored onboarding data

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687d9902ef7883249976d8c3edcc6e3c