### PR TITLE
Implement plant detail and coach enhancements

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -315,7 +315,18 @@ body {
 
 /* Gradient backdrop for hero text */
 .hero-name-bg {
-  @apply p-2;
+  @apply p-2 bg-black/50 rounded backdrop-blur-sm;
+}
+
+/* Simple chat bubble styling */
+.chat-bubble {
+  @apply p-3 rounded-lg bg-gray-100 dark:bg-gray-700 max-w-sm;
+}
+.chat-bubble.bot {
+  @apply ml-0 mr-auto text-gray-800 dark:text-gray-100 animate-fade-in;
+}
+.chat-bubble.user {
+  @apply ml-auto mr-0 bg-green-600 text-white animate-fade-in;
 }
 
 @layer utilities {

--- a/src/pages/Coach.jsx
+++ b/src/pages/Coach.jsx
@@ -1,5 +1,6 @@
 import { useParams } from "react-router-dom";
-import { useState } from "react";
+import { useState, useEffect } from "react";
+
 import { usePlants } from "../PlantContext.jsx";
 import usePlantCoach from "../hooks/usePlantCoach.js";
 import PageContainer from "../components/PageContainer.jsx";
@@ -12,11 +13,19 @@ export default function Coach() {
 
   const [question, setQuestion] = useState("");
   const [submitted, setSubmitted] = useState(false);
+  const [history, setHistory] = useState([]);
 
   const { answer, loading, error } = usePlantCoach(
     submitted ? question : "",
     plant,
   );
+
+  useEffect(() => {
+    if (submitted && answer) {
+      setHistory((h) => [...h, { q: question, a: answer }]);
+      setSubmitted(false);
+    }
+  }, [answer, submitted, question]);
 
   const sampleQuestions = generateSampleQuestions(plant);
 
@@ -34,11 +43,21 @@ export default function Coach() {
         }}
         placeholder="Type your plant question"
       />
-      <ul className="text-sm italic text-gray-600 mb-2 space-y-1">
+      <div className="flex gap-2 overflow-x-auto mb-2">
         {sampleQuestions.map((q) => (
-          <li key={q}>“{q}”</li>
+          <button
+            key={q}
+            type="button"
+            className="px-2 py-1 text-sm bg-gray-200 dark:bg-gray-600 rounded-full whitespace-nowrap"
+            onClick={() => {
+              setQuestion(q);
+              setSubmitted(false);
+            }}
+          >
+            {q}
+          </button>
         ))}
-      </ul>
+      </div>
       <button
         className="px-4 py-1 bg-green-600 text-white rounded"
         onClick={ask}
@@ -47,7 +66,15 @@ export default function Coach() {
         Ask
       </button>
       {loading && <p>Loading...</p>}
-      {answer && <p className="mt-4 whitespace-pre-wrap">{answer}</p>}
+      {history.map(({ q, a }, i) => (
+        <div key={i} className="mt-2">
+          <div className="chat-bubble user mb-1">{q}</div>
+          <div className="chat-bubble bot whitespace-pre-wrap">{a}</div>
+        </div>
+      ))}
+      {answer && (
+        <div className="mt-2 chat-bubble bot whitespace-pre-wrap">{answer}</div>
+      )}
       {error && (
         <p role="alert" className="text-red-600">
           {error}

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -21,6 +21,8 @@ import {
   Sun,
   Robot,
   Leaf,
+  Ruler,
+  Thermometer,
 } from "phosphor-react";
 
 import Lightbox from "../components/Lightbox.jsx";
@@ -365,31 +367,28 @@ export default function PlantDetail() {
             </button>
           </div>
           <div className="bg-gray-50 dark:bg-gray-700 p-4 rounded space-y-2">
-            <p className="text-sm">
-              <span className="text-gray-500 dark:text-gray-400">Pot diameter:</span>{" "}
-              <span className="text-gray-800 dark:text-gray-200">
-                {plant.diameter ? `${plant.diameter} in` : "N/A"}
-              </span>
+            <p className="text-sm flex items-center gap-2">
+              <Ruler className="w-4 h-4 text-gray-500" />
+              Pot diameter: {plant.diameter ? `${plant.diameter} in` : "N/A"}
             </p>
             {plant.waterPlan?.interval ? (
               <>
-                <p className="text-sm">
-                  <span className="text-gray-500 dark:text-gray-400">Water every:</span>{" "}
-                  <span className="text-gray-800 dark:text-gray-200">
-                    {plant.waterPlan.interval} days
-                  </span>
+                <p className="text-sm flex items-center gap-2">
+                  <Drop className="w-4 h-4 text-blue-500" />
+                  Water every: {plant.waterPlan.interval} days
                 </p>
-                <p className="text-sm">
-                  <span className="text-gray-500 dark:text-gray-400">Amount:</span>{" "}
-                  <span className="text-gray-800 dark:text-gray-200">
-                    {plant.waterPlan.volume} in³
-                  </span>
+                <p className="text-sm flex items-center gap-2">
+                  <Thermometer className="w-4 h-4 text-yellow-500" />
+                  Amount: {plant.waterPlan.volume} in³
                 </p>
               </>
             ) : (
-              <p className="text-sm text-gray-500 dark:text-gray-400 italic">
-                Care plan pending setup
-              </p>
+              <div className="text-center space-y-2">
+                <img src="/happy-plant.svg" alt="Set up care" className="w-16 mx-auto" />
+                <p className="text-sm text-gray-500 dark:text-gray-400 italic">
+                  Care plan pending setup
+                </p>
+              </div>
             )}
             {plant.smartWaterPlan && (
               <p className="text-xs text-gray-500 dark:text-gray-400" data-testid="smart-water-plan-details">
@@ -670,9 +669,18 @@ export default function PlantDetail() {
                   {fact}
                 </p>
               )}
+              <p
+                className="text-sm text-gray-100 animate-fade-in-down"
+                style={{ animationDelay: "250ms" }}
+              >
+                {plant.light} • {plant.humidity} •
+                {plant.waterPlan?.interval
+                  ? ` water every ${plant.waterPlan.interval}d`
+                  : " no schedule"}
+              </p>
               <Link
                 to={`/plant/${plant.id}/coach`}
-                className="inline-flex items-center gap-1 mt-2 px-3 py-1.5 bg-white/20 border rounded-full text-sm text-white"
+                className="inline-flex items-center gap-1 mt-2 px-3 py-1.5 bg-green-600 rounded-full text-sm text-white shadow"
               >
                 <Robot className="w-4 h-4" />
                 Coach


### PR DESCRIPTION
## Summary
- style hero overlay and coach button
- show light, humidity and watering info tagline
- display care plan info with icons and placeholder art when missing
- style chat responses with message bubbles and show history
- add quick question chips in coach view

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687db9327dec832491f3f0ddc72eba43