### PR TITLE
Expand plant detail tabs width

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -683,7 +683,7 @@ export default function PlantDetail() {
         <Toast />
 
         <div className="space-y-3">
-          <div className="sticky top-0 z-10 backdrop-blur-sm">
+          <div className="full-bleed sticky top-0 z-10 backdrop-blur-sm">
             <DetailTabs
               tabs={tabs}
               value={activeTab}


### PR DESCRIPTION
## Summary
- make the PlantDetail tabs full width using the existing `full-bleed` utility

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687dad72d7388324981acb1179070272