### PR TITLE
Add title prop to ToggleSwitch and tests

### DIFF
--- a/src/components/ToggleSwitch.jsx
+++ b/src/components/ToggleSwitch.jsx
@@ -1,9 +1,20 @@
 import { useId } from 'react'
 
-export default function ToggleSwitch({ checked = false, onChange, label, className = '', ...props }) {
+export default function ToggleSwitch({
+  checked = false,
+  onChange,
+  label,
+  title,
+  className = '',
+  ...props
+}) {
   const id = useId()
   return (
-    <label htmlFor={id} className={`inline-flex items-center cursor-pointer ${className}`}>
+    <label
+      htmlFor={id}
+      className={`inline-flex items-center cursor-pointer ${className}`}
+      title={title}
+    >
       <input
         id={id}
         type="checkbox"

--- a/src/pages/Settings.jsx
+++ b/src/pages/Settings.jsx
@@ -133,11 +133,13 @@ export default function Settings() {
             <ToggleSwitch
               checked={theme === 'dark'}
               onChange={handleThemeToggle}
+              title="Toggle dark mode"
               label="🌙 Enable Dark Mode for a softer nighttime experience"
             />
             <ToggleSwitch
               checked={enabled}
               onChange={handleOpenAIToggle}
+              title="Toggle AI features"
               label="🤖 Enable AI-powered features"
             />
           </div>

--- a/src/pages/__tests__/Settings.test.jsx
+++ b/src/pages/__tests__/Settings.test.jsx
@@ -50,3 +50,17 @@ test('handleReset clears storage and reloads only when confirmed', () => {
   confirmSpy.mockRestore()
   clearSpy.mockRestore()
 })
+
+test('toggles include descriptive titles', () => {
+  render(<Settings />)
+  expect(
+    screen
+      .getByLabelText(/enable dark mode/i)
+      .closest('label')
+  ).toHaveAttribute('title', 'Toggle dark mode')
+  expect(
+    screen
+      .getByLabelText(/enable ai-powered features/i)
+      .closest('label')
+  ).toHaveAttribute('title', 'Toggle AI features')
+})


### PR DESCRIPTION
## Summary
- allow `ToggleSwitch` to accept a `title` prop and render it on the label
- provide helpful titles for the dark mode and AI feature toggles in Settings page
- test that the new attributes render correctly

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6883fd9eeea083249e3a1608ac979b64