### PR TITLE
Add fertilization schedule editing

### DIFF
--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -38,6 +38,8 @@ const initialState = {
   image: '',
   lastWatered: '',
   nextWater: '',
+  lastFertilized: '',
+  nextFertilize: '',
   room: '',
   notes: '',
   careLevel: '',
@@ -53,6 +55,10 @@ function reducer(state, action) {
       return { ...state, lastWatered: action.payload }
     case 'SET_NEXT':
       return { ...state, nextWater: action.payload }
+    case 'SET_LAST_FERT':
+      return { ...state, lastFertilized: action.payload }
+    case 'SET_NEXT_FERT':
+      return { ...state, nextFertilize: action.payload }
     case 'SET_ROOM':
       return { ...state, room: action.payload }
     case 'SET_NOTES':
@@ -83,6 +89,8 @@ export default function Add() {
       image: imagePath,
       lastWatered: state.lastWatered,
       nextWater: state.nextWater,
+      lastFertilized: state.lastFertilized,
+      nextFertilize: state.nextFertilize,
       ...(state.room && { room: state.room }),
       ...(state.notes && { notes: state.notes }),
       ...(state.careLevel && { careLevel: state.careLevel }),
@@ -113,6 +121,8 @@ export default function Add() {
         <ScheduleStep
           lastWatered={state.lastWatered}
           nextWater={state.nextWater}
+          lastFertilized={state.lastFertilized}
+          nextFertilize={state.nextFertilize}
           dispatch={dispatch}
           onBack={back}
           onSubmit={next}

--- a/src/pages/EditPlant.jsx
+++ b/src/pages/EditPlant.jsx
@@ -13,6 +13,8 @@ export default function EditPlant() {
   const [image, setImage] = useState('')
   const [lastWatered, setLastWatered] = useState('')
   const [nextWater, setNextWater] = useState('')
+  const [lastFertilized, setLastFertilized] = useState('')
+  const [nextFertilize, setNextFertilize] = useState('')
   const nameInputRef = useRef(null)
 
   useEffect(() => {
@@ -35,6 +37,8 @@ export default function EditPlant() {
       setImage(plant.image || '')
       setLastWatered(plant.lastWatered || '')
       setNextWater(plant.nextWater || '')
+      setLastFertilized(plant.lastFertilized || '')
+      setNextFertilize(plant.nextFertilize || '')
     }
   }, [plant])
 
@@ -44,7 +48,14 @@ export default function EditPlant() {
 
   const handleSubmit = e => {
     e.preventDefault()
-    updatePlant(plant.id, { name, image, lastWatered, nextWater })
+    updatePlant(plant.id, {
+      name,
+      image,
+      lastWatered,
+      nextWater,
+      lastFertilized,
+      nextFertilize,
+    })
     navigate(`/plant/${plant.id}`)
   }
 
@@ -108,6 +119,26 @@ export default function EditPlant() {
           type="date"
           value={nextWater}
           onChange={e => setNextWater(e.target.value)}
+          className="border rounded p-2"
+        />
+      </div>
+      <div className="grid gap-1">
+        <label htmlFor="lastFertilized" className="font-medium">Last Fertilized</label>
+        <input
+          id="lastFertilized"
+          type="date"
+          value={lastFertilized}
+          onChange={e => setLastFertilized(e.target.value)}
+          className="border rounded p-2"
+        />
+      </div>
+      <div className="grid gap-1">
+        <label htmlFor="nextFertilize" className="font-medium">Next Fertilizing</label>
+        <input
+          id="nextFertilize"
+          type="date"
+          value={nextFertilize}
+          onChange={e => setNextFertilize(e.target.value)}
           className="border rounded p-2"
         />
       </div>

--- a/src/pages/__tests__/Add.test.jsx
+++ b/src/pages/__tests__/Add.test.jsx
@@ -56,6 +56,8 @@ test('user can complete steps and add a plant', () => {
   // step 3
   expect(screen.getByText(/step 3 of 4/i)).toBeInTheDocument()
   expect(screen.getByLabelText(/last watered/i)).toBeInTheDocument()
+  expect(screen.getByLabelText(/last fertilized/i)).toBeInTheDocument()
+  expect(screen.getByLabelText(/next fertilizing/i)).toBeInTheDocument()
   fireEvent.click(screen.getByRole('button', { name: /next/i }))
 
   // step 4

--- a/src/pages/add/ScheduleStep.jsx
+++ b/src/pages/add/ScheduleStep.jsx
@@ -1,5 +1,13 @@
 import PageContainer from "../../components/PageContainer.jsx"
-export default function ScheduleStep({ lastWatered, nextWater, dispatch, onBack, onSubmit }) {
+export default function ScheduleStep({
+  lastWatered,
+  nextWater,
+  lastFertilized,
+  nextFertilize,
+  dispatch,
+  onBack,
+  onSubmit,
+}) {
   return (
     <PageContainer size="md">
     <form onSubmit={e => {e.preventDefault(); onSubmit();}} className="space-y-4">
@@ -21,6 +29,26 @@ export default function ScheduleStep({ lastWatered, nextWater, dispatch, onBack,
           type="date"
           value={nextWater}
           onChange={e => dispatch({ type: 'SET_NEXT', payload: e.target.value })}
+          className="border rounded p-2"
+        />
+      </div>
+      <div className="grid gap-1">
+        <label htmlFor="lastFertilized" className="font-medium">Last Fertilized</label>
+        <input
+          id="lastFertilized"
+          type="date"
+          value={lastFertilized}
+          onChange={e => dispatch({ type: 'SET_LAST_FERT', payload: e.target.value })}
+          className="border rounded p-2"
+        />
+      </div>
+      <div className="grid gap-1">
+        <label htmlFor="nextFertilize" className="font-medium">Next Fertilizing</label>
+        <input
+          id="nextFertilize"
+          type="date"
+          value={nextFertilize}
+          onChange={e => dispatch({ type: 'SET_NEXT_FERT', payload: e.target.value })}
           className="border rounded p-2"
         />
       </div>


### PR DESCRIPTION
## Summary
- let ScheduleStep collect fertilization dates
- handle fertilization fields in Add flow
- support editing last/next fertilize dates
- test that Add flow shows fertilization fields

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687db1a039d48324b13e9dd1e6f56f4f