### PR TITLE
Handle missing plant updates

### DIFF
--- a/api/__tests__/plantsRoutes.test.js
+++ b/api/__tests__/plantsRoutes.test.js
@@ -130,6 +130,12 @@ test('update plant validation', async () => {
   expect(res.status).toBe(400)
 })
 
+test('update missing plant', async () => {
+  const res = await request(app).put('/api/plants/999').send({ name: 'Ghost' })
+  expect(res.status).toBe(404)
+  expect(res.body.error).toMatch(/not found/i)
+})
+
 test('delete plant', async () => {
   const plant = await prisma.plant.create({ data: { name: 'Del' } })
   const res = await request(app).delete(`/api/plants/${plant.id}`)

--- a/api/server.js
+++ b/api/server.js
@@ -261,8 +261,15 @@ app.put('/api/plants/:id', async (req, res) => {
     const plant = await prisma.plant.update({ where: { id }, data: parsed.data })
     res.json(plant)
   } catch (err) {
-    console.error('DB error', err)
-    res.status(400).json({ error: 'Failed to update plant' })
+    if (
+      err instanceof Prisma.PrismaClientKnownRequestError &&
+      err.code === 'P2025'
+    ) {
+      res.status(404).json({ error: 'Plant not found' })
+    } else {
+      console.error('DB error', err)
+      res.status(400).json({ error: 'Failed to update plant' })
+    }
   }
 })
 


### PR DESCRIPTION
## Summary
- handle P2025 errors in PUT /api/plants/:id
- test updating a missing plant returns 404

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6884c7eb948483248fc1873d5bd2749e