### PR TITLE
Fix care plan API and add tests

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,2 +1,3 @@
 VITE_WEATHER_API_KEY=your_key_here
 VITE_OPENAI_API_KEY=your_openai_key
+OPENAI_API_KEY=your_openai_key

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ You can change the city and switch between Fahrenheit and Celsius from the **Set
 1. Sign up at [OpenWeather](https://openweathermap.org/api) and create a key.
 2. Copy `.env.example` to `.env` in the project root and replace `your_key_here`
    with your actual API key.
-3. (Optional) Add `VITE_OPENAI_API_KEY` (or `OPENAI_API_KEY`) to enable featured plant facts, Coach, and Care Plan features.
+3. (Optional) Add `VITE_OPENAI_API_KEY` (or `OPENAI_API_KEY`) to enable featured plant facts, Coach, and Care Plan features. The Express API also reads `OPENAI_API_KEY` if you prefer not to expose the key to the frontend.
 
 ### How It Works
 
@@ -106,8 +106,8 @@ In the app this is displayed below the progress bars as:
 
 ## Plant Facts (Optional)
 
-Provide an OpenAI API key in `.env` as `VITE_OPENAI_API_KEY` (or `OPENAI_API_KEY`) to display a short
-fact about the featured plant. The same key is required for the Coach and Care Plan endpoints. If the key is missing or the request fails,
+Provide an OpenAI API key in `.env` as `VITE_OPENAI_API_KEY` or `OPENAI_API_KEY` to display a short
+fact about the featured plant. Both variables are supported by the API routes. If the key is missing or the request fails,
 Lisa falls back to a brief summary from Wikipedia.
 You can enable or disable these features from the **Settings → Preferences** page.
 Requests to the OpenAI API may incur charges.

--- a/lib/__tests__/carePlan.test.js
+++ b/lib/__tests__/carePlan.test.js
@@ -1,0 +1,30 @@
+/** @jest-environment node */
+import { generateCarePlan, validateCarePlanInput } from '../carePlan.js'
+
+test('validateCarePlanInput detects missing fields', () => {
+  const missing = validateCarePlanInput({ name: 'Aloe' })
+  expect(missing).toContain('diameter')
+  expect(missing).toContain('soil')
+})
+
+test('throws error when API key missing', async () => {
+  await expect(
+    generateCarePlan({ name: 'A', diameter: 4, soil: 'pot', light: 'Low', room: 'Office', humidity: 50 }, () => Promise.resolve({ ok: true, json: () => Promise.resolve({ choices: [{ message: { content: '{}' } }] }) }), '')
+  ).rejects.toThrow('Missing OpenAI API key')
+})
+
+
+test('returns plan text on success', async () => {
+  const fakeFetch = () =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({ choices: [{ message: { content: '{"water":7}' } }] }),
+    })
+  const plan = await generateCarePlan(
+    { name: 'A', diameter: 4, soil: 'pot', light: 'Low', room: 'Office', humidity: 50 },
+    fakeFetch,
+    'key'
+  )
+  expect(plan.text).toBe('{"water":7}')
+})

--- a/lib/carePlan.js
+++ b/lib/carePlan.js
@@ -1,0 +1,53 @@
+export function validateCarePlanInput(data = {}) {
+  const required = ['name', 'diameter', 'soil', 'light', 'room', 'humidity']
+  const missing = required.filter(k => data[k] === undefined || data[k] === '')
+  return missing
+}
+
+export async function generateCarePlan(data, fetchImpl = fetch, apiKey = process.env.OPENAI_API_KEY || process.env.VITE_OPENAI_API_KEY) {
+  const missing = validateCarePlanInput(data)
+  if (missing.length) {
+    const err = new Error(`Missing fields: ${missing.join(', ')}`)
+    err.status = 400
+    throw err
+  }
+  if (!apiKey) {
+    const err = new Error('Missing OpenAI API key')
+    err.status = 400
+    throw err
+  }
+
+  const messages = [
+    { role: 'system', content: 'You are a helpful plant care assistant.' },
+    {
+      role: 'user',
+      content: `Plant: ${data.name}\nDiameter: ${data.diameter}\nSoil: ${data.soil}\nLight: ${data.light}\nRoom: ${data.room}\nHumidity: ${data.humidity}`,
+    },
+  ]
+
+  const response = await fetchImpl('https://api.openai.com/v1/chat/completions', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify({ model: 'gpt-4o', messages }),
+  })
+
+  if (!response.ok) {
+    const err = new Error('Failed to fetch plan')
+    err.status = 500
+    throw err
+  }
+
+  const dataJson = await response.json()
+  const text = dataJson?.choices?.[0]?.message?.content?.trim() || ''
+  let plan
+  try {
+    plan = JSON.parse(text)
+  } catch {
+    plan = { text }
+  }
+  plan.text = text
+  return plan
+}

--- a/pages/api/care-plan.js
+++ b/pages/api/care-plan.js
@@ -1,0 +1,15 @@
+import { generateCarePlan } from '../../lib/carePlan.js'
+
+export default async function handler(req, res) {
+  if (req.method !== 'POST') {
+    res.status(405).json({ error: 'Method not allowed' })
+    return
+  }
+  try {
+    const plan = await generateCarePlan(req.body)
+    res.status(200).json(plan)
+  } catch (err) {
+    const status = err.status || 500
+    res.status(status).json({ error: err.message || 'Failed to generate plan' })
+  }
+}

--- a/src/pages/__tests__/Onboard.test.jsx
+++ b/src/pages/__tests__/Onboard.test.jsx
@@ -138,3 +138,18 @@ test('selecting a name fetches defaults', async () => {
   )
   expect(screen.getByLabelText(/humidity/i)).toHaveValue(60)
 })
+
+test('shows error message on failure', async () => {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'bad' }) }))
+  render(
+    <MemoryRouter initialEntries={['/onboard']}>
+      <Routes>
+        <Route path="/onboard" element={<Onboard />} />
+      </Routes>
+    </MemoryRouter>
+  )
+  fireEvent.change(screen.getByLabelText(/plant name/i), { target: { value: 'A' } })
+  fireEvent.click(screen.getByRole('button', { name: /generate care plan/i }))
+  await waitFor(() => screen.getByRole('alert'))
+  expect(screen.getByRole('alert')).toHaveTextContent('Failed to generate plan')
+})


### PR DESCRIPTION
## Summary
- add new `carePlan` helper with input validation
- expose Next.js-style `/api/care-plan` route
- use helper in Express API
- document `OPENAI_API_KEY`
- add unit tests for `carePlan` helper and error UI path

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688360a21b9083248105fa3bcf6df6ad