### PR TITLE
Adjust hero overlay and plant details

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -305,12 +305,12 @@ body {
 
 /* Image gradient overlay */
 .img-gradient-overlay {
-  @apply absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent;
+  @apply absolute inset-0 bg-gradient-to-t from-black/50 via-transparent;
 }
 
 /* Gradient backdrop for hero text */
 .hero-name-bg {
-  @apply bg-gradient-to-r from-black/70 via-black/40 to-transparent rounded-xl p-2;
+  @apply p-2;
 }
 
 @layer utilities {

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -645,17 +645,17 @@ export default function PlantDetail() {
           </div>
           <div className="absolute bottom-2 left-3 right-3 flex flex-col sm:flex-row justify-between text-white drop-shadow space-y-1 sm:space-y-0">
             <div className="hero-name-bg">
-              <h2 className="text-3xl font-extrabold font-headline animate-fade-in-down">
+              <h2 className="text-4xl font-extrabold font-headline tracking-wide animate-fade-in-down">
                 {plant.name}
               </h2>
               {plant.scientificName && (
-                <p className="text-lg italic text-gray-200 animate-fade-in-down" style={{ animationDelay: '50ms' }}>
+                <p className="text-sm italic text-gray-100 animate-fade-in-down" style={{ animationDelay: '50ms' }}>
                   {plant.scientificName}
                 </p>
               )}
               {plant.nickname && (
                 <p
-                  className="text-sm text-gray-200 animate-fade-in-down"
+                  className="text-sm italic text-gray-100 animate-fade-in-down"
                   style={{ animationDelay: "100ms" }}
                 >
                   {plant.nickname}
@@ -671,7 +671,7 @@ export default function PlantDetail() {
               )}
               <Link
                 to={`/plant/${plant.id}/coach`}
-                className="inline-block mt-2 px-3 py-1 bg-green-600 text-white text-sm rounded"
+                className="inline-block mt-2 px-3 py-1 bg-white/20 border rounded-full text-xs text-white"
               >
                 Coach
               </Link>


### PR DESCRIPTION
## Summary
- soften overlay gradient and remove hero text gradient
- enlarge plant name heading and adjust fonts
- unify scientific and nickname styling
- style coach link as translucent pill

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687da8f769c08324868731bce368505e