### PR TITLE
Add volume utils and water info

### DIFF
--- a/src/components/CareCard.jsx
+++ b/src/components/CareCard.jsx
@@ -8,6 +8,7 @@ export default function CareCard({
   status,
   onDone,
   completed = false,
+  info,
 }) {
   const [internalCompleted, setInternalCompleted] = useState(false)
   const pct = Math.min(Math.max(progress, 0), 1)
@@ -26,20 +27,27 @@ export default function CareCard({
       className={`relative bg-white dark:bg-gray-700 rounded-2xl shadow p-4 space-y-2 ${internalCompleted ? 'swipe-left-out' : ''}`}
       data-testid="care-card"
     >
-      <div className="flex items-center justify-between">
+      <div className="flex items-start justify-between">
         <div className="flex items-center gap-2">
           {Icon && <Icon className="w-5 h-5" aria-hidden="true" />}
           <span className="font-semibold">{label}</span>
         </div>
-        {onDone && (
-          <button
-            type="button"
-            onClick={handleDone}
-            className="text-sm font-semibold text-white bg-green-600 hover:bg-green-700 rounded shadow px-3 py-1 transition"
-          >
-            Mark as Done
-          </button>
-        )}
+        <div className="flex flex-col items-end gap-1">
+          {info && (
+            <span className="text-xs text-gray-500" data-testid="care-info">
+              {info}
+            </span>
+          )}
+          {onDone && (
+            <button
+              type="button"
+              onClick={handleDone}
+              className="text-sm font-semibold text-white bg-green-600 hover:bg-green-700 rounded shadow px-3 py-1 transition"
+            >
+              Mark as Done
+            </button>
+          )}
+        </div>
       </div>
       {status && <p className="text-sm text-gray-500">{status}</p>}
       <div

--- a/src/components/__tests__/CareCard.test.jsx
+++ b/src/components/__tests__/CareCard.test.jsx
@@ -40,3 +40,16 @@ test('shows sprout icon for fertilize card when completed', async () => {
 
   jest.useRealTimers()
 })
+
+test('renders info text when provided', () => {
+  render(
+    <CareCard
+      label="Water"
+      Icon={Drop}
+      progress={0}
+      status="Today"
+      info="200 mL / 7 oz every 5 days"
+    />
+  )
+  expect(screen.getByText(/200 mL/)).toBeInTheDocument()
+})

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -49,6 +49,7 @@ import confetti from "canvas-confetti";
 import { formatMonth, formatDate, daysUntil } from "../utils/date.js";
 import { formatDaysAgo, formatTimeOfDay } from "../utils/dateFormat.js";
 import { getWateringProgress } from "../utils/watering.js";
+import { cubicInchesToMl, mlToOz } from "../utils/volume.js";
 
 import { buildEvents, groupEventsByMonth } from "../utils/events.js";
 import { useWeather } from "../WeatherContext.jsx";
@@ -132,6 +133,13 @@ export default function PlantDetail() {
 
   const waterStatus = getStatus(waterDays);
   const fertStatus = getStatus(fertDays);
+
+  const planInfo = plant?.smartWaterPlan || plant?.waterPlan;
+  const waterInfo = planInfo
+    ? `${Math.round(cubicInchesToMl(planInfo.volume))}\u00A0mL / ${Math.round(
+        mlToOz(cubicInchesToMl(planInfo.volume))
+      )}\u00A0oz every ${planInfo.interval}\u00A0days`
+    : null;
 
   const todayIso = new Date().toISOString().slice(0, 10);
   const dueWater = plant?.nextWater && plant.nextWater <= todayIso;
@@ -299,6 +307,7 @@ export default function PlantDetail() {
                 progress={waterProgress}
                 status={waterStatus}
                 onDone={handleWatered}
+                info={waterInfo}
               />
               <div
                 className={

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -104,6 +104,43 @@ test('tasks tab displays a heading', () => {
   expect(screen.getByTestId('tasks-heading')).toHaveTextContent(/today/i)
 })
 
+test('water care card shows volume info', () => {
+  localStorage.setItem(
+    'plants',
+    JSON.stringify([
+      {
+        id: 1,
+        name: 'Aloe',
+        image: 'a.jpg',
+        waterPlan: { volume: 50, interval: 7 },
+        smartWaterPlan: { volume: 127, interval: 9, reason: 'AI' },
+        photos: [],
+        careLog: [],
+      },
+    ])
+  )
+
+  render(
+    <OpenAIProvider>
+      <MenuProvider>
+        <PlantProvider>
+          <MemoryRouter initialEntries={['/plant/1']}>
+            <Routes>
+              <Route path="/plant/:id" element={<PlantDetail />} />
+            </Routes>
+          </MemoryRouter>
+        </PlantProvider>
+      </MenuProvider>
+    </OpenAIProvider>
+  )
+
+  expect(screen.getByTestId('care-info')).toHaveTextContent(
+    '2081 mL / 70 oz every 9 days'
+  )
+
+  localStorage.clear()
+})
+
 test('cannot mark fertilize done when not scheduled', () => {
   const plant = plants.find(p => p.id === 2)
   render(

--- a/src/utils/volume.js
+++ b/src/utils/volume.js
@@ -1,0 +1,11 @@
+export function cubicInchesToMl(in3 = 0) {
+  const value = Number(in3)
+  if (isNaN(value)) return 0
+  return value * 16.387
+}
+
+export function mlToOz(ml = 0) {
+  const value = Number(ml)
+  if (isNaN(value)) return 0
+  return value / 29.574
+}


### PR DESCRIPTION
## Summary
- add `volume.js` conversion helpers
- extend `CareCard` with `info` slot
- display water volume/interval info in PlantDetail tasks
- test CareCard and PlantDetail info rendering

## Testing
- `npm test --silent` *(fails: future watering date does not show Water badge)*

------
https://chatgpt.com/codex/tasks/task_e_688060fb041c8324b6ea40685b8e95ef