### PR TITLE
Add overdue animation to progress bars

### DIFF
--- a/src/components/CareCard.jsx
+++ b/src/components/CareCard.jsx
@@ -9,6 +9,7 @@ export default function CareCard({
   onDone,
   completed = false,
   info,
+  overdue = false,
 }) {
   const [internalCompleted, setInternalCompleted] = useState(false)
   const pct = Math.min(Math.max(progress, 0), 1)
@@ -58,7 +59,7 @@ export default function CareCard({
         aria-valuemax="100"
       >
         <div
-          className="h-full bg-gradient-to-r from-green-500 via-orange-500 to-red-500"
+          className={`h-full bg-gradient-to-r from-green-500 via-orange-500 to-red-500 ${overdue ? 'bar-pulse' : ''}`}
           style={{ width }}
         ></div>
       </div>

--- a/src/components/__tests__/CareCard.test.jsx
+++ b/src/components/__tests__/CareCard.test.jsx
@@ -53,3 +53,11 @@ test('renders info text when provided', () => {
   )
   expect(screen.getByText(/200 mL/)).toBeInTheDocument()
 })
+
+test('adds animation when overdue', () => {
+  render(
+    <CareCard label="Water" Icon={Drop} progress={0.1} status="Overdue" overdue />
+  )
+  const bar = screen.getByRole('progressbar').firstChild
+  expect(bar.className).toMatch(/bar-pulse/)
+})

--- a/src/index.css
+++ b/src/index.css
@@ -259,6 +259,19 @@ body {
   animation: drip-pulse 0.4s ease-out;
 }
 
+@keyframes bar-pulse {
+  0%, 100% {
+    transform: scaleY(1);
+  }
+  50% {
+    transform: scaleY(1.05);
+  }
+}
+
+.bar-pulse {
+  animation: bar-pulse 1s ease-in-out infinite;
+}
+
 @keyframes task-complete-fade {
   from {
     background-color: rgba(74, 222, 128, 0.4);

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -160,13 +160,13 @@ export default function PlantDetail() {
   const todayIso = new Date().toISOString().slice(0, 10);
   const dueWater = plant?.nextWater && plant.nextWater <= todayIso;
   const dueFertilize = plant?.nextFertilize && plant.nextFertilize <= todayIso;
+  const waterOverdue = plant?.nextWater && plant.nextWater < todayIso;
+  const fertOverdue = plant?.nextFertilize && plant.nextFertilize < todayIso;
   const urgent =
     plant?.urgency === "high" ||
     (dueWater && plant.nextWater === todayIso) ||
     (dueFertilize && plant.nextFertilize === todayIso);
-  const overdue =
-    (dueWater && plant.nextWater < todayIso) ||
-    (dueFertilize && plant.nextFertilize < todayIso);
+  const overdue = waterOverdue || fertOverdue;
   const lastCared = [plant?.lastWatered, plant?.lastFertilized]
     .filter(Boolean)
     .sort((a, b) => new Date(b) - new Date(a))[0];
@@ -322,6 +322,7 @@ export default function PlantDetail() {
                 Icon={Drop}
                 progress={waterProgress}
                 status={waterStatus}
+                overdue={waterOverdue}
                 onDone={handleWatered}
                 info={waterInfo}
               />
@@ -337,6 +338,7 @@ export default function PlantDetail() {
                   Icon={Sun}
                   progress={fertProgress}
                   status={fertStatus}
+                  overdue={fertOverdue}
                   completed={fertilizeDone}
                   onDone={plant.nextFertilize ? handleFertilized : undefined}
                 />


### PR DESCRIPTION
## Summary
- tweak CareCard progress bar to animate when overdue
- surface overdue status on plant detail page
- add bar-pulse CSS animation
- test that CareCard uses overdue animation

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_688069a301a08324a420ab88f91ec89a