### PR TITLE
Add care plan info modal

### DIFF
--- a/src/components/CarePlanInfoModal.jsx
+++ b/src/components/CarePlanInfoModal.jsx
@@ -1,0 +1,29 @@
+import React from 'react'
+
+export default function CarePlanInfoModal({ onClose }) {
+  return (
+    <div
+      role="dialog"
+      aria-modal="true"
+      aria-label="Care plan information"
+      className="modal-overlay bg-black/70 z-50"
+    >
+      <div className="modal-box p-4 w-72 max-w-full">
+        <h3 className="font-headline mb-2">How We Create Your Care Plan</h3>
+        <p className="text-sm mb-4">
+          Suggested watering amounts use your plant type, pot size and light level
+          along with weather data to fine tune the schedule.
+        </p>
+        <div className="flex justify-end">
+          <button
+            type="button"
+            onClick={onClose}
+            className="px-3 py-1 bg-gray-200 dark:bg-gray-600 rounded"
+          >
+            Close
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -24,6 +24,7 @@ import actionIcons from "../components/ActionIcons.jsx";
 import NoteModal from "../components/NoteModal.jsx";
 import { useMenu, defaultMenu } from "../MenuContext.jsx";
 import LegendModal from "../components/LegendModal.jsx";
+import CarePlanInfoModal from "../components/CarePlanInfoModal.jsx";
 import CareCard from "../components/CareCard.jsx";
 import PlantDetailFab from "../components/PlantDetailFab.jsx";
 import DetailTabs from "../components/DetailTabs.jsx";
@@ -83,6 +84,7 @@ export default function PlantDetail() {
   const [showNoteModal, setShowNoteModal] = useState(false);
   const [lightboxIndex, setLightboxIndex] = useState(null);
   const [showLegend, setShowLegend] = useState(false);
+  const [showCarePlanInfo, setShowCarePlanInfo] = useState(false);
   const [collapsedMonths, setCollapsedMonths] = useState({});
   const [latestFirst, setLatestFirst] = useState(true);
   const [offsetY, setOffsetY] = useState(0);
@@ -315,11 +317,21 @@ export default function PlantDetail() {
       label: "Care Plan",
       content: (
         <div className="p-4 space-y-2" data-testid="care-plan-tab">
-          {(plant.waterPlan?.interval || plant.smartWaterPlan) && (
-            <h3 className="text-heading font-semibold">
-              {plant.smartWaterPlan ? "Recommended Plan" : "Custom Care Plan"}
-            </h3>
-          )}
+          <div className="flex items-center justify-between">
+            {(plant.waterPlan?.interval || plant.smartWaterPlan) && (
+              <h3 className="text-heading font-semibold">
+                {plant.smartWaterPlan ? "Recommended Plan" : "Custom Care Plan"}
+              </h3>
+            )}
+            <button
+              type="button"
+              aria-label="How care plan is generated"
+              onClick={() => setShowCarePlanInfo(true)}
+              className="text-gray-400 hover:text-gray-600 dark:hover:text-gray-300"
+            >
+              ⓘ
+            </button>
+          </div>
           <div className="bg-gray-50 dark:bg-gray-700 p-4 rounded space-y-2">
             <p className="text-sm">
               <span className="text-gray-500 dark:text-gray-400">Pot diameter:</span>{" "}
@@ -665,6 +677,9 @@ export default function PlantDetail() {
           <NoteModal label="Note" onSave={saveNote} onCancel={cancelNote} />
         )}
         {showLegend && <LegendModal onClose={() => setShowLegend(false)} />}
+        {showCarePlanInfo && (
+          <CarePlanInfoModal onClose={() => setShowCarePlanInfo(false)} />
+        )}
         {showDiameterModal && (
           <InputModal
             label="Pot diameter (inches)"

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -292,3 +292,47 @@ test('care plan tab displays stored onboarding values', () => {
 
   localStorage.clear()
 })
+
+test('care plan info modal opens from button', () => {
+  localStorage.setItem(
+    'plants',
+    JSON.stringify([
+      {
+        id: 1,
+        name: 'Aloe',
+        image: 'a.jpg',
+        diameter: 4,
+        waterPlan: { volume: 10, interval: 7 },
+        photos: [],
+        careLog: [],
+      },
+    ])
+  )
+
+  render(
+    <OpenAIProvider>
+      <MenuProvider>
+        <PlantProvider>
+          <MemoryRouter initialEntries={['/plant/1']}>
+            <Routes>
+              <Route path="/plant/:id" element={<PlantDetail />} />
+            </Routes>
+          </MemoryRouter>
+        </PlantProvider>
+      </MenuProvider>
+    </OpenAIProvider>
+  )
+
+  fireEvent.click(screen.getByRole('tab', { name: /care plan/i }))
+  const panel = screen.getByTestId('care-plan-tab')
+  const btn = within(panel).getByRole('button', {
+    name: /how care plan is generated/i,
+  })
+  fireEvent.click(btn)
+
+  expect(
+    screen.getByRole('dialog', { name: /care plan information/i })
+  ).toBeInTheDocument()
+
+  localStorage.clear()
+})


### PR DESCRIPTION
## Summary
- explain plant care plan with new `CarePlanInfoModal`
- show an info button on the Care Plan tab in `PlantDetail`
- open/close the modal via state
- test that button and modal appear

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687da050e9e08324969cdb2f0b4bba50