### PR TITLE
Add petSafe flag with badge display

### DIFF
--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -32,6 +32,8 @@ export function PlantProvider({ children }) {
       careLog: (p.careLog || []).map((ev) => ({ ...ev, tags: ev.tags || [] })),
       diameter: p.diameter || 0,
 
+      petSafe: !!p.petSafe,
+
       waterPlan: p.waterPlan || { volume: 0, interval: 0 },
 
       carePlan: p.carePlan || null,

--- a/src/__tests__/PlantContext.test.jsx
+++ b/src/__tests__/PlantContext.test.jsx
@@ -140,3 +140,17 @@ test("updating diameter recalculates water plan", async () => {
   fireEvent.click(screen.getByText("set"));
   await screen.findByText("74");
 });
+
+function SafeCheck() {
+  const { plants } = usePlants();
+  return <span>{plants[0].petSafe ? "safe" : "no"}</span>;
+}
+
+test("plants include petSafe field", () => {
+  render(
+    <PlantProvider>
+      <SafeCheck />
+    </PlantProvider>,
+  );
+  expect(screen.getByText("safe")).toBeInTheDocument();
+});

--- a/src/components/MetadataStrip.jsx
+++ b/src/components/MetadataStrip.jsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Sun, Drop, CloudRain, Leaf } from 'phosphor-react'
+import { Sun, Drop, CloudRain, Leaf, PawPrint } from 'phosphor-react'
 
 export default function MetadataStrip({ plant }) {
   if (!plant) return null
@@ -15,6 +15,7 @@ export default function MetadataStrip({ plant }) {
       Icon: Drop,
     },
     plant.difficulty && { key: 'difficulty', label: plant.difficulty, Icon: Leaf },
+    plant.petSafe && { key: 'petSafe', label: 'Pet safe', Icon: PawPrint },
   ].filter(Boolean)
 
   return (

--- a/src/components/__tests__/MetadataStrip.test.jsx
+++ b/src/components/__tests__/MetadataStrip.test.jsx
@@ -6,6 +6,7 @@ const plant = {
   humidity: 'High',
   waterPlan: { interval: 7 },
   difficulty: 'Easy',
+  petSafe: true,
 }
 
 test('renders badges with plant metadata', () => {
@@ -14,6 +15,7 @@ test('renders badges with plant metadata', () => {
   expect(screen.getByText('High')).toBeInTheDocument()
   expect(screen.getByText('Water every 7d')).toBeInTheDocument()
   expect(screen.getByText('Easy')).toBeInTheDocument()
-  const badges = screen.getAllByText(/Bright|High|Water every 7d|Easy/)
-  expect(badges).toHaveLength(4)
+  expect(screen.getByText('Pet safe')).toBeInTheDocument()
+  const badges = screen.getAllByText(/Bright|High|Water every 7d|Easy|Pet safe/)
+  expect(badges).toHaveLength(5)
 })

--- a/src/plants.json
+++ b/src/plants.json
@@ -42,7 +42,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": true
   },
   {
     "id": 2,
@@ -87,7 +88,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 3,
@@ -132,7 +134,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 4,
@@ -177,7 +180,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 5,
@@ -222,7 +226,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 6,
@@ -267,7 +272,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 7,
@@ -312,7 +318,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 8,
@@ -357,7 +364,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 9,
@@ -402,7 +410,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 10,
@@ -447,7 +456,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 11,
@@ -492,7 +502,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 12,
@@ -537,7 +548,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 13,
@@ -582,7 +594,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 14,
@@ -627,7 +640,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 15,
@@ -672,7 +686,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 16,
@@ -717,7 +732,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 17,
@@ -762,7 +778,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 18,
@@ -807,7 +824,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 19,
@@ -852,7 +870,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 20,
@@ -897,7 +916,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 21,
@@ -942,7 +962,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 22,
@@ -987,7 +1008,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 23,
@@ -1032,7 +1054,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 24,
@@ -1077,7 +1100,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 25,
@@ -1122,7 +1146,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 26,
@@ -1167,7 +1192,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 27,
@@ -1212,7 +1238,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 28,
@@ -1257,7 +1284,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 29,
@@ -1302,7 +1330,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 30,
@@ -1347,7 +1376,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 31,
@@ -1392,7 +1422,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 32,
@@ -1437,7 +1468,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 33,
@@ -1482,7 +1514,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 34,
@@ -1527,7 +1560,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 35,
@@ -1572,7 +1606,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 36,
@@ -1617,7 +1652,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 37,
@@ -1662,7 +1698,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 38,
@@ -1707,7 +1744,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 39,
@@ -1752,7 +1790,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 40,
@@ -1797,7 +1836,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 41,
@@ -1842,7 +1882,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 42,
@@ -1887,7 +1928,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 43,
@@ -1932,7 +1974,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 44,
@@ -1977,7 +2020,8 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   },
   {
     "id": 45,
@@ -2022,6 +2066,7 @@
       "summer",
       "fall",
       "winter"
-    ]
+    ],
+    "petSafe": false
   }
 ]


### PR DESCRIPTION
## Summary
- mark plants with a `petSafe` boolean in `plants.json`
- expose `petSafe` field via `PlantContext`
- show a “Pet safe” badge in `MetadataStrip`
- update tests for new metadata

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_687e36d4e89883248b022560bf8002d1