### PR TITLE
Adjust fertilize UI in plant detail page

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -289,7 +289,7 @@ export default function PlantDetail() {
             aria-describedby="progress-hint"
             title="Progress toward next scheduled care"
           >
-            <div className="w-full max-w-xs space-y-4">
+            <div className="w-full max-w-xs flex flex-col gap-y-4">
               <CareCard
                 label="Water"
                 Icon={Drop}
@@ -301,7 +301,7 @@ export default function PlantDetail() {
                 className={
                   plant.nextFertilize
                     ? ''
-                    : 'opacity-50 bg-gray-50 dark:bg-gray-700 p-2 rounded-2xl'
+                    : 'opacity-50 bg-gray-50 dark:bg-gray-700 p-4 rounded-2xl'
                 }
               >
               <CareCard
@@ -316,7 +316,7 @@ export default function PlantDetail() {
                   <button
                     type="button"
                     onClick={handleEdit}
-                    className="mt-2 text-sm text-green-600 underline"
+                    className="mt-3 inline-block px-3 py-1.5 text-sm font-semibold text-green-700 bg-green-50 rounded-full"
                   >
                     Add Schedule
                   </button>


### PR DESCRIPTION
## Summary
- improve layout of care cards by switching from `space-y` to flex with `gap-y-4`
- use more visible padding for fertilize box when not scheduled
- style "Add Schedule" button with a more discoverable pill shape

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687db0af1d788324bd32c84e1ec94740