### PR TITLE
Update water care card button

### DIFF
--- a/src/components/CareCard.jsx
+++ b/src/components/CareCard.jsx
@@ -9,6 +9,8 @@ export default function CareCard({
   onDone,
   completed = false,
   info,
+  buttonLabel,
+  infoBelow = false,
 }) {
   const [internalCompleted, setInternalCompleted] = useState(false)
   const pct = Math.min(Math.max(progress, 0), 1)
@@ -33,7 +35,7 @@ export default function CareCard({
           <span className="font-semibold">{label}</span>
         </div>
         <div className="flex flex-col items-end gap-1">
-          {info && (
+          {info && !infoBelow && (
             <span className="text-xs text-gray-500" data-testid="care-info">
               {info}
             </span>
@@ -44,8 +46,13 @@ export default function CareCard({
               onClick={handleDone}
               className="text-sm font-semibold text-white bg-green-600 hover:bg-green-700 rounded shadow px-3 py-1 transition"
             >
-              Mark as Done
+              {buttonLabel || 'Mark as Done'}
             </button>
+          )}
+          {info && infoBelow && (
+            <span className="text-xs text-gray-500" data-testid="care-info">
+              {info}
+            </span>
           )}
         </div>
       </div>

--- a/src/components/__tests__/CareCard.test.jsx
+++ b/src/components/__tests__/CareCard.test.jsx
@@ -48,8 +48,20 @@ test('renders info text when provided', () => {
       Icon={Drop}
       progress={0}
       status="Today"
-      info="200 mL / 7 oz every 5 days"
+      info="every 5 days"
+      buttonLabel="Water 200 mL / 7 oz"
+      infoBelow
+      onDone={() => {}}
     />
   )
-  expect(screen.getByText(/200 mL/)).toBeInTheDocument()
+  expect(
+    screen.getByRole('button', { name: /water 200 mL/i })
+  ).toBeInTheDocument()
+  })
+
+test('uses custom button label when provided', () => {
+  render(
+    <CareCard label="Water" Icon={Drop} progress={0} status="Today" buttonLabel="Water 500 mL" onDone={() => {}} />
+  )
+  expect(screen.getByRole('button', { name: /water 500 ml/i })).toBeInTheDocument()
 })

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -151,11 +151,12 @@ export default function PlantDetail() {
   const fertStatus = getStatus(fertDays);
 
   const planInfo = plant?.smartWaterPlan || plant?.waterPlan;
-  const waterInfo = planInfo
+  const waterVolume = planInfo
     ? `${Math.round(cubicInchesToMl(planInfo.volume))}\u00A0mL / ${Math.round(
         mlToOz(cubicInchesToMl(planInfo.volume))
-      )}\u00A0oz every ${planInfo.interval}\u00A0days`
+      )}\u00A0oz`
     : null;
+  const waterInterval = planInfo ? `every ${planInfo.interval}\u00A0days` : null;
 
   const todayIso = new Date().toISOString().slice(0, 10);
   const dueWater = plant?.nextWater && plant.nextWater <= todayIso;
@@ -323,7 +324,9 @@ export default function PlantDetail() {
                 progress={waterProgress}
                 status={waterStatus}
                 onDone={handleWatered}
-                info={waterInfo}
+                buttonLabel={waterVolume ? `Water ${waterVolume}` : undefined}
+                info={waterInterval}
+                infoBelow
               />
               <div
                 className={

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -134,9 +134,11 @@ test('water care card shows volume info', () => {
     </OpenAIProvider>
   )
 
-  expect(screen.getByTestId('care-info')).toHaveTextContent(
-    '2081 mL / 70 oz every 9 days'
-  )
+  const info = screen.getByTestId('care-info')
+  expect(info).toHaveTextContent('every 9 days')
+  expect(
+    screen.getByRole('button', { name: /water 2081/i })
+  ).toBeInTheDocument()
 
   localStorage.clear()
 })
@@ -157,8 +159,7 @@ test('cannot mark fertilize done when not scheduled', () => {
     </OpenAIProvider>
   )
 
-  const buttons = screen.getAllByRole('button', { name: /mark as done/i })
-  expect(buttons).toHaveLength(1)
+  expect(screen.queryByRole('button', { name: /mark as done/i })).toBeNull()
 })
 
 


### PR DESCRIPTION
## Summary
- support custom `buttonLabel` and below-button info in `CareCard`
- show water amount in plant detail's water care card and move interval text below
- update related tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880654a985083248b0c1d4033d9a019