### PR TITLE
Fix plant detail placeholder image

### DIFF
--- a/src/__tests__/FabVisibility.test.jsx
+++ b/src/__tests__/FabVisibility.test.jsx
@@ -6,6 +6,7 @@ import { OpenAIProvider } from '../OpenAIContext.jsx'
 
 jest.mock('../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: [] }),
+  addBase: (u) => u,
 }))
 
 jest.mock('../WeatherContext.jsx', () => ({

--- a/src/components/__tests__/PlantCard.test.jsx
+++ b/src/components/__tests__/PlantCard.test.jsx
@@ -22,6 +22,7 @@ jest.mock('react-router-dom', () => {
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: jest.fn(),
+  addBase: (u) => u,
 }))
 
 const usePlantsMock = usePlants

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -17,6 +17,7 @@ jest.mock('react-router-dom', () => {
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: jest.fn(),
+  addBase: (u) => u,
 }))
 
 const usePlantsMock = usePlants

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -24,6 +24,7 @@ jest.mock('react-router-dom', () => {
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: jest.fn(),
+  addBase: (u) => u,
 }))
 
 const usePlantsMock = usePlants

--- a/src/hooks/__tests__/usePlantCoach.test.js
+++ b/src/hooks/__tests__/usePlantCoach.test.js
@@ -9,6 +9,7 @@ let forecast = { temp: '70°F', condition: 'Sunny' }
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: [mockPlant] }),
+  addBase: (u) => u,
 }))
 
 jest.mock('../../WeatherContext.jsx', () => ({

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -28,7 +28,7 @@ import {
 import Lightbox from "../components/Lightbox.jsx";
 import PageContainer from "../components/PageContainer.jsx";
 
-import { usePlants } from "../PlantContext.jsx";
+import { usePlants, addBase } from "../PlantContext.jsx";
 import actionIcons from "../components/ActionIcons.jsx";
 import NoteModal from "../components/NoteModal.jsx";
 import { useMenu, defaultMenu } from "../MenuContext.jsx";
@@ -410,7 +410,7 @@ export default function PlantDetail() {
                   </>
                 ) : (
                   <div className="text-center space-y-2">
-                    <img src="/happy-plant.svg" alt="Set up care" className="w-16 mx-auto" />
+                    <img src={addBase('/happy-plant.svg')} alt="Set up care" className="w-16 mx-auto" />
                     <p className="text-sm text-gray-500 dark:text-gray-400 italic">
                       Care plan pending setup
                     </p>

--- a/src/pages/__tests__/Coach.test.jsx
+++ b/src/pages/__tests__/Coach.test.jsx
@@ -10,6 +10,7 @@ jest.mock('../../hooks/usePlantCoach.js', () => ({
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: jest.fn(),
+  addBase: (u) => u,
 }))
 
 const usePlantsMock = usePlants

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -16,6 +16,7 @@ const mockPlants = []
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: mockPlants }),
+  addBase: (u) => u,
 }))
 
 function renderWithSnackbar(ui) {

--- a/src/pages/__tests__/MyPlants.test.jsx
+++ b/src/pages/__tests__/MyPlants.test.jsx
@@ -7,6 +7,7 @@ let mockRooms = []
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: mockPlants }),
+  addBase: (u) => u,
 }))
 
 jest.mock('../../RoomContext.jsx', () => ({

--- a/src/pages/__tests__/Onboard.test.jsx
+++ b/src/pages/__tests__/Onboard.test.jsx
@@ -12,6 +12,7 @@ jest.mock('../../PlantContext.jsx', () => {
     __esModule: true,
     usePlants: () => ({ addPlant }),
     __addPlant: addPlant,
+    addBase: (u) => u,
   }
 })
 

--- a/src/pages/__tests__/PlantDetailActions.test.jsx
+++ b/src/pages/__tests__/PlantDetailActions.test.jsx
@@ -19,6 +19,7 @@ let mockPlants = []
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: jest.fn(),
+  addBase: (u) => u,
 }))
 
 const usePlantsMock = usePlants

