### PR TITLE
Update PlantDetail back button with ripple

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -55,6 +55,7 @@ import { formatMlOz } from "../utils/units.js";
 
 import { buildEvents, groupEventsByMonth } from "../utils/events.js";
 import { useWeather } from "../WeatherContext.jsx";
+import { createRipple } from "../utils/interactions.js";
 
 const bulletColors = {
   water: "bg-blue-500",
@@ -701,7 +702,9 @@ export default function PlantDetail() {
             <button
               type="button"
               onClick={() => navigate(-1)}
-              className="p-1 rounded-full bg-black/40 hover:bg-black/50 flex items-center gap-1"
+              onMouseDown={createRipple}
+              onTouchStart={createRipple}
+              className="p-2 rounded-full bg-black/50 backdrop-blur-sm flex items-center gap-1 text-white"
             >
               <ArrowLeft className="w-4 h-4" aria-hidden="true" />
               <span className="ml-1">{backLabel}</span>

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -264,7 +264,7 @@ test('view all button opens the viewer from first image', () => {
 
 test('back button navigates to previous page', () => {
   const plant = plants[0]
-  render(
+  const { container } = render(
     <OpenAIProvider>
       <MenuProvider>
         <PlantProvider>
@@ -288,6 +288,9 @@ test('back button navigates to previous page', () => {
 
   const backBtn = screen.getByRole('button', { name: /back/i })
   expect(backBtn).toBeInTheDocument()
+  expect(backBtn).toHaveClass('backdrop-blur-sm')
+  fireEvent.mouseDown(backBtn)
+  expect(container.querySelector('.ripple-effect')).toBeInTheDocument()
   fireEvent.click(backBtn)
 
   expect(screen.getByText(/all plants view/i)).toBeInTheDocument()


### PR DESCRIPTION
## Summary
- style the PlantDetail back button with a blurred dark background
- attach ripple interactions on mouse and touch
- verify ripple effect and new class in PlantDetail tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880b2c685a48324a997afc1c6b4866f