### PR TITLE
Improve label readability in CareStats

### DIFF
--- a/src/components/CareStats.jsx
+++ b/src/components/CareStats.jsx
@@ -45,7 +45,7 @@ function StatBlock({
         </div>
       </div>
       <div className="flex items-center gap-1 mt-1">
-        <span className="text-[11px] font-semibold text-gray-700 font-body">
+        <span className="text-xs font-semibold text-gray-700 font-body">
           {label}
         </span>
       </div>


### PR DESCRIPTION
## Summary
- bump label font size in `CareStats` from `text-[11px]` to `text-xs`

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687d9a49eef88324846516ad97a46624