### PR TITLE
Add Room & User models

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -23,6 +23,8 @@ const plantSchema = z.object({
   name: z.string(),
   species: z.string().optional(),
   imageUrl: z.string().url().optional(),
+  roomId: z.number().int().optional(),
+  ownerId: z.number().int().optional(),
 })
 const plantUpdateSchema = plantSchema.partial()
 
@@ -223,7 +225,7 @@ app.get('/api/plants', async (req, res) => {
   try {
     const plants = await prisma.plant.findMany({
       where: { deletedAt: null },
-      include: { photos: true, careEvents: true },
+      include: { photos: true, careEvents: true, room: true, owner: true },
       orderBy: { id: 'asc' },
     })
     res.json(plants)

--- a/prisma/migrations/20250726070000_add_rooms_and_users/migration.sql
+++ b/prisma/migrations/20250726070000_add_rooms_and_users/migration.sql
@@ -1,0 +1,32 @@
+-- CreateTable
+CREATE TABLE `Room` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `name` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- CreateTable
+CREATE TABLE `User` (
+    `id` INTEGER NOT NULL AUTO_INCREMENT,
+    `email` VARCHAR(191) NOT NULL,
+
+    PRIMARY KEY (`id`),
+    UNIQUE INDEX `User_email_key`(`email`)
+) DEFAULT CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci;
+
+-- AlterTable
+ALTER TABLE `Plant` ADD COLUMN `roomId` INTEGER NULL,
+    ADD COLUMN `ownerId` INTEGER NULL;
+
+-- CreateIndex
+CREATE INDEX `Plant_roomId_idx` ON `Plant`(`roomId`);
+
+-- CreateIndex
+CREATE INDEX `Plant_ownerId_idx` ON `Plant`(`ownerId`);
+
+-- AddForeignKey
+ALTER TABLE `Plant` ADD CONSTRAINT `Plant_roomId_fkey` FOREIGN KEY (`roomId`) REFERENCES `Room`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE `Plant` ADD CONSTRAINT `Plant_ownerId_fkey` FOREIGN KEY (`ownerId`) REFERENCES `User`(`id`) ON DELETE SET NULL ON UPDATE CASCADE;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -17,8 +17,24 @@ model Plant {
   updatedAt  DateTime    @updatedAt
   deletedAt  DateTime?
   imageUrl    String?
+  roomId     Int?
+  ownerId    Int?
+  room       Room?       @relation(fields: [roomId], references: [id])
+  owner      User?       @relation(fields: [ownerId], references: [id])
   photos     Photo[]
   careEvents CareEvent[]
+}
+
+model Room {
+  id     Int     @id @default(autoincrement())
+  name   String
+  plants Plant[]
+}
+
+model User {
+  id     Int     @id @default(autoincrement())
+  email  String  @unique
+  plants Plant[]
 }
 
 model Photo {

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -3,12 +3,16 @@ import { PrismaClient, CareEventType } from '@prisma/client'
 const prisma = new PrismaClient()
 
 async function main() {
+  const user = await prisma.user.create({ data: { email: 'user@example.com' } })
+  const room = await prisma.room.create({ data: { name: 'Living Room' } })
   const snake = await prisma.plant.create({
     data: {
       name: 'Snake Plant',
       species: 'Sansevieria trifasciata',
       imageUrl: 'https://source.unsplash.com/featured/?snake%20plant',
       createdAt: new Date(),
+      ownerId: user.id,
+      roomId: room.id,
     },
   })
   const pothos = await prisma.plant.create({
@@ -17,6 +21,8 @@ async function main() {
       species: 'Epipremnum aureum',
       imageUrl: 'https://source.unsplash.com/featured/?pothos',
       createdAt: new Date(),
+      ownerId: user.id,
+      roomId: room.id,
     },
   })
 


### PR DESCRIPTION
## Summary
- define `Room` and `User` models in `schema.prisma`
- link plants to rooms and users via new `roomId` and `ownerId` fields
- expose the new relations in API plant list
- seed DB with example room and user
- create migration for new tables and relations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68845c6937bc8324b5da55a3ae67c8ec