### PR TITLE
Remove residual iNaturalist references

### DIFF
--- a/src/discoverablePlants.json
+++ b/src/discoverablePlants.json
@@ -2,7 +2,7 @@
   {
     "id": 101,
     "name": "Chinese Evergreen",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/210155110/medium.jpeg",
+    "image": "/placeholder.svg",
     "origin": "Asia",
     "light": "Low",
     "humidity": "High",
@@ -11,7 +11,7 @@
   {
     "id": 102,
     "name": "Fiddle Leaf Fig",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/120489396/medium.jpeg",
+    "image": "/placeholder.svg",
     "origin": "West Africa",
     "light": "Bright",
     "humidity": "Average",
@@ -20,7 +20,7 @@
   {
     "id": 103,
     "name": "Spider Plant",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/8212688/medium.jpg",
+    "image": "/placeholder.svg",
     "origin": "South Africa",
     "light": "Medium",
     "humidity": "Average",
@@ -29,7 +29,7 @@
   {
     "id": 104,
     "name": "English Ivy",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/185788097/medium.jpeg",
+    "image": "/placeholder.svg",
     "origin": "Europe",
     "light": "Low",
     "humidity": "Average",
@@ -38,7 +38,7 @@
   {
     "id": 105,
     "name": "Boston Fern",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/34207973/medium.jpeg",
+    "image": "/placeholder.svg",
     "origin": "South America",
     "light": "Indirect",
     "humidity": "High",

--- a/src/hooks/__tests__/usePlantTaxon.test.js
+++ b/src/hooks/__tests__/usePlantTaxon.test.js
@@ -13,34 +13,15 @@ function Test({ query }) {
 }
 
 afterEach(() => {
-  global.fetch && (global.fetch = undefined)
   localStorage.clear()
 })
 
-test('fetches taxon suggestions', async () => {
-  const data = {
-    results: [
-      { id: 1, name: 'Aloe vera', preferred_common_name: 'Aloe' },
-    ],
-  }
-  global.fetch = jest.fn(() =>
-    Promise.resolve({ json: () => Promise.resolve(data) })
-  )
-  render(<Test query="aloe" />)
-  await waitFor(() => screen.getByText('Aloe:Aloe vera'))
-  expect(global.fetch).toHaveBeenCalledWith(
-    expect.stringContaining('taxa/autocomplete?q=aloe'),
-    expect.any(Object)
-  )
+test('returns matching suggestions', async () => {
+  render(<Test query="Alo" />)
+  await waitFor(() => screen.getByText('Aloe Vera:Aloe Vera'))
 })
 
-test('aborts fetch on unmount', async () => {
-  const abortMock = jest.fn()
-  global.AbortController = jest.fn(() => ({ signal: 's', abort: abortMock }))
-  global.fetch = jest.fn(() => Promise.resolve({ json: () => Promise.resolve({ results: [] }) }))
-  const { unmount } = render(<Test query="al" />)
-  await waitFor(() => expect(global.fetch).toHaveBeenCalled())
-  unmount()
-  expect(abortMock).toHaveBeenCalled()
-  global.AbortController = undefined
+test('ignores short queries', () => {
+  render(<Test query="a" />)
+  expect(screen.queryByText(/:/)).toBeNull()
 })

--- a/src/pages/__tests__/Onboard.test.jsx
+++ b/src/pages/__tests__/Onboard.test.jsx
@@ -79,11 +79,8 @@ test('generates plan and adds plant then navigates home', async () => {
 })
 
 test('autocomplete fills scientific name', async () => {
-  const taxaData = { results: [ { id: 1, name: 'Aloe vera', preferred_common_name: 'Aloe' } ] }
   const planData = { text: 'ok', water: 7, water_volume_ml: 500, water_volume_oz: 17 }
-  global.fetch = jest.fn()
-    .mockResolvedValueOnce({ json: () => Promise.resolve(taxaData) })
-    .mockResolvedValueOnce({ ok: true, json: () => Promise.resolve(planData) })
+  global.fetch = jest.fn(() => Promise.resolve({ ok: true, json: () => Promise.resolve(planData) }))
 
   render(
     <MemoryRouter initialEntries={['/onboard']}>
@@ -96,15 +93,15 @@ test('autocomplete fills scientific name', async () => {
 
   const nameInput = screen.getByLabelText(/plant name/i)
   fireEvent.change(nameInput, { target: { value: 'Al' } })
-  await waitFor(() => screen.getByText('Aloe vera'))
-  fireEvent.change(nameInput, { target: { value: 'Aloe' } })
+  await waitFor(() => screen.getByText('Aloe Vera'))
+  fireEvent.change(nameInput, { target: { value: 'Aloe Vera' } })
   fireEvent.change(screen.getByLabelText(/pot diameter/i), { target: { value: '4' } })
   fireEvent.click(screen.getByRole('button', { name: /generate care plan/i }))
   await waitFor(() => screen.getByTestId('care-plan'))
   fireEvent.click(screen.getByRole('button', { name: /add plant/i }))
 
   expect(addPlant).toHaveBeenCalledWith(
-    expect.objectContaining({ scientificName: 'Aloe vera', name: 'Aloe' })
+    expect.objectContaining({ scientificName: 'Aloe Vera', name: 'Aloe Vera' })
   )
 })
 

--- a/src/plants.json
+++ b/src/plants.json
@@ -2,23 +2,23 @@
   {
     "id": 1,
     "name": "Pothos",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/24339002/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/24339002/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/24339002/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Pothos photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/439386/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Pothos photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20430629/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Pothos photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/29279055/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Pothos photo 4"
       }
     ],
@@ -48,23 +48,23 @@
   {
     "id": 2,
     "name": "Begonia",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/439386/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/439386/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/439386/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Begonia photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/138693139/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Begonia photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/34232708/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Begonia photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/340224811/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Begonia photo 4"
       }
     ],
@@ -94,23 +94,23 @@
   {
     "id": 3,
     "name": "Azalea",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/20430629/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/20430629/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20430629/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Azalea photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/82166001/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Azalea photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/1471161/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Azalea photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/229075348/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Azalea photo 4"
       }
     ],
@@ -140,23 +140,23 @@
   {
     "id": 4,
     "name": "Hydrangea",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/29279055/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/29279055/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/29279055/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Hydrangea photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/126892897/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Hydrangea photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20210365/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Hydrangea photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/59736705/square.jpg",
+        "src": "/placeholder.svg",
         "caption": "Hydrangea photo 4"
       }
     ],
@@ -186,23 +186,23 @@
   {
     "id": 5,
     "name": "Clematis",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/138693139/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/138693139/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/138693139/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Clematis photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/134247814/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Clematis photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/116385724/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Clematis photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/75790/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Clematis photo 4"
       }
     ],
@@ -232,23 +232,23 @@
   {
     "id": 6,
     "name": "Gaillardia",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/34232708/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/34232708/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/34232708/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Gaillardia photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/105002993/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Gaillardia photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/2526018/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Gaillardia photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/86566147/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Gaillardia photo 4"
       }
     ],
@@ -278,23 +278,23 @@
   {
     "id": 7,
     "name": "Black-eyed Susan",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/340224811/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/340224811/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/340224811/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Black-eyed Susan photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/22878295/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Black-eyed Susan photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/120845281/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Black-eyed Susan photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/10802854/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Black-eyed Susan photo 4"
       }
     ],
@@ -324,23 +324,23 @@
   {
     "id": 8,
     "name": "Sunkiss",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/82166001/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/82166001/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/82166001/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Sunkiss photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/112410547/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Sunkiss photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/62723485/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Sunkiss photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/487625794/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Sunkiss photo 4"
       }
     ],
@@ -370,23 +370,23 @@
   {
     "id": 9,
     "name": "African Marigold",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/1471161/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/1471161/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/1471161/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "African Marigold photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/254288383/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "African Marigold photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/463614054/square.jpg",
+        "src": "/placeholder.svg",
         "caption": "African Marigold photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/876072/medium.JPG",
+        "src": "/placeholder.svg",
         "caption": "African Marigold photo 4"
       }
     ],
@@ -416,23 +416,23 @@
   {
     "id": 10,
     "name": "Geraniums",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/229075348/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/229075348/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/229075348/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Geraniums photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/50142932/square.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Geraniums photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/55944984/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Geraniums photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/148979348/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Geraniums photo 4"
       }
     ],
@@ -462,23 +462,23 @@
   {
     "id": 11,
     "name": "Gladiolus",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/126892897/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/126892897/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/126892897/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Gladiolus photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/82160203/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Gladiolus photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/252085655/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Gladiolus photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/108567955/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Gladiolus photo 4"
       }
     ],
@@ -508,23 +508,23 @@
   {
     "id": 12,
     "name": "Snapdragons",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/20210365/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/20210365/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20210365/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Snapdragons photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/24449418/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Snapdragons photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/224058295/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Snapdragons photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/35190474/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Snapdragons photo 4"
       }
     ],