--- a/src/pages/__tests__/PlantDetailCareLog.test.jsx
+++ b/src/pages/__tests__/PlantDetailCareLog.test.jsx
@@ -11,6 +11,7 @@ jest.mock('../../PlantContext.jsx', () => ({
     addPhoto: jest.fn(),
     removePhoto: jest.fn(),
   }),
+  addBase: (u) => u,
 }))
 
 beforeEach(() => {

--- a/src/pages/__tests__/ProfileRoute.test.jsx
+++ b/src/pages/__tests__/ProfileRoute.test.jsx
@@ -5,6 +5,7 @@ import App from '../../App.jsx'
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: [] }),
+  addBase: (u) => u,
 }))
 
 jest.mock('../../WeatherContext.jsx', () => ({

--- a/src/pages/__tests__/RoomList.test.jsx
+++ b/src/pages/__tests__/RoomList.test.jsx
@@ -6,6 +6,7 @@ let mockPlants = []
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: mockPlants }),
+  addBase: (u) => u,
 }))
 
 function renderWithRoute(path) {

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -1,7 +1,6 @@
 import { render, screen, fireEvent, within, cleanup } from '@testing-library/react'
 
 import { MemoryRouter } from 'react-router-dom'
-import userEvent from '@testing-library/user-event'
 import SnackbarProvider, { Snackbar } from '../../hooks/SnackbarProvider.jsx'
 
 
@@ -26,6 +25,7 @@ let mockPlants = samplePlants
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: mockPlants }),
+  addBase: (u) => u,
 }))
 
 jest.mock('../../WeatherContext.jsx', () => ({
@@ -114,7 +114,7 @@ test('switching to Past tab shows past events', async () => {
   )
 
   const pastTab = screen.getByRole('tab', { name: /Past/i })
-  await userEvent.click(pastTab)
+  fireEvent.click(pastTab)
 
 
   const cards = screen.getAllByTestId('task-card')
@@ -161,9 +161,11 @@ test('future watering date does not show Water badge', async () => {
   jest.useRealTimers()
 
   const pastTab = screen.getByRole('tab', { name: /Past/i })
-  await userEvent.click(pastTab)
+  fireEvent.click(pastTab)
 
   cleanup()
+
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-16'))
 
   renderWithSnackbar(
       <Tasks />
@@ -171,7 +173,7 @@ test('future watering date does not show Water badge', async () => {
 
 
   const byPlantTab = screen.getByRole('tab', { name: /By Plant/i })
-  await userEvent.click(byPlantTab)
+  fireEvent.click(byPlantTab)
 
   const cards = screen.getAllByTestId('unified-task-card')
   expect(cards).toHaveLength(2)
@@ -179,9 +181,12 @@ test('future watering date does not show Water badge', async () => {
   expect(within(cards[0]).getByText('Water', { exact: true })).toBeInTheDocument()
   expect(within(cards[1]).queryByText('Water', { exact: true })).toBeNull()
 
+  jest.useRealTimers()
+
 })
 
 test('by plant view shows due and future tasks correctly', async () => {
+  jest.useFakeTimers().setSystemTime(new Date('2025-07-16'))
   mockPlants = [
     {
       id: 1,
@@ -204,7 +209,7 @@ test('by plant view shows due and future tasks correctly', async () => {
   )
 
   const byPlantTab = screen.getByRole('tab', { name: /By Plant/i })
-  await userEvent.click(byPlantTab)
+  fireEvent.click(byPlantTab)
 
   const cards = screen.getAllByTestId('unified-task-card')
   expect(cards).toHaveLength(2)
@@ -221,4 +226,6 @@ test('by plant view shows due and future tasks correctly', async () => {
 
   expect(within(futureCard).queryByText('Water', { exact: true })).toBeNull()
   expect(within(futureCard).queryByText('Fertilize', { exact: true })).toBeNull()
+
+  jest.useRealTimers()
 })

--- a/src/pages/__tests__/Timeline.test.jsx
+++ b/src/pages/__tests__/Timeline.test.jsx
@@ -22,6 +22,7 @@ const samplePlants = [
 let mockPlants = samplePlants
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: mockPlants }),
+  addBase: (u) => u,
 }))
 
 function renderWithRouter(ui) {

--- a/src/pages/__tests__/TimelineFab.test.jsx
+++ b/src/pages/__tests__/TimelineFab.test.jsx
@@ -7,6 +7,7 @@ const addTimelineNote = jest.fn()
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: jest.fn(),
+  addBase: (u) => u,
 }))
 
 const usePlantsMock = usePlants

--- a/src/pages/__tests__/TimelineRoute.test.jsx
+++ b/src/pages/__tests__/TimelineRoute.test.jsx
@@ -5,6 +5,7 @@ import App from '../../App.jsx'
 
 jest.mock('../../PlantContext.jsx', () => ({
   usePlants: () => ({ plants: [{ id: 1, name: 'Plant A', lastWatered: '2025-07-10' }] }),
+  addBase: (u) => u,
 }))
 
 test('navigating to /timeline renders the Timeline page', () => {


### PR DESCRIPTION
## Summary
- use `addBase` for placeholder image on PlantDetail page
- add `addBase` stub to PlantContext mocks
- stabilize Tasks tests across system dates

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880512bd4888324ac3ed6b86a6aae8d