### PR TITLE
Fix fertilize button when unscheduled

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -281,13 +281,13 @@ export default function PlantDetail() {
                     : 'opacity-50 bg-gray-50 dark:bg-gray-700 p-2 rounded-2xl'
                 }
               >
-                <CareCard
+              <CareCard
                   label="Fertilize"
                   Icon={Sun}
                   progress={fertProgress}
                   status={fertStatus}
                   completed={fertilizeDone}
-                  onDone={handleFertilized}
+                  onDone={plant.nextFertilize ? handleFertilized : undefined}
                 />
                 {!plant.nextFertilize && (
                   <button

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -98,6 +98,26 @@ test('tasks tab displays a heading', () => {
   expect(screen.getByTestId('tasks-heading')).toHaveTextContent(/today/i)
 })
 
+test('cannot mark fertilize done when not scheduled', () => {
+  const plant = plants.find(p => p.id === 2)
+  render(
+    <OpenAIProvider>
+      <MenuProvider>
+        <PlantProvider>
+          <MemoryRouter initialEntries={[`/plant/${plant.id}`]}>
+            <Routes>
+              <Route path="/plant/:id" element={<PlantDetail />} />
+            </Routes>
+          </MemoryRouter>
+        </PlantProvider>
+      </MenuProvider>
+    </OpenAIProvider>
+  )
+
+  const buttons = screen.getAllByRole('button', { name: /mark as done/i })
+  expect(buttons).toHaveLength(1)
+})
+
 
 test('displays all sections', () => {
   const plant = plants[0]


### PR DESCRIPTION
## Summary
- prevent completing fertilize task when no schedule exists
- test that fertilize "Mark as Done" does not render for unscheduled plants

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687da7b7706c83248ca12db33996312f