@@ -554,23 +554,23 @@
   {
     "id": 13,
     "name": "Primrose",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/59736705/square.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/59736705/square.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/59736705/square.jpg",
+        "src": "/placeholder.svg",
         "caption": "Primrose photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/10615/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Primrose photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/31355205/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Primrose photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/448953057/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Primrose photo 4"
       }
     ],
@@ -600,23 +600,23 @@
   {
     "id": 14,
     "name": "Tobacco",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/134247814/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/134247814/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/134247814/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Tobacco photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/29047197/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Tobacco photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/24339002/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Tobacco photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/439386/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Tobacco photo 4"
       }
     ],
@@ -646,23 +646,23 @@
   {
     "id": 15,
     "name": "Zinnia",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/116385724/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/116385724/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/116385724/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Zinnia photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20430629/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Zinnia photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/29279055/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Zinnia photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/138693139/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Zinnia photo 4"
       }
     ],
@@ -692,23 +692,23 @@
   {
     "id": 16,
     "name": "Sunflower",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/75790/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/75790/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/75790/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Sunflower photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/34232708/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Sunflower photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/340224811/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Sunflower photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/82166001/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Sunflower photo 4"
       }
     ],
@@ -738,23 +738,23 @@
   {
     "id": 17,
     "name": "Christmas Cactus",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/105002993/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/105002993/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/105002993/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Christmas Cactus photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/1471161/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Christmas Cactus photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/229075348/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Christmas Cactus photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/126892897/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Christmas Cactus photo 4"
       }
     ],
