### PR TITLE
Add OpenAI proxy endpoints

### DIFF
--- a/src/OpenAIContext.jsx
+++ b/src/OpenAIContext.jsx
@@ -8,7 +8,7 @@ export function OpenAIProvider({ children }) {
       const stored = localStorage.getItem('openai_enabled')
       if (stored != null) return stored === 'true'
     }
-    return !!process.env.VITE_OPENAI_API_KEY
+    return true
   })
 
   useEffect(() => {
@@ -31,5 +31,5 @@ export function getOpenAIEnabled() {
     const stored = localStorage.getItem('openai_enabled')
     if (stored != null) return stored === 'true'
   }
-  return !!process.env.VITE_OPENAI_API_KEY
+  return true
 }

--- a/src/components/__tests__/FeaturedCard.test.jsx
+++ b/src/components/__tests__/FeaturedCard.test.jsx
@@ -77,13 +77,9 @@ test('arrow keys change plant', () => {
 })
 
 test('displays plant fact when loaded', async () => {
-  process.env.VITE_OPENAI_API_KEY = 'key'
   global.fetch = jest.fn(url => {
-    if (url.includes('openai')) {
-      return Promise.resolve({
-        ok: true,
-        json: () => Promise.resolve({ choices: [{ message: { content: 'fun fact' } }] }),
-      })
+    if (url.includes('/api/plant-fact')) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve({ fact: 'fun fact' }) })
     }
     return Promise.resolve({ json: () => Promise.resolve({ results: [] }) })
   })
@@ -94,5 +90,4 @@ test('displays plant fact when loaded', async () => {
   )
   await screen.findByText('fun fact')
   global.fetch = undefined
-  delete process.env.VITE_OPENAI_API_KEY
 })

