### PR TITLE
Enhance Plant detail task tab

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -255,13 +255,16 @@ export default function PlantDetail() {
       label: "Tasks",
       content: (
         <div className="p-4 space-y-2">
+          <h3 className="text-lg font-semibold" data-testid="tasks-heading">
+            Today's Tasks
+          </h3>
           <div
             className="flex flex-col items-center"
             aria-label="Care progress"
             aria-describedby="progress-hint"
             title="Progress toward next scheduled care"
           >
-            <div className="w-full max-w-xs space-y-3">
+            <div className="w-full max-w-xs space-y-4">
               <CareCard
                 label="Water"
                 Icon={Drop}
@@ -269,7 +272,13 @@ export default function PlantDetail() {
                 status={waterStatus}
                 onDone={handleWatered}
               />
-              <div className={plant.nextFertilize ? '' : 'opacity-50'}>
+              <div
+                className={
+                  plant.nextFertilize
+                    ? ''
+                    : 'opacity-50 bg-gray-50 dark:bg-gray-700 p-2 rounded-2xl'
+                }
+              >
                 <CareCard
                   label="Fertilize"
                   Icon={Sun}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -79,6 +79,25 @@ test('shows countdown text inside care cards', () => {
   jest.useRealTimers()
 })
 
+test('tasks tab displays a heading', () => {
+  const plant = plants[0]
+  render(
+    <OpenAIProvider>
+      <MenuProvider>
+        <PlantProvider>
+          <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+            <Routes>
+              <Route path="/plant/:id" element={<PlantDetail />} />
+            </Routes>
+          </MemoryRouter>
+        </PlantProvider>
+      </MenuProvider>
+    </OpenAIProvider>
+  )
+
+  expect(screen.getByTestId('tasks-heading')).toHaveTextContent(/today/i)
+})
+
 
 test('displays all sections', () => {
   const plant = plants[0]


### PR DESCRIPTION
## Summary
- add new heading in the tasks tab
- enlarge spacing between task cards
- style unscheduled fertilize task with dimmed gray background
- test for new tasks heading

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687da005f33c832494fa7f3511b13149