@@ -784,23 +784,23 @@
   {
     "id": 18,
     "name": "Bunny Ear Cactus White",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/2526018/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/2526018/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/2526018/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Bunny Ear Cactus White photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20210365/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Bunny Ear Cactus White photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/59736705/square.jpg",
+        "src": "/placeholder.svg",
         "caption": "Bunny Ear Cactus White photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/134247814/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Bunny Ear Cactus White photo 4"
       }
     ],
@@ -830,23 +830,23 @@
   {
     "id": 19,
     "name": "Aloe Vera",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/86566147/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/86566147/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/86566147/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Aloe Vera photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/116385724/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Aloe Vera photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/75790/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Aloe Vera photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/105002993/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Aloe Vera photo 4"
       }
     ],
@@ -876,23 +876,23 @@
   {
     "id": 20,
     "name": "Lime Tree",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/22878295/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/22878295/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/22878295/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Lime Tree photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/2526018/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lime Tree photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/86566147/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lime Tree photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/120845281/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Lime Tree photo 4"
       }
     ],
@@ -922,23 +922,23 @@
   {
     "id": 21,
     "name": "Jade Plant",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/120845281/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/120845281/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/120845281/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Jade Plant photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/10802854/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Jade Plant photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/112410547/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Jade Plant photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/62723485/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Jade Plant photo 4"
       }
     ],
@@ -968,23 +968,23 @@
   {
     "id": 22,
     "name": "ZZ Plant",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/10802854/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/10802854/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/10802854/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "ZZ Plant photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/487625794/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "ZZ Plant photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/254288383/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "ZZ Plant photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/463614054/square.jpg",
+        "src": "/placeholder.svg",
         "caption": "ZZ Plant photo 4"
       }
     ],
