### PR TITLE
Increase JSON limit in server

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -10,7 +10,7 @@ import { generateCarePlan } from '../lib/carePlan.js'
 const discoverPath = path.join(process.cwd(), 'src', 'discoverablePlants.json')
 const discoverable = JSON.parse(fs.readFileSync(discoverPath))
 const app = express()
-app.use(express.json())
+app.use(express.json({ limit: '50mb' }))
 
 // Configure Cloudinary
 cloudinary.config({


### PR DESCRIPTION
## Summary
- raise Express JSON body limit to 50MB

## Testing
- `npm test` *(fails: 2 test suites, 7 tests)*

------
https://chatgpt.com/codex/tasks/task_e_68843853979c83248b2b035150c658b6