### PR TITLE
Align care plan header size

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -352,11 +352,11 @@ export default function PlantDetail() {
       content: (
         <div className="p-4 space-y-2" data-testid="care-plan-tab">
           <div className="flex items-center justify-between">
-            {(plant.waterPlan?.interval || plant.smartWaterPlan) && (
-              <h3 className="text-heading font-semibold">
-                {plant.smartWaterPlan ? "Recommended Plan" : "Custom Care Plan"}
-              </h3>
-            )}
+              {(plant.waterPlan?.interval || plant.smartWaterPlan) && (
+                <h3 className="text-lg font-semibold">
+                  {plant.smartWaterPlan ? "Recommended Plan" : "Custom Care Plan"}
+                </h3>
+              )}
             <button
               type="button"
               aria-label="How care plan is generated"


### PR DESCRIPTION
## Summary
- make the Recommended Plan header match the size of "Today's Tasks" header

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687dbe6557088324b8ca1754cdd9c00a