### PR TITLE
Update care card layout

### DIFF
--- a/src/components/CareCard.jsx
+++ b/src/components/CareCard.jsx
@@ -12,7 +12,6 @@ export default function CareCard({
   overdue = false,
 
   buttonLabel,
-  infoBelow = false,
 
 }) {
   const [internalCompleted, setInternalCompleted] = useState(false)
@@ -38,11 +37,6 @@ export default function CareCard({
           <span className="font-semibold">{label}</span>
         </div>
         <div className="flex flex-col items-end gap-1">
-          {info && !infoBelow && (
-            <span className="text-xs text-gray-500" data-testid="care-info">
-              {info}
-            </span>
-          )}
           {onDone && (
             <button
               type="button"
@@ -52,14 +46,20 @@ export default function CareCard({
               {buttonLabel || 'Mark as Done'}
             </button>
           )}
-          {info && infoBelow && (
-            <span className="text-xs text-gray-500" data-testid="care-info">
-              {info}
-            </span>
-          )}
         </div>
       </div>
-      {status && <p className="text-sm text-gray-500">{status}</p>}
+      {status && (
+        <p
+          className={`text-sm ${overdue ? 'text-red-600 font-semibold' : 'text-gray-500'}`}
+        >
+          {status}
+        </p>
+      )}
+      {info && (
+        <p className="text-xs text-gray-500" data-testid="care-info">
+          {info}
+        </p>
+      )}
       <div
         className="h-2 rounded bg-gray-200 overflow-hidden"
         role="progressbar"

--- a/src/components/__tests__/CareCard.test.jsx
+++ b/src/components/__tests__/CareCard.test.jsx
@@ -2,10 +2,19 @@ import { render, screen, fireEvent, act } from '@testing-library/react'
 import { Drop, Sun } from 'phosphor-react'
 import CareCard from '../CareCard.jsx'
 
-test('renders label, status and progress width', () => {
-  render(<CareCard label="Water" Icon={Drop} progress={0.5} status="Due in 3 days" />)
+test('renders label, status, info and progress width', () => {
+  render(
+    <CareCard
+      label="Water"
+      Icon={Drop}
+      progress={0.5}
+      status="Due in 3 days"
+      info="200 mL every 9 days"
+    />,
+  )
   expect(screen.getByText('Water')).toBeInTheDocument()
   expect(screen.getByText(/due in 3 days/i)).toBeInTheDocument()
+  expect(screen.getByText(/200 mL every 9 days/i)).toBeInTheDocument()
   const bar = screen.getByRole('progressbar').firstChild
   expect(bar).toHaveStyle('width: 50%')
 })
@@ -39,4 +48,19 @@ test('shows sprout icon for fertilize card when completed', async () => {
   })
 
   jest.useRealTimers()
+})
+
+test('highlights overdue status', () => {
+  render(
+    <CareCard
+      label="Water"
+      Icon={Drop}
+      progress={0}
+      status="Overdue"
+      overdue
+    />,
+  )
+  const status = screen.getByText(/overdue/i)
+  expect(status).toHaveClass('text-red-600')
+  expect(status).toHaveClass('font-semibold')
 })

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -322,9 +322,7 @@ export default function PlantDetail() {
                 status={waterStatus}
                 overdue={waterOverdue}
                 onDone={handleWatered}
-                buttonLabel={waterVolume ? `Water ${waterVolume}` : undefined}
-                info={waterInterval}
-                infoBelow
+                info={[waterVolume, waterInterval].filter(Boolean).join(' ')}
               />
               <div
                 className={
@@ -340,6 +338,7 @@ export default function PlantDetail() {
                   status={fertStatus}
                   overdue={fertOverdue}
                   completed={fertilizeDone}
+                  info={plant.carePlan?.fertilize ? `every ${plant.carePlan.fertilize}\u00A0days` : null}
                   onDone={plant.nextFertilize ? handleFertilized : undefined}
                 />
                 {!plant.nextFertilize && (

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -155,7 +155,9 @@ test('cannot mark fertilize done when not scheduled', () => {
     </OpenAIProvider>
   )
 
-  expect(screen.queryByRole('button', { name: /mark as done/i })).toBeNull()
+  const buttons = screen.getAllByRole('button', { name: /mark as done/i })
+  // only the water task should show a button
+  expect(buttons).toHaveLength(1)
 })
 
 


### PR DESCRIPTION
## Summary
- improve CareCard layout
- show combined info line on PlantDetail task tab
- adjust PlantDetail test for new button label
- expand CareCard tests for info and overdue highlight

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6880cf87c6448324acc287b3a790597d