### PR TITLE
Update care plan display

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -49,6 +49,7 @@ import confetti from "canvas-confetti";
 import { formatMonth, formatDate, daysUntil } from "../utils/date.js";
 import { formatDaysAgo, formatTimeOfDay } from "../utils/dateFormat.js";
 import { getWateringProgress } from "../utils/watering.js";
+import { formatVolume } from "../utils/units.js";
 
 import { buildEvents, groupEventsByMonth } from "../utils/events.js";
 import { useWeather } from "../WeatherContext.jsx";
@@ -339,8 +340,8 @@ export default function PlantDetail() {
               className="text-xs text-gray-500 dark:text-gray-400"
               data-testid="smart-water-plan"
             >
-              {plant.smartWaterPlan.volume} in³ every{" "}
-              {plant.smartWaterPlan.interval} days —{" "}
+              {formatVolume(plant.smartWaterPlan.volume)} every{' '}
+              {plant.smartWaterPlan.interval} days —{' '}
               {plant.smartWaterPlan.reason}
             </p>
           )}
@@ -380,7 +381,7 @@ export default function PlantDetail() {
                 </li>
                 <li className="flex items-center gap-2">
                   <Thermometer className="w-4 h-4 text-yellow-500" />
-                  Amount: {plant.waterPlan.volume} in³
+                  Amount: {formatVolume(plant.waterPlan.volume)}
                 </li>
                 <li className="flex items-center gap-2">
                   <Flower className="w-4 h-4 text-pink-500" />
@@ -405,7 +406,7 @@ export default function PlantDetail() {
                     </p>
                     <p className="text-sm flex items-center gap-2">
                       <Thermometer className="w-4 h-4 text-yellow-500" />
-                      Amount: {plant.waterPlan.volume} in³
+                      Amount: {formatVolume(plant.waterPlan.volume)}
                     </p>
                   </>
                 ) : (
@@ -426,11 +427,8 @@ export default function PlantDetail() {
             )}
             {plant.smartWaterPlan && (
               <p className="text-xs text-gray-500 dark:text-gray-400" data-testid="smart-water-plan-details">
-                {plant.smartWaterPlan.volume} in³ every {plant.smartWaterPlan.interval} days — {plant.smartWaterPlan.reason}
+                {formatVolume(plant.smartWaterPlan.volume)} every {plant.smartWaterPlan.interval} days — {plant.smartWaterPlan.reason}
               </p>
-            )}
-            {!plant.carePlan && plant.notes && (
-              <pre className="whitespace-pre-wrap">{plant.notes}</pre>
             )}
           </div>
         </div>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -358,12 +358,11 @@ test('care plan tab displays stored onboarding values', () => {
     within(panel).getByText((c, el) => el.textContent === 'Water every: 7 days')
   ).toBeInTheDocument()
   expect(
-    within(panel).getByText((c, el) => el.textContent === 'Amount: 10 in³')
+    within(panel).getByText((c, el) => el.textContent === 'Amount: 164 mL / 6 oz')
   ).toBeInTheDocument()
   expect(
     within(panel).getByTestId('smart-water-plan-details')
-  ).toHaveTextContent('12 in³ every 5 days — test reason')
-  expect(within(panel).getByText('keep soil moist')).toBeInTheDocument()
+  ).toHaveTextContent('197 mL / 7 oz every 5 days — test reason')
 
   localStorage.clear()
 })

--- a/src/pages/__tests__/Tasks.test.jsx
+++ b/src/pages/__tests__/Tasks.test.jsx
@@ -179,7 +179,7 @@ test('future watering date does not show Water badge', async () => {
   expect(cards).toHaveLength(2)
 
   expect(within(cards[0]).getByText('Water', { exact: true })).toBeInTheDocument()
-  expect(within(cards[1]).queryByText('Water', { exact: true })).toBeInTheDocument()
+  expect(within(cards[1]).queryByText('Water', { exact: true })).toBeNull()
 
   jest.useRealTimers()
 
@@ -224,7 +224,7 @@ test('by plant view shows due and future tasks correctly', async () => {
   expect(within(dueCard).getByText('Water', { exact: true })).toBeInTheDocument()
   expect(within(dueCard).getByText('Fertilize', { exact: true })).toBeInTheDocument()
 
-  expect(within(futureCard).queryByText('Water', { exact: true })).toBeInTheDocument()
+  expect(within(futureCard).queryByText('Water', { exact: true })).toBeNull()
   expect(within(futureCard).queryByText('Fertilize', { exact: true })).toBeNull()
 
   jest.useRealTimers()

--- a/src/utils/__tests__/units.test.js
+++ b/src/utils/__tests__/units.test.js
@@ -1,0 +1,6 @@
+import { formatVolume } from '../units.js'
+
+test('converts cubic inches to mL and oz', () => {
+  expect(formatVolume(10)).toBe('164 mL / 6 oz')
+  expect(formatVolume(127)).toBe('2081 mL / 70 oz')
+})

--- a/src/utils/units.js
+++ b/src/utils/units.js
@@ -1,0 +1,5 @@
+export function formatVolume(cubicInches) {
+  const ml = Math.round(cubicInches * 16.387);
+  const oz = Math.round(ml / 29.5735);
+  return `${ml} mL / ${oz} oz`;
+}


### PR DESCRIPTION
## Summary
- format care plan volumes in mL and oz
- hide raw JSON notes in the care plan tab
- adjust tests to match new display
- add `formatVolume` helper

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68805f394de88324998a59128d25a40a