### PR TITLE
Use Badge in FeaturedCard overlay

### DIFF
--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -16,6 +16,7 @@ import {
 import useINatPhoto from '../hooks/useINatPhoto.js'
 import usePlantFact from '../hooks/usePlantFact.js'
 import { createRipple } from '../utils/interactions.js'
+import Badge from './Badge.jsx'
 
 
 
@@ -93,10 +94,13 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
       />
       <div className="featured-overlay" aria-hidden="true"></div>
       <div className="absolute bottom-3 left-4 right-4 text-white space-y-1 drop-shadow-md">
-        <span className="text-xs uppercase tracking-wide opacity-90 flex items-center gap-1">
-          <Flower className="w-3 h-3" aria-hidden="true" />
+        <Badge
+          Icon={Flower}
+          colorClass="bg-black/60 text-white backdrop-blur-sm"
+          className="uppercase tracking-wide opacity-90"
+        >
           Featured Plant of the Day
-        </span>
+        </Badge>
 
         <h2 className="font-display text-3xl font-bold">{name}</h2>
         {preview && (

--- a/src/components/__tests__/FeaturedCard.test.jsx
+++ b/src/components/__tests__/FeaturedCard.test.jsx
@@ -24,7 +24,9 @@ test('shows featured label and care summary', () => {
       <FeaturedCard plants={plants} />
     </MemoryRouter>
   )
-  expect(screen.getByText('Featured Plant of the Day')).toBeInTheDocument()
+  const badge = screen.getByText('Featured Plant of the Day')
+  expect(badge).toBeInTheDocument()
+  expect(badge).toHaveClass('rounded-full')
   expect(screen.getByText('Aloe')).toBeInTheDocument()
   expect(screen.getByText('Last watered 3 days ago \u00B7 Needs water today')).toBeInTheDocument()
 })


### PR DESCRIPTION
## Summary
- show `Featured Plant of the Day` using the reusable `Badge` component
- verify badge styling in tests

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687daa5274c883248dd0b251bb96e5f0