### PR TITLE
Add care plan defaults on name selection

### DIFF
--- a/src/pages/__tests__/Onboard.test.jsx
+++ b/src/pages/__tests__/Onboard.test.jsx
@@ -107,3 +107,37 @@ test('autocomplete fills scientific name', async () => {
     expect.objectContaining({ scientificName: 'Aloe vera', name: 'Aloe' })
   )
 })
+
+test('selecting a name fetches defaults', async () => {
+  const planData = {
+    light: 'Low',
+    humidity: 60,
+    water: 5,
+    water_volume_ml: 400,
+    water_volume_oz: 13,
+  }
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: true, json: () => Promise.resolve(planData) })
+  )
+
+  render(
+    <MemoryRouter initialEntries={['/onboard']}>
+      <Routes>
+        <Route path="/onboard" element={<Onboard />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+  fireEvent.change(screen.getByLabelText(/pot diameter/i), {
+    target: { value: '6' },
+  })
+  fireEvent.change(screen.getByLabelText(/plant name/i), {
+    target: { value: 'Snake' },
+  })
+
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled())
+  await waitFor(() =>
+    expect(screen.getByLabelText(/light level/i)).toHaveValue('Low')
+  )
+  expect(screen.getByLabelText(/humidity/i)).toHaveValue(60)
+})


### PR DESCRIPTION
## Summary
- trigger a `/api/care-plan` request from `handleNameChange`
- prefill light, humidity and watering fields with the response
- test default filling behaviour

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880aeb521748324a28a4264d9f58751