### PR TITLE
Add care plan history with revert option

### DIFF
--- a/src/pages/EditCarePlan.jsx
+++ b/src/pages/EditCarePlan.jsx
@@ -15,7 +15,7 @@ export default function EditCarePlan() {
   const [waterVolumeMl, setWaterVolumeMl] = useState(plant?.waterPlan?.volume_ml || '')
   const [waterVolumeOz, setWaterVolumeOz] = useState(plant?.waterPlan?.volume_oz || '')
   const [fertilizeInterval, setFertilizeInterval] = useState(plant?.carePlan?.fertilize || '')
-  const { plan, loading, generate } = useCarePlan()
+  const { plan, loading, generate, history, revert, index } = useCarePlan()
 
   useEffect(() => {
     if (!plan) return
@@ -108,6 +108,21 @@ export default function EditCarePlan() {
           </button>
           <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">Save</button>
         </div>
+        {history.length > 1 && (
+          <div className="flex items-center gap-2">
+            <label htmlFor="plan-version" className="font-medium">Version</label>
+            <select
+              id="plan-version"
+              value={index}
+              onChange={e => revert(Number(e.target.value))}
+              className="border rounded p-1"
+            >
+              {history.map((_, i) => (
+                <option key={i} value={i}>v{i + 1}</option>
+              ))}
+            </select>
+          </div>
+        )}
         {loading && <Spinner className="mt-2 text-green-600" />}
       </form>
     </PageContainer>

--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -23,7 +23,7 @@ export default function Onboard() {
     humidity: '',
   })
   const [water, setWater] = useState(null)
-  const { plan, loading, error, generate } = useCarePlan()
+  const { plan, loading, error, generate, history, revert, index } = useCarePlan()
   const [carePlan, setCarePlan] = useState(null)
   const taxa = usePlantTaxon(form.name)
 
@@ -187,6 +187,21 @@ export default function Onboard() {
 
       {loading && <Spinner className="mt-4 text-green-600" />}
       {error && <p role="alert" className="text-red-600 mt-4">{error}</p>}
+      {history.length > 1 && (
+        <div className="mt-4 flex items-center gap-2">
+          <label htmlFor="plan-version" className="font-medium">Version</label>
+          <select
+            id="plan-version"
+            value={index}
+            onChange={e => revert(Number(e.target.value))}
+            className="border rounded p-1"
+          >
+            {history.map((_, i) => (
+              <option key={i} value={i}>v{i + 1}</option>
+            ))}
+          </select>
+        </div>
+      )}
       {plan && water ? (
         <div className="mt-6 space-y-4" data-testid="care-plan">
           <pre className="whitespace-pre-wrap p-4 bg-green-50 rounded">{plan.text}</pre>


### PR DESCRIPTION
## Summary
- extend `useCarePlan` with plan history and `revert` support
- allow selecting previous plans on onboarding and edit pages
- test reverting plan history

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6883fa02b8f8832488b3957a883d49ca