--- a/src/hooks/__tests__/usePlantFact.test.js
+++ b/src/hooks/__tests__/usePlantFact.test.js
@@ -11,31 +11,27 @@ function Test({ name }) {
 
 afterEach(() => {
   global.fetch && (global.fetch = undefined)
-  delete process.env.VITE_OPENAI_API_KEY
   localStorage.clear()
 })
 
-test('fetches fact from OpenAI when key provided', async () => {
-  process.env.VITE_OPENAI_API_KEY = 'key'
+test('fetches fact from API', async () => {
   global.fetch = jest.fn(() =>
     Promise.resolve({
       ok: true,
-      json: () =>
-        Promise.resolve({ choices: [{ message: { content: 'gpt fact' } }] }),
+      json: () => Promise.resolve({ fact: 'gpt fact' }),
     })
   )
   render(<Test name="Aloe" />)
   await waitFor(() => screen.getByText('gpt fact'))
   expect(global.fetch).toHaveBeenCalledWith(
-    'https://api.openai.com/v1/chat/completions',
+    '/api/plant-fact',
     expect.any(Object)
   )
 })
 
 test('falls back to wikipedia summary', async () => {
-  process.env.VITE_OPENAI_API_KEY = 'key'
   global.fetch = jest.fn(requestUrl => {
-    if (requestUrl.includes('openai')) {
+    if (requestUrl.includes('/api/plant-fact')) {
       return Promise.resolve({ ok: false })
     }
     return Promise.resolve({

--- a/src/hooks/__tests__/useTimelineSummary.test.js
+++ b/src/hooks/__tests__/useTimelineSummary.test.js
@@ -17,28 +17,24 @@ function Test({ events }) {
 
 afterEach(() => {
   global.fetch && (global.fetch = undefined)
-  delete process.env.VITE_OPENAI_API_KEY
 })
 
-test('fetches summary from OpenAI', async () => {
-  process.env.VITE_OPENAI_API_KEY = 'key'
+test('fetches summary from API', async () => {
   global.fetch = jest.fn(() =>
     Promise.resolve({
       ok: true,
-      json: () =>
-        Promise.resolve({ choices: [{ message: { content: 'hello summary' } }] }),
+      json: () => Promise.resolve({ summary: 'hello summary' }),
     })
   )
   render(<Test events={[{ date: '2025-07-01', label: 'Watered', type: 'water' }]} />)
   await waitFor(() => screen.getByText('hello summary'))
   expect(global.fetch).toHaveBeenCalledWith(
-    'https://api.openai.com/v1/chat/completions',
+    '/api/timeline-summary',
     expect.any(Object)
   )
 })
 
 test('sets error on failure', async () => {
-  process.env.VITE_OPENAI_API_KEY = 'key'
   global.fetch = jest.fn(() => Promise.resolve({ ok: false }))
   render(<Test events={[{ date: '2025-07-01', label: 'Watered', type: 'water' }]} />)
   await waitFor(() => screen.getByText('Failed to load summary'))

--- a/src/hooks/usePlantFact.js
+++ b/src/hooks/usePlantFact.js
@@ -25,25 +25,16 @@ export default function usePlantFact(name) {
         setError('Failed to load fact')
         return
       }
-      const openaiKey = enabled ? process.env.VITE_OPENAI_API_KEY : null
       try {
-        if (openaiKey) {
-          const prompt = `Give me a short fun or cultural fact about the plant "${name}". One sentence.`
-          const res = await fetch('https://api.openai.com/v1/chat/completions', {
+        if (enabled) {
+          const res = await fetch('/api/plant-fact', {
             method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              Authorization: `Bearer ${openaiKey}`,
-            },
-            body: JSON.stringify({
-              model: 'gpt-4o',
-              messages: [{ role: 'user', content: prompt }],
-              temperature: 0.7,
-            }),
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify({ name }),
           })
-          if (!res.ok) throw new Error('openai failed')
+          if (!res.ok) throw new Error('fact failed')
           const data = await res.json()
-          const text = data?.choices?.[0]?.message?.content?.trim()
+          const text = data.fact
           if (text && !aborted) {
             setFact(text)
             if (typeof localStorage !== 'undefined') {

--- a/src/utils/__tests__/autoTag.test.js
+++ b/src/utils/__tests__/autoTag.test.js
@@ -1,28 +1,29 @@
 import autoTag from '../autoTag.js'
+jest.mock('../../OpenAIContext.jsx', () => ({
+  getOpenAIEnabled: () => true,
+}))
 
 afterEach(() => {
   global.fetch && (global.fetch = undefined)
-  delete process.env.VITE_OPENAI_API_KEY
 })
 
 test('fetches tags from OpenAI', async () => {
-  process.env.VITE_OPENAI_API_KEY = 'key'
   global.fetch = jest.fn(() =>
     Promise.resolve({
       ok: true,
-      json: () =>
-        Promise.resolve({ choices: [{ message: { content: 'cat, plant' } }] }),
+      json: () => Promise.resolve({ tags: ['cat', 'plant'] }),
     })
   )
   const tags = await autoTag('my note')
   expect(global.fetch).toHaveBeenCalledWith(
-    'https://api.openai.com/v1/chat/completions',
+    '/api/auto-tag',
     expect.any(Object)
   )
   expect(tags).toEqual(['cat', 'plant'])
 })
 
-test('returns empty array when key missing', async () => {
+test('returns empty array on failure', async () => {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: false }))
   const tags = await autoTag('text')
   expect(tags).toEqual([])
 })

--- a/src/utils/autoTag.js
+++ b/src/utils/autoTag.js
@@ -2,33 +2,16 @@ import { getOpenAIEnabled } from '../OpenAIContext.jsx'
 
 export default async function autoTag(text = '') {
   const enabled = getOpenAIEnabled()
-  const apiKey = enabled ? process.env.VITE_OPENAI_API_KEY : null
-  if (!apiKey || !text) return []
+  if (!enabled || !text) return []
   try {
-    const res = await fetch('https://api.openai.com/v1/chat/completions', {
+    const res = await fetch('/api/auto-tag', {
       method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: 'gpt-4o',
-        messages: [
-          {
-            role: 'user',
-            content: `Provide 3 short tags for: "${text}". Respond with a comma-separated list.`,
-          },
-        ],
-        temperature: 0.5,
-      }),
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ text }),
     })
-    if (!res.ok) throw new Error('openai failed')
+    if (!res.ok) throw new Error('autoTag failed')
     const data = await res.json()
-    const raw = data?.choices?.[0]?.message?.content || ''
-    return raw
-      .split(/[,\n]+/)
-      .map(t => t.trim().replace(/^#/, ''))
-      .filter(Boolean)
+    return data.tags || []
   } catch (err) {
     console.error('autoTag error', err)
     return []


### PR DESCRIPTION
## Summary
- add `/api/auto-tag`, `/api/plant-fact` and `/api/timeline-summary` server routes
- update hooks/utils to call new API endpoints
- remove client `VITE_OPENAI_API_KEY` references
- adjust tests to mock the new endpoints

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6880bd9bcbe48324a6739c60f379894a