### PR TITLE
Change featured plant preview

### DIFF
--- a/src/components/FeaturedCard.jsx
+++ b/src/components/FeaturedCard.jsx
@@ -1,7 +1,6 @@
 import { useState } from 'react'
 import { Link, useLocation } from 'react-router-dom'
 import { useWeather } from '../WeatherContext.jsx'
-import { formatCareSummary } from '../utils/date.js'
 import {
   Flower,
   Sun,
@@ -66,7 +65,7 @@ export default function FeaturedCard({ plants = [], task, startIndex = 0 }) {
   const preview =
     caredToday && !needsCareToday
       ? `${name} is all set today!`
-      : formatCareSummary(plant.lastWatered, plant.nextWater)
+      : [plant.light, plant.difficulty].filter(Boolean).join(' \u00B7 ')
   const imageSrc =
     (plant.photos && plant.photos[0]?.src) ||
     plant.image ||

--- a/src/components/__tests__/FeaturedCard.test.jsx
+++ b/src/components/__tests__/FeaturedCard.test.jsx
@@ -14,11 +14,27 @@ beforeAll(() => {
 jest.useFakeTimers().setSystemTime(new Date('2025-07-10'))
 
 const plants = [
-  { id: 1, name: 'Aloe', image: 'test.jpg', lastWatered: '2025-07-07', nextWater: '2025-07-10' },
-  { id: 2, name: 'Pothos', image: 'test2.jpg', lastWatered: '2025-07-08', nextWater: '2025-07-11' },
+  {
+    id: 1,
+    name: 'Aloe',
+    image: 'test.jpg',
+    lastWatered: '2025-07-07',
+    nextWater: '2025-07-10',
+    light: 'Bright',
+    difficulty: 'Moderate',
+  },
+  {
+    id: 2,
+    name: 'Pothos',
+    image: 'test2.jpg',
+    lastWatered: '2025-07-08',
+    nextWater: '2025-07-11',
+    light: 'Low',
+    difficulty: 'Easy',
+  },
 ]
 
-test('shows featured label and care summary', () => {
+test('shows featured label and plant info', () => {
   render(
     <MemoryRouter>
       <FeaturedCard plants={plants} />
@@ -28,7 +44,7 @@ test('shows featured label and care summary', () => {
   expect(badge).toBeInTheDocument()
   expect(badge).toHaveClass('rounded-full')
   expect(screen.getByText('Aloe')).toBeInTheDocument()
-  expect(screen.getByText('Last watered 3 days ago \u00B7 Needs water today')).toBeInTheDocument()
+  expect(screen.getByText('Bright \u00B7 Moderate')).toBeInTheDocument()
 })
 
 test('swipe does not change plant', () => {


### PR DESCRIPTION
## Summary
- show light and difficulty on the Featured Plant card instead of last watering details
- update FeaturedCard tests accordingly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dad08e4808324ade6bdf0d6933666