### PR TITLE
Display coach sample questions vertically

### DIFF
--- a/src/pages/Coach.jsx
+++ b/src/pages/Coach.jsx
@@ -43,7 +43,7 @@ export default function Coach() {
         }}
         placeholder="Type your plant question"
       />
-      <div className="flex gap-2 overflow-x-auto mb-2">
+      <div className="flex flex-col gap-2 mb-2">
         {sampleQuestions.map((q) => (
           <button
             key={q}


### PR DESCRIPTION
## Summary
- show sample questions in a vertical stack on Coach page

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_687e30d397d883249db80694ca2613fc