### PR TITLE
Add plantId indexes

### DIFF
--- a/prisma/migrations/20250726043711_add_plantid_indexes/migration.sql
+++ b/prisma/migrations/20250726043711_add_plantid_indexes/migration.sql
@@ -1,0 +1,6 @@
+-- CreateIndex
+CREATE INDEX `Photo_plantId_idx` ON `Photo`(`plantId`);
+
+-- CreateIndex
+CREATE INDEX `CareEvent_plantId_idx` ON `CareEvent`(`plantId`);
+

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -27,6 +27,7 @@ model Photo {
   uploaded  DateTime @default(now())
   plant     Plant    @relation(fields: [plantId], references: [id])
   plantId   Int
+  @@index([plantId])
 }
 
 model CareEvent {
@@ -35,6 +36,7 @@ model CareEvent {
   date     DateTime
   plant    Plant    @relation(fields: [plantId], references: [id])
   plantId  Int
+  @@index([plantId])
 }
 
 enum CareEventType {


### PR DESCRIPTION
## Summary
- add plantId indexes to Photo and CareEvent models
- include migration for the new indexes

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68845af1ef988324bf908989a146f051