### PR TITLE
Fix stray zero in care plan tab

### DIFF
--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -462,7 +462,7 @@ export default function PlantDetail() {
                 )}
               </>
             )}
-            {(plant.carePlan || plant.waterPlan?.interval) && (
+            {Boolean(plant.carePlan || plant.waterPlan?.interval) && (
               <Link
                 to={`/plant/${plant.id}/edit-care-plan`}
                 className="inline-block px-3 py-1.5 text-sm font-semibold text-white bg-green-600 rounded-full"


### PR DESCRIPTION
## Summary
- avoid rendering numeric `0` when care plan is missing

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6883694622e883249599071aebdc4732