### PR TITLE
Add MetadataStrip badges

### DIFF
--- a/src/components/MetadataStrip.jsx
+++ b/src/components/MetadataStrip.jsx
@@ -1,0 +1,30 @@
+import React from 'react'
+import { Sun, Drop, CloudRain, Leaf } from 'phosphor-react'
+
+export default function MetadataStrip({ plant }) {
+  if (!plant) return null
+
+  const items = [
+    plant.light && { key: 'light', label: plant.light, Icon: Sun },
+    plant.humidity && { key: 'humidity', label: plant.humidity, Icon: CloudRain },
+    {
+      key: 'water',
+      label: plant.waterPlan?.interval
+        ? `Water every ${plant.waterPlan.interval}d`
+        : 'No water schedule',
+      Icon: Drop,
+    },
+    plant.difficulty && { key: 'difficulty', label: plant.difficulty, Icon: Leaf },
+  ].filter(Boolean)
+
+  return (
+    <div className="flex flex-wrap gap-2 mt-1" data-testid="metadata-strip">
+      {items.map(({ key, label, Icon }) => (
+        <span key={key} className="metadata-badge">
+          <Icon className="w-4 h-4" aria-hidden="true" />
+          {label}
+        </span>
+      ))}
+    </div>
+  )
+}

--- a/src/components/__tests__/MetadataStrip.test.jsx
+++ b/src/components/__tests__/MetadataStrip.test.jsx
@@ -1,0 +1,19 @@
+import { render, screen } from '@testing-library/react'
+import MetadataStrip from '../MetadataStrip.jsx'
+
+const plant = {
+  light: 'Bright',
+  humidity: 'High',
+  waterPlan: { interval: 7 },
+  difficulty: 'Easy',
+}
+
+test('renders badges with plant metadata', () => {
+  render(<MetadataStrip plant={plant} />)
+  expect(screen.getByText('Bright')).toBeInTheDocument()
+  expect(screen.getByText('High')).toBeInTheDocument()
+  expect(screen.getByText('Water every 7d')).toBeInTheDocument()
+  expect(screen.getByText('Easy')).toBeInTheDocument()
+  const badges = screen.getAllByText(/Bright|High|Water every 7d|Easy/)
+  expect(badges).toHaveLength(4)
+})

--- a/src/index.css
+++ b/src/index.css
@@ -304,6 +304,11 @@ body {
   @apply p-2 bg-black/50 rounded backdrop-blur-sm;
 }
 
+/* Metadata badges used in plant detail hero */
+.metadata-badge {
+  @apply inline-flex items-center gap-1 rounded-full text-sm px-2 py-1;
+}
+
 /* Simple chat bubble styling */
 .chat-bubble {
   @apply p-3 rounded-lg bg-gray-100 dark:bg-gray-700 max-w-sm;

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -38,6 +38,7 @@ import CareCard from "../components/CareCard.jsx";
 import PlantDetailFab from "../components/PlantDetailFab.jsx";
 import DetailTabs from "../components/DetailTabs.jsx";
 import BaseCard from "../components/BaseCard.jsx";
+import MetadataStrip from "../components/MetadataStrip.jsx";
 import UnifiedTaskCard from "../components/UnifiedTaskCard.jsx";
 import InputModal from "../components/InputModal.jsx";
 import usePlantFact from "../hooks/usePlantFact.js";
@@ -683,15 +684,7 @@ export default function PlantDetail() {
                   {fact}
                 </p>
               )}
-              <p
-                className="text-sm text-gray-100 animate-fade-in-down"
-                style={{ animationDelay: "250ms" }}
-              >
-                {plant.light} • {plant.humidity} •
-                {plant.waterPlan?.interval
-                  ? ` water every ${plant.waterPlan.interval}d`
-                  : " no schedule"}
-              </p>
+              <MetadataStrip plant={plant} />
               <Link
                 to={`/plant/${plant.id}/coach`}
                 className="inline-flex items-center gap-1 mt-2 px-3 py-1.5 bg-green-600 rounded-full text-sm text-white shadow"


### PR DESCRIPTION
## Summary
- show plant metadata as badges via new `MetadataStrip` component
- style metadata badges
- display badges on PlantDetail page
- test new component

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_687e354b82f48324805a9fc04881c41a