@@ -1014,23 +1014,23 @@
   {
     "id": 23,
     "name": "Fiddle Leaf Fig Tree",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/112410547/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/112410547/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/112410547/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Fiddle Leaf Fig Tree photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/876072/medium.JPG",
+        "src": "/placeholder.svg",
         "caption": "Fiddle Leaf Fig Tree photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/50142932/square.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Fiddle Leaf Fig Tree photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/55944984/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Fiddle Leaf Fig Tree photo 4"
       }
     ],
@@ -1060,23 +1060,23 @@
   {
     "id": 24,
     "name": "Coffee",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/62723485/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/62723485/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/62723485/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Coffee photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/148979348/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Coffee photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/82160203/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Coffee photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/252085655/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Coffee photo 4"
       }
     ],
@@ -1106,23 +1106,23 @@
   {
     "id": 25,
     "name": "Croton",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/487625794/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/487625794/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/487625794/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Croton photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/108567955/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Croton photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/24449418/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Croton photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/224058295/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Croton photo 4"
       }
     ],
@@ -1152,23 +1152,23 @@
   {
     "id": 26,
     "name": "Elephant Ears",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/254288383/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/254288383/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/254288383/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Elephant Ears photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/35190474/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Elephant Ears photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/10615/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Elephant Ears photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/31355205/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Elephant Ears photo 4"
       }
     ],
@@ -1198,23 +1198,23 @@
   {
     "id": 27,
     "name": "Golden Pothos",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/463614054/square.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/463614054/square.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/463614054/square.jpg",
+        "src": "/placeholder.svg",
         "caption": "Golden Pothos photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/448953057/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Golden Pothos photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/29047197/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Golden Pothos photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/24339002/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Golden Pothos photo 4"
       }
     ],
@@ -1244,23 +1244,23 @@
   {
     "id": 28,
     "name": "Peace Lily",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/876072/medium.JPG",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/876072/medium.JPG",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/876072/medium.JPG",
+        "src": "/placeholder.svg",
         "caption": "Peace Lily photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/439386/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Peace Lily photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20430629/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Peace Lily photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/29279055/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Peace Lily photo 4"
       }
     ],
@@ -1290,23 +1290,23 @@
   {
     "id": 29,
     "name": "Snake Plant",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/50142932/square.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/50142932/square.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/50142932/square.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Snake Plant photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/138693139/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Snake Plant photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/34232708/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Snake Plant photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/340224811/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Snake Plant photo 4"
       }
     ],
@@ -1336,23 +1336,23 @@
   {
     "id": 30,
     "name": "Snake Plant Norma",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/55944984/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/55944984/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/55944984/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Snake Plant Norma photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/82166001/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Snake Plant Norma photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/1471161/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Snake Plant Norma photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/229075348/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Snake Plant Norma photo 4"
       }
     ],
@@ -1382,23 +1382,23 @@
   {
     "id": 31,
     "name": "Strawberries",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/148979348/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/148979348/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/148979348/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Strawberries photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/126892897/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Strawberries photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20210365/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Strawberries photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/59736705/square.jpg",
+        "src": "/placeholder.svg",
         "caption": "Strawberries photo 4"
       }
     ],
@@ -1428,23 +1428,23 @@
   {
     "id": 32,
     "name": "Lettuce",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/82160203/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/82160203/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/82160203/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Lettuce photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/134247814/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lettuce photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/116385724/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Lettuce photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/75790/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lettuce photo 4"
       }
     ],
@@ -1474,23 +1474,23 @@
   {
     "id": 33,
     "name": "Lotus",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/252085655/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/252085655/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/252085655/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Lotus photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/105002993/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Lotus photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/2526018/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lotus photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/86566147/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lotus photo 4"
       }
     ],
@@ -1520,23 +1520,23 @@
   {
     "id": 34,
     "name": "Venus Fly Trap",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/108567955/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/108567955/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/108567955/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Venus Fly Trap photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/22878295/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Venus Fly Trap photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/120845281/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Venus Fly Trap photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/10802854/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Venus Fly Trap photo 4"
       }
     ],
@@ -1566,23 +1566,23 @@
   {
     "id": 35,
     "name": "Bleeding Heart",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/24449418/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/24449418/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/24449418/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Bleeding Heart photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/112410547/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Bleeding Heart photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/62723485/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Bleeding Heart photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/487625794/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Bleeding Heart photo 4"
       }
     ],
