### PR TITLE
Enhance PlantDetailFab menu effects

### DIFF
--- a/src/components/PlantDetailFab.jsx
+++ b/src/components/PlantDetailFab.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react'
 import { createPortal } from 'react-dom'
 import { Plus, Image as ImageIcon, Note, Drop, Flower } from 'phosphor-react'
+import { motion } from 'framer-motion'
 
 export default function PlantDetailFab({
   onAddPhoto,
@@ -39,6 +40,22 @@ export default function PlantDetailFab({
     violet: { bg: 'bg-violet-100', text: 'text-violet-600' },
   }
 
+  const listVariants = {
+    closed: {},
+    open: {
+      transition: { staggerChildren: 0.05, delayChildren: 0.05 },
+    },
+  }
+
+  const itemVariants = {
+    closed: { scale: 0.8, opacity: 0 },
+    open: {
+      scale: 1,
+      opacity: 1,
+      transition: { type: 'spring', stiffness: 260, damping: 20 },
+    },
+  }
+
   const labelText = plantName ? `Add to ${plantName}'s Journal` : 'Add to Journal'
 
   return (
@@ -46,14 +63,17 @@ export default function PlantDetailFab({
       {open &&
         createPortal(
           <div
-            className="modal-overlay bg-black/50 z-30"
+            className="modal-overlay bg-black/50 z-30 backdrop-blur-sm"
             role="dialog"
             aria-modal="true"
             aria-label={labelText}
             onClick={() => setOpen(false)}
           >
-            <div
-              className="modal-box relative p-4 w-80 max-w-full"
+            <motion.div
+              initial={{ scale: 0.95, opacity: 0 }}
+              animate={{ scale: 1, opacity: 1 }}
+              transition={{ type: 'spring', stiffness: 260, damping: 20 }}
+              className="modal-box relative p-4 w-80 max-w-full bloom-pop"
               onClick={e => e.stopPropagation()}
             >
               <div className="flex items-center justify-between mb-3">
@@ -69,9 +89,18 @@ export default function PlantDetailFab({
                   &times;
                 </button>
               </div>
-              <ul className="grid grid-cols-2 gap-2">
+              <motion.ul
+                variants={listVariants}
+                initial="closed"
+                animate="open"
+                className="grid grid-cols-2 gap-2"
+              >
                 {items.map(({ label, Icon, action, color }) => (
-                  <li key={label} className="list-none">
+                  <motion.li
+                    key={label}
+                    variants={itemVariants}
+                    className="list-none animate-bounce-once"
+                  >
                     <button
                       type="button"
                       onClick={() => {
@@ -88,10 +117,10 @@ export default function PlantDetailFab({
                         {label}
                       </span>
                     </button>
-                  </li>
+                  </motion.li>
                 ))}
-              </ul>
-            </div>
+              </motion.ul>
+            </motion.div>
           </div>,
           document.body
         )}

--- a/src/pages/__tests__/PlantDetailActions.test.jsx
+++ b/src/pages/__tests__/PlantDetailActions.test.jsx
@@ -121,3 +121,26 @@ test('fab triggers file input click', () => {
   expect(clickSpy).toHaveBeenCalled()
   clickSpy.mockRestore()
 })
+
+test('fab menu overlay blurred with animated items', () => {
+  render(
+    <OpenAIProvider>
+      <SnackbarProvider>
+        <MenuProvider>
+          <MemoryRouter initialEntries={['/plant/1']}>
+            <Routes>
+              <Route path="/plant/:id" element={<PlantDetail />} />
+            </Routes>
+          </MemoryRouter>
+        </MenuProvider>
+        <Snackbar />
+      </SnackbarProvider>
+    </OpenAIProvider>
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /add to journal/i }))
+  const overlay = screen.getByRole('dialog', { name: /journal/i })
+  expect(overlay).toHaveClass('backdrop-blur-sm')
+  const animated = overlay.querySelector('.bloom-pop')
+  expect(animated).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- add blur backdrop and framer-motion animation to PlantDetailFab
- stagger menu items for bounce effect
- test overlay blur and animation classes

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687da6b45d4483248261d4b4c2fc60dd