### PR TITLE
Add parsed care plan

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -34,6 +34,8 @@ export function PlantProvider({ children }) {
 
       waterPlan: p.waterPlan || { volume: 0, interval: 0 },
 
+      carePlan: p.carePlan || null,
+
       smartWaterPlan: p.smartWaterPlan || null,
 
       lastEvaluated: p.lastEvaluated || null,
@@ -195,6 +197,7 @@ export function PlantProvider({ children }) {
         careLog: [],
         diameter: 0,
         waterPlan: { volume: 0, interval: 0 },
+        carePlan: null,
         ...plant,
       };
       return [...prev, newPlant];

--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -1,4 +1,4 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate } from 'react-router-dom'
 import { usePlants } from '../PlantContext.jsx'
 import { useRooms } from '../RoomContext.jsx'
@@ -24,7 +24,22 @@ export default function Onboard() {
   })
   const [water, setWater] = useState(null)
   const { plan, loading, error, generate } = useCarePlan()
+  const [carePlan, setCarePlan] = useState(null)
   const taxa = usePlantTaxon(form.name)
+
+  useEffect(() => {
+    if (plan?.text) {
+      try {
+        const parsed = JSON.parse(plan.text)
+        if (parsed && typeof parsed === 'object') setCarePlan(parsed)
+        else setCarePlan(null)
+      } catch {
+        setCarePlan(null)
+      }
+    } else {
+      setCarePlan(null)
+    }
+  }, [plan])
 
   const handleUseOutdoorHumidity = () => {
     if (forecast?.humidity !== undefined) {
@@ -58,6 +73,7 @@ export default function Onboard() {
       light: form.light,
       waterPlan: water,
       notes: plan?.text || '',
+      carePlan,
     })
     navigate('/')
   }

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -396,8 +396,16 @@ export default function PlantDetail() {
                 {plant.smartWaterPlan.volume} in³ every {plant.smartWaterPlan.interval} days — {plant.smartWaterPlan.reason}
               </p>
             )}
-            {plant.notes && (
-              <pre className="whitespace-pre-wrap">{plant.notes}</pre>
+            {plant.carePlan ? (
+              <ul className="list-disc pl-4 text-sm text-gray-800 dark:text-gray-200" data-testid="care-plan-list">
+                <li>Water every {plant.carePlan.water} days</li>
+                <li>Fertilize every {plant.carePlan.fertilize} days</li>
+                <li>Light: {plant.carePlan.light}</li>
+              </ul>
+            ) : (
+              plant.notes && (
+                <pre className="whitespace-pre-wrap">{plant.notes}</pre>
+              )
             )}
           </div>
         </div>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -411,3 +411,45 @@ test('care plan info modal opens from button', () => {
 
   localStorage.clear()
 })
+
+test('renders carePlan values in list', () => {
+  localStorage.setItem(
+    'plants',
+    JSON.stringify([
+      {
+        id: 1,
+        name: 'Aloe',
+        image: 'a.jpg',
+        diameter: 4,
+        waterPlan: { volume: 10, interval: 7 },
+        carePlan: { water: 7, fertilize: 30, light: 'Medium' },
+        notes: '{"water":7}',
+        photos: [],
+        careLog: [],
+      },
+    ])
+  )
+
+  render(
+    <OpenAIProvider>
+      <MenuProvider>
+        <PlantProvider>
+          <MemoryRouter initialEntries={['/plant/1']}>
+            <Routes>
+              <Route path="/plant/:id" element={<PlantDetail />} />
+            </Routes>
+          </MemoryRouter>
+        </PlantProvider>
+      </MenuProvider>
+    </OpenAIProvider>
+  )
+
+  fireEvent.click(screen.getByRole('tab', { name: /care plan/i }))
+  const panel = screen.getByTestId('care-plan-tab')
+  const list = within(panel).getByTestId('care-plan-list')
+  expect(within(list).getByText(/water every 7 days/i)).toBeInTheDocument()
+  expect(within(list).getByText(/fertilize every 30 days/i)).toBeInTheDocument()
+  expect(within(list).getByText(/light: medium/i)).toBeInTheDocument()
+
+  localStorage.clear()
+})


### PR DESCRIPTION
## Summary
- parse plan text into a carePlan object during onboarding
- save the carePlan with new plants and handle it in context
- show water, fertilize and light info in Plant detail
- test rendering of the carePlan list

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687dbb6f5eec8324b6585b115e87723b