### PR TITLE
Add swipe hint and confirm dialog for tasks

### DIFF
--- a/src/components/SwipeTip.jsx
+++ b/src/components/SwipeTip.jsx
@@ -1,0 +1,39 @@
+import { useEffect, useState } from 'react'
+
+export default function SwipeTip() {
+  const [show, setShow] = useState(false)
+
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      const seen = localStorage.getItem('swipeTipSeen')
+      if (!seen) setShow(true)
+    }
+  }, [])
+
+  const hide = () => {
+    setShow(false)
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('swipeTipSeen', 'true')
+    }
+  }
+
+  useEffect(() => {
+    if (!show) return
+    const timer = setTimeout(hide, 5000)
+    return () => clearTimeout(timer)
+  }, [show])
+
+  return show ? (
+    <div className="fixed inset-x-0 bottom-20 pb-safe flex justify-center pointer-events-none z-30">
+      <div
+        role="status"
+        className="px-3 py-2 bg-gray-800 text-white text-sm rounded shadow pointer-events-auto flex items-center gap-2"
+      >
+        <span>Swipe a task for more options</span>
+        <button onClick={hide} className="underline text-xs">
+          Got it
+        </button>
+      </div>
+    </div>
+  ) : null
+}

--- a/src/components/__tests__/TaskCard.test.jsx
+++ b/src/components/__tests__/TaskCard.test.jsx
@@ -169,6 +169,7 @@ test('partial left swipe reveals actions', () => {
   fireEvent.click(screen.getByRole('button', { name: /reschedule task/i }))
   expect(updatePlant).toHaveBeenCalled()
   fireEvent.click(screen.getByRole('button', { name: /delete task/i }))
+  fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
   expect(updatePlant).toHaveBeenCalledTimes(2)
 })
 

--- a/src/components/__tests__/UnifiedTaskCard.test.jsx
+++ b/src/components/__tests__/UnifiedTaskCard.test.jsx
@@ -122,6 +122,7 @@ test('kebab menu exposes actions', () => {
   expect(updatePlant).toHaveBeenCalled()
   fireEvent.click(screen.getByRole('button', { name: /open task menu/i }))
   fireEvent.click(screen.getByRole('button', { name: /delete task/i }))
+  fireEvent.click(screen.getByRole('button', { name: /confirm/i }))
   expect(updatePlant).toHaveBeenCalledTimes(2)
 })
 

--- a/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
+++ b/src/components/__tests__/__snapshots__/UnifiedTaskCard.test.jsx.snap
@@ -2,9 +2,11 @@
 
 exports[`matches snapshot in dark mode 1`] = `
 <div
+  aria-label="Task card for Fern"
   class="relative rounded-2xl border border-neutral-200 dark:border-gray-600 shadow overflow-hidden touch-pan-y select-none bg-slate-50 dark:bg-gray-800 "
   data-testid="unified-task-card"
   style="transform: translateX(0px); transition: transform 0.2s;"
+  tabindex="0"
 >
   <div
     class="flex items-center gap-4 p-4"

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -23,6 +23,7 @@ import {
 import CareStats from '../components/CareStats.jsx'
 import DiscoveryCard from '../components/DiscoveryCard.jsx'
 import Card from '../components/Card.jsx'
+import SwipeTip from '../components/SwipeTip.jsx'
 import useHappyPlant from '../hooks/useHappyPlant.js'
 import useDiscoverablePlant from '../hooks/useDiscoverablePlant.js'
 
@@ -267,6 +268,7 @@ export default function Home() {
         <CareSummaryModal tasks={tasks} onClose={() => setShowSummary(false)} />
       )}
       <TasksContainer visibleTasks={visibleTasks} happyPlant={happyPlant} />
+      <SwipeTip />
       <div className="mt-4">
         <Card className="p-0 text-center font-semibold">
           <Link to="/myplants" className="block px-4 py-2">

--- a/src/pages/Tasks.jsx
+++ b/src/pages/Tasks.jsx
@@ -9,6 +9,7 @@ import BaseCard from '../components/BaseCard.jsx'
 import TaskTabs from '../components/TaskTabs.jsx'
 import CareRings from '../components/CareRings.jsx'
 import PageHeader from '../components/PageHeader.jsx'
+import SwipeTip from '../components/SwipeTip.jsx'
 import { ListBullets, SquaresFour, Sun } from 'phosphor-react'
 import useTaskLayout from '../hooks/useTaskLayout.js'
 
@@ -452,6 +453,7 @@ export default function Tasks() {
 
         })
         )}
+      <SwipeTip />
     </div>
   )
 }


### PR DESCRIPTION
## Summary
- show a swipe tip on Home and Tasks pages
- add keyboard shortcuts and confirm dialog to `TaskCard`
- add keyboard shortcuts and confirm dialog to `UnifiedTaskCard`
- update tests and snapshots

## Testing
- `npm test`
- `npm test -- -u`

------
https://chatgpt.com/codex/tasks/task_e_6883e1a3ca288324aef8095d4fe9f22e