### PR TITLE
Add reset confirmation

### DIFF
--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -30,10 +30,12 @@ export default function Settings() {
   }
 
   const handleReset = () => {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.clear()
+    if (window.confirm('This will clear all data. Continue?')) {
+      if (typeof localStorage !== 'undefined') {
+        localStorage.clear()
+      }
+      window.location.reload()
     }
-    window.location.reload()
   }
 
   const weatherIcon = forecast?.condition

--- a/src/pages/__tests__/Settings.test.jsx
+++ b/src/pages/__tests__/Settings.test.jsx
@@ -1,0 +1,52 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import Settings from '../Settings.jsx'
+
+jest.mock('../../ThemeContext.jsx', () => ({
+  useTheme: () => ({ theme: 'light', toggleTheme: jest.fn() }),
+}))
+
+jest.mock('../../WeatherContext.jsx', () => ({
+  useWeather: () => ({
+    location: 'NYC',
+    setLocation: jest.fn(),
+    units: 'imperial',
+    setUnits: jest.fn(),
+    forecast: null,
+  }),
+}))
+
+jest.mock('../../UserContext.jsx', () => ({
+  useUser: () => ({
+    username: 'Jon',
+    setUsername: jest.fn(),
+    timeZone: 'UTC',
+    setTimeZone: jest.fn(),
+  }),
+}))
+
+jest.mock('../../OpenAIContext.jsx', () => ({
+  useOpenAI: () => ({ enabled: true, setEnabled: jest.fn() }),
+}))
+
+jest.mock('../../hooks/useToast.jsx', () => ({
+  __esModule: true,
+  default: () => ({ Toast: () => null, showToast: jest.fn() }),
+}))
+
+
+test('handleReset clears storage and reloads only when confirmed', () => {
+  const clearSpy = jest.spyOn(Storage.prototype, 'clear')
+  const confirmSpy = jest.spyOn(window, 'confirm')
+
+  confirmSpy.mockReturnValue(false)
+  render(<Settings />)
+  fireEvent.click(screen.getByRole('button', { name: /reset app/i }))
+  expect(clearSpy).not.toHaveBeenCalled()
+
+  confirmSpy.mockReturnValue(true)
+  fireEvent.click(screen.getByRole('button', { name: /reset app/i }))
+  expect(clearSpy).toHaveBeenCalled()
+
+  confirmSpy.mockRestore()
+  clearSpy.mockRestore()
+})


### PR DESCRIPTION
## Summary
- show a confirmation dialog before resetting the app
- clear storage and reload only on user confirmation
- test Settings reset flow

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883fb600dcc8324b5c85aa34c97b762