### PR TITLE
Remove hero overlay from plant details

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -307,11 +307,6 @@ body {
   @apply absolute inset-0 bg-gradient-to-t from-black/60 via-black/30 to-transparent;
 }
 
-/* Gradient + blur overlay used in plant detail hero */
-.hero-overlay {
-  /* Slightly lighter overlay to match room thumbnails */
-  @apply bg-gradient-to-t from-black/50 via-black/20 to-transparent backdrop-blur-sm;
-}
 
 /* Overlay for featured card images */
 .featured-overlay {

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -718,9 +718,8 @@ export default function PlantDetail() {
               <span className="ml-1">{backLabel}</span>
             </button>
           </div>
-          <div className="absolute bottom-2 left-3 right-3">
-            <div className="hero-overlay p-4 flex flex-col sm:flex-row justify-between text-white drop-shadow space-y-1 sm:space-y-0">
-              <div className="hero-name-bg">
+          <div className="absolute bottom-2 left-3 right-3 p-4 flex flex-col sm:flex-row justify-between text-white drop-shadow space-y-1 sm:space-y-0">
+            <div className="hero-name-bg">
                 <h2 className="text-4xl font-extrabold font-headline tracking-wide animate-fade-in-down">
                   {plant.name}
                 </h2>
@@ -747,7 +746,6 @@ export default function PlantDetail() {
               )}
                 <MetadataStrip plant={plant} />
               </div>
-            </div>
           </div>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- delete the obsolete `hero-overlay` CSS rule
- inline hero text container directly without the overlay wrapper

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6880cd3de81c8324981a272c7e3703fa