@@ -1612,23 +1612,23 @@
   {
     "id": 36,
     "name": "Hibiscus",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/224058295/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/224058295/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/224058295/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Hibiscus photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/254288383/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Hibiscus photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/463614054/square.jpg",
+        "src": "/placeholder.svg",
         "caption": "Hibiscus photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/876072/medium.JPG",
+        "src": "/placeholder.svg",
         "caption": "Hibiscus photo 4"
       }
     ],
@@ -1658,23 +1658,23 @@
   {
     "id": 37,
     "name": "Shasta Daisy",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/35190474/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/35190474/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/35190474/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Shasta Daisy photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/50142932/square.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Shasta Daisy photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/55944984/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Shasta Daisy photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/148979348/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Shasta Daisy photo 4"
       }
     ],
@@ -1704,23 +1704,23 @@
   {
     "id": 38,
     "name": "Foxglove",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/10615/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/10615/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/10615/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Foxglove photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/82160203/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Foxglove photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/252085655/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Foxglove photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/108567955/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Foxglove photo 4"
       }
     ],
@@ -1750,23 +1750,23 @@
   {
     "id": 39,
     "name": "Periwinkle",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/31355205/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/31355205/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/31355205/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Periwinkle photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/24449418/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Periwinkle photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/224058295/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Periwinkle photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/35190474/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Periwinkle photo 4"
       }
     ],
@@ -1796,23 +1796,23 @@
   {
     "id": 40,
     "name": "Wandering Jew",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/448953057/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/448953057/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/448953057/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Wandering Jew photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/10615/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Wandering Jew photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/31355205/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Wandering Jew photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/29047197/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Wandering Jew photo 4"
       }
     ],
@@ -1842,23 +1842,23 @@
   {
     "id": 41,
     "name": "Bee Balm",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/29047197/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/29047197/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/29047197/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Bee Balm photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/24339002/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Bee Balm photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/439386/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Bee Balm photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20430629/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Bee Balm photo 4"
       }
     ],
@@ -1888,23 +1888,23 @@
   {
     "id": 42,
     "name": "Astilbe",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/24339002/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/24339002/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/24339002/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Astilbe photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/29279055/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Astilbe photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/138693139/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Astilbe photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/34232708/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Astilbe photo 4"
       }
     ],
@@ -1934,23 +1934,23 @@
   {
     "id": 43,
     "name": "Lupine",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/439386/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/439386/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/439386/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lupine photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/340224811/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lupine photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/82166001/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lupine photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/1471161/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lupine photo 4"
       }
     ],
@@ -1980,23 +1980,23 @@
   {
     "id": 44,
     "name": "Monstera",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/20430629/medium.jpg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/20430629/medium.jpg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20430629/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Monstera photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/229075348/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Monstera photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/126892897/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Monstera photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/20210365/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Monstera photo 4"
       }
     ],
@@ -2026,23 +2026,23 @@
   {
     "id": 45,
     "name": "Lil Fiddle",
-    "placeholderSrc": "https://inaturalist-open-data.s3.amazonaws.com/photos/29279055/medium.jpeg",
-    "image": "https://inaturalist-open-data.s3.amazonaws.com/photos/29279055/medium.jpeg",
+    "placeholderSrc": "/placeholder.svg",
+    "image": "/placeholder.svg",
     "photos": [
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/29279055/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Lil Fiddle photo 1"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/59736705/square.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lil Fiddle photo 2"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/134247814/medium.jpg",
+        "src": "/placeholder.svg",
         "caption": "Lil Fiddle photo 3"
       },
       {
-        "src": "https://inaturalist-open-data.s3.amazonaws.com/photos/116385724/medium.jpeg",
+        "src": "/placeholder.svg",
         "caption": "Lil Fiddle photo 4"
       }
     ],


### PR DESCRIPTION
## Summary
- replace remote photo links in datasets with `/placeholder.svg`
- drop iNaturalist API calls by reworking `usePlantTaxon`
- update tests for new local autocomplete behavior

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6880d34c77c08324a73c14e761be1d75