### PR TITLE
Add care plan fallback handling

### DIFF
--- a/src/hooks/__tests__/useCarePlan.test.js
+++ b/src/hooks/__tests__/useCarePlan.test.js
@@ -33,3 +33,26 @@ test('posts details to /api/care-plan', async () => {
   )
 })
 
+test('returns fallback plan on failure', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'bad' }) })
+  )
+  function Fallback() {
+    const { plan, error, generate } = useCarePlan()
+    return (
+      <div>
+        <button onClick={() => generate({ name: 'Snake' })}>go</button>
+        <span data-testid="error">{error}</span>
+        {plan && <span data-testid="water">{plan.water}</span>}
+      </div>
+    )
+  }
+  render(<Fallback />)
+  await act(async () => {
+    screen.getByText('go').click()
+  })
+  await waitFor(() => screen.getByTestId('error'))
+  expect(screen.getByTestId('error')).toHaveTextContent('Failed to generate plan')
+  expect(screen.getByTestId('water')).toHaveTextContent('0')
+})
+

--- a/src/hooks/useCarePlan.js
+++ b/src/hooks/useCarePlan.js
@@ -7,6 +7,14 @@ export default function useCarePlan() {
   const [error, setError] = useState('')
   const { enabled } = useOpenAI()
 
+  const DEFAULT_PLAN = {
+    text: '',
+    water: 0,
+    water_volume_ml: 0,
+    water_volume_oz: 0,
+    fertilize: 0,
+  }
+
   const generate = async details => {
     if (!enabled) {
       setError('Missing API key')
@@ -26,6 +34,7 @@ export default function useCarePlan() {
     } catch (err) {
       console.error('care plan error', err)
       setError('Failed to generate plan')
+      setPlan(DEFAULT_PLAN)
     } finally {
       setLoading(false)
     }

--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -36,6 +36,8 @@ export default function Onboard() {
       } catch {
         setCarePlan(null)
       }
+    } else if (plan) {
+      setCarePlan(plan)
     } else {
       setCarePlan(null)
     }

--- a/src/pages/__tests__/EditCarePlan.test.jsx
+++ b/src/pages/__tests__/EditCarePlan.test.jsx
@@ -110,3 +110,21 @@ test('shows spinner while loading', async () => {
   resolveFetch()
   await waitFor(() => screen.getByLabelText(/water interval/i))
 })
+
+test('uses fallback plan on failure', async () => {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'bad' }) }))
+  render(
+    <MemoryRouter initialEntries={['/plant/1/edit-care-plan']}>
+      <Routes>
+        <Route path="/plant/:id/edit-care-plan" element={<EditCarePlan />} />
+      </Routes>
+    </MemoryRouter>
+  )
+  fireEvent.click(screen.getByRole('button', { name: /generate care plan/i }))
+  await waitFor(() =>
+    expect(screen.getByLabelText(/water interval/i)).toHaveValue(0)
+  )
+  await waitFor(() =>
+    expect(screen.getByLabelText(/water amount \(mL\)/i)).toHaveValue(0)
+  )
+})

--- a/src/pages/__tests__/Onboard.test.jsx
+++ b/src/pages/__tests__/Onboard.test.jsx
@@ -154,6 +154,22 @@ test('shows error message on failure', async () => {
   expect(screen.getByRole('alert')).toHaveTextContent('Failed to generate plan')
 })
 
+test('uses fallback plan on failure', async () => {
+  global.fetch = jest.fn(() => Promise.resolve({ ok: false, json: () => Promise.resolve({ error: 'bad' }) }))
+  render(
+    <MemoryRouter initialEntries={['/onboard']}>
+      <Routes>
+        <Route path="/onboard" element={<Onboard />} />
+      </Routes>
+    </MemoryRouter>
+  )
+  fireEvent.change(screen.getByLabelText(/plant name/i), { target: { value: 'Aloe' } })
+  fireEvent.change(screen.getByLabelText(/pot diameter/i), { target: { value: '4' } })
+  fireEvent.click(screen.getByRole('button', { name: /generate care plan/i }))
+  await waitFor(() => screen.getByTestId('water-plan'))
+  expect(screen.getByTestId('water-plan')).toHaveTextContent('0 mL / 0 oz every 0 days')
+})
+
 test('shows spinner while loading', async () => {
   let resolveFetch
   global.fetch = jest.fn(


### PR DESCRIPTION
## Summary
- handle failures in `useCarePlan` by returning a default plan
- propagate the fallback plan in `Onboard.jsx`
- test the new fallback behaviour in hook and page tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883f365e75483249a82a623d6d5330f