### PR TITLE
Update DiscoveryCard overlay and styles

### DIFF
--- a/src/components/DiscoveryCard.jsx
+++ b/src/components/DiscoveryCard.jsx
@@ -12,51 +12,50 @@ export default function DiscoveryCard({ plant, onAdd }) {
         alt={plant.name}
         className="absolute inset-0 w-full h-full object-cover"
       />
-      <div
-        className="absolute inset-0 bg-gradient-to-t from-black/70 via-black/40 to-transparent"
-        aria-hidden="true"
-      ></div>
+      <div className="img-gradient-overlay" aria-hidden="true" />
       <div className="absolute bottom-2 left-3 right-3 text-white drop-shadow space-y-1 text-left">
-        <h3 className="font-headline font-extrabold text-xl leading-none">
-          {plant.name}
-        </h3>
-        {plant.origin && (
-          <p className="text-sm leading-none">Origin: {plant.origin}</p>
-        )}
-        <div className="flex gap-1 flex-wrap">
-          {plant.light && (
-            <Badge
-              Icon={Sun}
-              size="sm"
-              colorClass="bg-black/40 text-white backdrop-blur-sm"
-            >
-              {plant.light}
-            </Badge>
+        <div className="hero-name-bg">
+          <h3 className="font-headline font-extrabold text-xl leading-none">
+            {plant.name}
+          </h3>
+          {plant.origin && (
+            <p className="text-sm leading-none">Origin: {plant.origin}</p>
           )}
-          {plant.humidity && (
-            <Badge
-              Icon={Leaf}
-              size="sm"
-              colorClass="bg-black/40 text-white backdrop-blur-sm"
-            >
-              {plant.humidity}
-            </Badge>
-          )}
-          {plant.difficulty && (
-            <Badge size="sm" colorClass="bg-black/40 text-white backdrop-blur-sm">
-              {plant.difficulty}
-            </Badge>
-          )}
+          <div className="flex gap-1 flex-wrap">
+            {plant.light && (
+              <Badge
+                Icon={Sun}
+                size="sm"
+                colorClass="bg-black/40 text-white backdrop-blur-sm"
+              >
+                {plant.light}
+              </Badge>
+            )}
+            {plant.humidity && (
+              <Badge
+                Icon={Leaf}
+                size="sm"
+                colorClass="bg-black/40 text-white backdrop-blur-sm"
+              >
+                {plant.humidity}
+              </Badge>
+            )}
+            {plant.difficulty && (
+              <Badge size="sm" colorClass="bg-black/40 text-white backdrop-blur-sm">
+                {plant.difficulty}
+              </Badge>
+            )}
+          </div>
+          <button
+            type="button"
+            onMouseDown={createRipple}
+            onTouchStart={createRipple}
+            onClick={() => onAdd?.(plant)}
+            className="mt-2 bg-blue-600 text-white px-3 py-1 rounded relative overflow-hidden"
+          >
+            Add to Wishlist
+          </button>
         </div>
-        <button
-          type="button"
-          onMouseDown={createRipple}
-          onTouchStart={createRipple}
-          onClick={() => onAdd?.(plant)}
-          className="mt-2 bg-blue-600 text-white px-3 py-1 rounded relative overflow-hidden"
-        >
-          Add to Wishlist
-        </button>
       </div>
     </div>
   )


### PR DESCRIPTION
## Summary
- swap in `img-gradient-overlay` for image gradient
- wrap card contents in `.hero-name-bg` to apply blur background

## Testing
- `npx jest --ci`

------
https://chatgpt.com/codex/tasks/task_e_6880d0ba7e948324842ca5954252fe86