### PR TITLE
Fix CareCard overdue prop undefined

### DIFF
--- a/src/components/CareCard.jsx
+++ b/src/components/CareCard.jsx
@@ -9,6 +9,7 @@ export default function CareCard({
   onDone,
   completed = false,
   info,
+  overdue = false,
 
   buttonLabel,
   infoBelow = false,


### PR DESCRIPTION
## Summary
- add missing `overdue` prop to CareCard

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880ad203a188324a7fa430e7e970e41