### PR TITLE
Reduce bundle size with manualChunks

### DIFF
--- a/vite.config.js
+++ b/vite.config.js
@@ -14,6 +14,19 @@ export default defineConfig(({ mode }) => {
       'import.meta.env.VITE_BASE_PATH': JSON.stringify(basePath),
     },
     plugins: [react()],
+    build: {
+      rollupOptions: {
+        output: {
+          manualChunks(id) {
+            if (id.includes('node_modules')) {
+              if (id.includes('react')) return 'react-vendor'
+              if (id.includes('framer-motion')) return 'framer-motion'
+              if (id.includes('phosphor-react')) return 'phosphor'
+            }
+          },
+        },
+      },
+    },
     server: {
       proxy: {
         '/api': 'http://localhost:3000',


### PR DESCRIPTION
## Summary
- add manual chunking rules in Vite build configuration to split vendor code

## Testing
- `npm test`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_687e6bef22908324a9ebcb8454744279