### PR TITLE
Increase server JSON limit

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -10,7 +10,8 @@ import { generateCarePlan } from '../lib/carePlan.js'
 const discoverPath = path.join(process.cwd(), 'src', 'discoverablePlants.json')
 const discoverable = JSON.parse(fs.readFileSync(discoverPath))
 const app = express()
-app.use(express.json({ limit: '50mb' }))
+// Temporarily increase JSON payload limit while the upload feature is in progress
+app.use(express.json({ limit: '100mb' }))
 
 // Configure Cloudinary
 cloudinary.config({


### PR DESCRIPTION
## Summary
- allow larger request bodies in API server by upping the JSON payload limit

## Testing
- `npm test` *(fails: Tasks.test.jsx and Timeline.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_68843c81b5b8832496bfe468c82f8555