### PR TITLE
Add hero overlay blur

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -307,6 +307,11 @@ body {
   @apply absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent;
 }
 
+/* Gradient + blur overlay used in plant detail hero */
+.hero-overlay {
+  @apply bg-gradient-to-t from-black/60 via-black/30 to-transparent backdrop-blur-sm;
+}
+
 /* Overlay for featured card images */
 .featured-overlay {
   @apply absolute inset-0 bg-gradient-to-t from-black/80 via-black/50 to-transparent;

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -710,11 +710,12 @@ export default function PlantDetail() {
               <span className="ml-1">{backLabel}</span>
             </button>
           </div>
-          <div className="absolute bottom-2 left-3 right-3 flex flex-col sm:flex-row justify-between text-white drop-shadow space-y-1 sm:space-y-0">
-            <div className="hero-name-bg">
-              <h2 className="text-4xl font-extrabold font-headline tracking-wide animate-fade-in-down">
-                {plant.name}
-              </h2>
+          <div className="absolute bottom-2 left-3 right-3">
+            <div className="hero-overlay p-4 flex flex-col sm:flex-row justify-between text-white drop-shadow space-y-1 sm:space-y-0">
+              <div className="hero-name-bg">
+                <h2 className="text-4xl font-extrabold font-headline tracking-wide animate-fade-in-down">
+                  {plant.name}
+                </h2>
               {plant.scientificName && (
                 <p className="text-sm italic text-gray-100 animate-fade-in-down" style={{ animationDelay: '50ms' }}>
                   {plant.scientificName}
@@ -736,7 +737,8 @@ export default function PlantDetail() {
                   {fact}
                 </p>
               )}
-              <MetadataStrip plant={plant} />
+                <MetadataStrip plant={plant} />
+              </div>
             </div>
           </div>
         </div>


### PR DESCRIPTION
## Summary
- add `.hero-overlay` utility for gradient+blur
- wrap PlantDetail hero text in new overlay and pad it
- update snapshots

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880b3c948e08324b8f757e7a4b5ab76