### PR TITLE
Improve desktop layout for Plant detail page

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -390,6 +390,14 @@ body {
   margin-right: calc(50% - 50vw);
 }
 
+@media (min-width: 1024px) {
+  .full-bleed {
+    width: auto;
+    margin-left: 0;
+    margin-right: 0;
+  }
+}
+
 /* Animated underline used in tab components */
 .tab-underline {
   @apply absolute bottom-0 h-0.5 bg-green-600 rounded-full transition-all duration-300;

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -613,8 +613,8 @@ export default function PlantDetail() {
   }
 
   return (
-    <>
-      <div className="full-bleed relative mb-1 -mt-8 lg:sticky top-0 z-10">
+    <div className="lg:flex lg:items-start lg:max-w-5xl lg:mx-auto lg:space-x-8">
+      <div className="full-bleed relative mb-1 -mt-8 lg:sticky top-0 z-10 lg:w-1/2">
         <div className="hidden lg:block absolute inset-0 overflow-hidden -z-10">
           <img
             src={plant.image}
@@ -681,7 +681,7 @@ export default function PlantDetail() {
           </div>
         </div>
       </div>
-      <PageContainer size="xl" className="relative text-left pt-0 space-y-3">
+      <PageContainer size="xl" className="relative text-left pt-0 space-y-3 lg:w-1/2">
         <Toast />
 
         <div className="space-y-3">
@@ -716,6 +716,6 @@ export default function PlantDetail() {
           />
         )}
       </PageContainer>
-    </>
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- limit `full-bleed` utility to mobile widths
- arrange PlantDetail hero and content side by side on large screens

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_687db610a2d883248edd766a9fde6050