### PR TITLE
Remove redundant water plan details

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -425,11 +425,6 @@ export default function PlantDetail() {
                 )}
               </>
             )}
-            {plant.smartWaterPlan && (
-              <p className="text-xs text-gray-500 dark:text-gray-400" data-testid="smart-water-plan-details">
-                {formatVolume(plant.smartWaterPlan.volume)} every {plant.smartWaterPlan.interval} days — {plant.smartWaterPlan.reason}
-              </p>
-            )}
           </div>
         </div>
       ),

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -360,9 +360,7 @@ test('care plan tab displays stored onboarding values', () => {
   expect(
     within(panel).getByText((c, el) => el.textContent === 'Amount: 164 mL / 6 oz')
   ).toBeInTheDocument()
-  expect(
-    within(panel).getByTestId('smart-water-plan-details')
-  ).toHaveTextContent('197 mL / 7 oz every 5 days — test reason')
+  expect(within(panel).queryByTestId('smart-water-plan-details')).toBeNull()
 
   localStorage.clear()
 })


### PR DESCRIPTION
## Summary
- remove duplicate smart watering line from care plan tab
- update tests to expect the element to be absent

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880635571b48324bcadb668bf64ccdc