### PR TITLE
Fix coach route error handling

### DIFF
--- a/api/__tests__/coachRoute.test.js
+++ b/api/__tests__/coachRoute.test.js
@@ -1,0 +1,51 @@
+/** @jest-environment node */
+import request from 'supertest'
+let app
+
+process.env.OPENAI_API_KEY = 'test-key'
+
+jest.mock('cloudinary', () => ({
+  v2: { config: jest.fn(), uploader: { upload_stream: jest.fn() } },
+}))
+
+jest.mock('@prisma/client', () => ({
+  PrismaClient: jest.fn(() => ({})),
+}))
+
+afterEach(() => {
+  global.fetch = undefined
+})
+
+beforeAll(async () => {
+  ;({ default: app } = await import('../server.js'))
+})
+
+test('returns answer from OpenAI', async () => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ choices: [{ message: { content: 'hi' } }] }),
+    }),
+  )
+  const res = await request(app)
+    .post('/api/coach')
+    .send({ question: 'How water?', plantType: 'Rose' })
+  expect(res.status).toBe(200)
+  expect(res.body.answer).toBe('hi')
+})
+
+test('validates missing question', async () => {
+  const res = await request(app)
+    .post('/api/coach')
+    .send({ plantType: 'Rose' })
+  expect(res.status).toBe(400)
+})
+
+test('handles OpenAI failure', async () => {
+  global.fetch = jest.fn(() => Promise.reject(new Error('fail')))
+  const res = await request(app)
+    .post('/api/coach')
+    .send({ question: 'hi', plantType: 'Rose' })
+  expect(res.status).toBe(502)
+  expect(res.body.error).toMatch(/Failed/)
+})

--- a/api/server.js
+++ b/api/server.js
@@ -26,6 +26,11 @@ const upload = multer({ storage: multer.memoryStorage() })
 app.post('/api/coach', async (req, res) => {
   const { question, plantType, lastWatered, weather } = req.body || {}
   const apiKey = process.env.VITE_OPENAI_API_KEY || process.env.OPENAI_API_KEY
+
+  if (!question) {
+    res.status(400).json({ error: 'Missing question' })
+    return
+  }
   if (!apiKey) {
     res.status(400).json({ error: 'Missing OpenAI API key' })
     return
@@ -54,7 +59,7 @@ app.post('/api/coach', async (req, res) => {
     res.json({ answer })
   } catch (err) {
     console.error('OpenAI error', err)
-    res.status(500).json({ error: 'Failed to fetch coach answer' })
+    res.status(502).json({ error: 'Failed to fetch coach answer' })
   }
 })
 


### PR DESCRIPTION
## Summary
- validate questions on `/api/coach`
- return 502 when the OpenAI call fails
- add tests for the coach route

## Testing
- `npm run lint`
- `npm test` *(fails: Tasks.test.jsx, Timeline.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_688441b571808324873a2b9f0bbab119