### PR TITLE
Add care plan generation to edit page

### DIFF
--- a/src/pages/EditCarePlan.jsx
+++ b/src/pages/EditCarePlan.jsx
@@ -1,7 +1,8 @@
-import { useState } from 'react'
+import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import PageContainer from '../components/PageContainer.jsx'
 import { usePlants } from '../PlantContext.jsx'
+import useCarePlan from '../hooks/useCarePlan.js'
 
 export default function EditCarePlan() {
   const { id } = useParams()
@@ -13,6 +14,15 @@ export default function EditCarePlan() {
   const [waterVolumeMl, setWaterVolumeMl] = useState(plant?.waterPlan?.volume_ml || '')
   const [waterVolumeOz, setWaterVolumeOz] = useState(plant?.waterPlan?.volume_oz || '')
   const [fertilizeInterval, setFertilizeInterval] = useState(plant?.carePlan?.fertilize || '')
+  const { plan, loading, generate } = useCarePlan()
+
+  useEffect(() => {
+    if (!plan) return
+    if (plan.water !== undefined) setWaterInterval(plan.water)
+    if (plan.water_volume_ml !== undefined) setWaterVolumeMl(plan.water_volume_ml)
+    if (plan.water_volume_oz !== undefined) setWaterVolumeOz(plan.water_volume_oz)
+    if (plan.fertilize !== undefined) setFertilizeInterval(plan.fertilize)
+  }, [plan])
 
   if (!plant) {
     return <div className="text-gray-700">Plant not found</div>
@@ -29,6 +39,17 @@ export default function EditCarePlan() {
       carePlan: { ...(plant.carePlan || {}), water: Number(waterInterval) || 0, fertilize: Number(fertilizeInterval) || 0 },
     })
     navigate(`/plant/${plant.id}`)
+  }
+
+  const handleGenerate = () => {
+    generate({
+      name: plant.name,
+      diameter: plant.diameter,
+      soil: plant.soil || 'potting mix',
+      light: plant.light || 'Medium',
+      room: plant.room || '',
+      humidity: Number(plant.humidity) || 50,
+    })
   }
 
   return (
@@ -75,7 +96,18 @@ export default function EditCarePlan() {
             className="border rounded p-2"
           />
         </div>
-        <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">Save</button>
+        <div className="flex gap-2">
+          <button
+            type="button"
+            onClick={handleGenerate}
+            className="px-4 py-2 bg-green-600 text-white rounded"
+            disabled={loading}
+          >
+            Generate Care Plan
+          </button>
+          <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">Save</button>
+        </div>
+        {loading && <p className="mt-2">Loading...</p>}
       </form>
     </PageContainer>
   )

--- a/src/pages/__tests__/EditCarePlan.test.jsx
+++ b/src/pages/__tests__/EditCarePlan.test.jsx
@@ -1,0 +1,77 @@
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import EditCarePlan from '../EditCarePlan.jsx'
+import { __updatePlant as updatePlant } from '../../PlantContext.jsx'
+
+const mockPlants = [
+  {
+    id: 1,
+    name: 'Aloe',
+    diameter: 4,
+    room: 'Office',
+    humidity: 40,
+    light: 'Medium',
+    waterPlan: { interval: 3, volume_ml: 100, volume_oz: 3 },
+    carePlan: { fertilize: 15 },
+  },
+]
+
+jest.mock('../../PlantContext.jsx', () => {
+  const updatePlant = jest.fn()
+  return {
+    __esModule: true,
+    usePlants: () => ({ plants: mockPlants, updatePlant }),
+    __updatePlant: updatePlant,
+    addBase: (u) => u,
+  }
+})
+
+jest.mock('../../OpenAIContext.jsx', () => ({
+  useOpenAI: () => ({ enabled: true }),
+}))
+
+afterEach(() => {
+  updatePlant.mockClear()
+  global.fetch && (global.fetch = undefined)
+})
+
+test('generates plan and saves updates', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () =>
+        Promise.resolve({
+          water: 7,
+          water_volume_ml: 500,
+          water_volume_oz: 17,
+          fertilize: 30,
+        }),
+    })
+  )
+
+  render(
+    <MemoryRouter initialEntries={['/plant/1/edit-care-plan']}>
+      <Routes>
+        <Route path="/plant/:id/edit-care-plan" element={<EditCarePlan />} />
+        <Route path="/plant/:id" element={<div>Detail</div>} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+  fireEvent.click(screen.getByRole('button', { name: /generate care plan/i }))
+
+  await waitFor(() => expect(screen.getByLabelText(/water interval/i)).toHaveValue(7))
+  expect(screen.getByLabelText(/fertilize interval/i)).toHaveValue(30)
+
+  fireEvent.click(screen.getByRole('button', { name: /save/i }))
+
+  expect(updatePlant).toHaveBeenCalledWith(
+    1,
+    expect.objectContaining({
+      waterPlan: { interval: 7, volume_ml: 500, volume_oz: 17 },
+      carePlan: expect.objectContaining({ fertilize: 30, water: 7 }),
+    })
+  )
+
+  expect(screen.getByText('Detail')).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- use `useCarePlan` on the EditCarePlan page
- generate watering data from existing plant details
- show progress indicator and populate fields with generated values
- test care plan generation on the edit page

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883ee891f9c8324bdb7367c77ab5fe0