### PR TITLE
Remove unused prisma mock

### DIFF
--- a/api/__tests__/uploadValidation.test.js
+++ b/api/__tests__/uploadValidation.test.js
@@ -20,11 +20,6 @@ jest.mock('cloudinary', () => {
   }
 })
 
-const prisma = {
-  photo: { createMany: jest.fn(), findMany: jest.fn(), delete: jest.fn() },
-  plant: {},
-  careEvent: {},
-}
 
 jest.mock('@prisma/client', () => {
   const prisma = {


### PR DESCRIPTION
## Summary
- clean up unused `const prisma` in upload validation test

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68840b2007e08324a055e3e3e9782738