### PR TITLE
Remove pot diameter edit section

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -659,18 +659,6 @@ export default function PlantDetail() {
       </div>
       <PageContainer size="xl" className="relative text-left pt-0 space-y-3">
         <Toast />
-        <div className="flex justify-between items-center px-2">
-          <p className="text-sm">
-            Pot diameter: {plant.diameter ? `${plant.diameter} in` : "N/A"}
-          </p>
-          <button
-            type="button"
-            onClick={() => setShowDiameterModal(true)}
-            className="text-green-600 text-sm"
-          >
-            Edit
-          </button>
-        </div>
 
         <div className="space-y-3">
           <DetailTabs tabs={tabs} />


### PR DESCRIPTION
## Summary
- remove pot diameter display/edit section from PlantDetail page

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687da31f70888324ba0e3ea7e53ae1dc