### PR TITLE
Add wishlist feature

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -14,6 +14,7 @@ import Gallery from './pages/Gallery.jsx'
 import Coach from './pages/Coach.jsx'
 import Onboard from './pages/Onboard.jsx'
 import EditCarePlan from './pages/EditCarePlan.jsx'
+import Wishlist from './pages/Wishlist.jsx'
 
 import PersistentBottomNav from './components/PersistentBottomNav.jsx'
 
@@ -56,6 +57,7 @@ export default function App() {
             <Route path="/room/:roomName/plant/:id" element={<PageTransition><PlantDetail /></PageTransition>} />
             <Route path="/timeline" element={<Timeline />} />
             <Route path="/gallery" element={<Gallery />} />
+            <Route path="/wishlist" element={<Wishlist />} />
             <Route path="/profile" element={<Settings />} />
             <Route path="/plant/:id" element={<PageTransition><PlantDetail /></PageTransition>} />
             <Route path="/plant/:id/coach" element={<PageTransition><Coach /></PageTransition>} />

--- a/src/MenuContext.jsx
+++ b/src/MenuContext.jsx
@@ -4,6 +4,7 @@ import {
   Flower,
   CalendarBlank,
   UserCircle,
+  Heart,
   List,
 } from 'phosphor-react'
 
@@ -14,6 +15,7 @@ export const defaultMenu = {
     { to: '/', label: 'Today', Icon: House },
     { to: '/myplants', label: 'All Plants', Icon: Flower },
     { to: '/timeline', label: 'Timeline', Icon: CalendarBlank },
+    { to: '/wishlist', label: 'Wishlist', Icon: Heart },
     { to: '/profile', label: 'Profile', Icon: UserCircle },
   ],
   Icon: List,

--- a/src/WishlistContext.jsx
+++ b/src/WishlistContext.jsx
@@ -1,0 +1,42 @@
+import { createContext, useContext, useEffect, useState } from 'react'
+
+const WishlistContext = createContext()
+
+export function WishlistProvider({ children }) {
+  const [wishlist, setWishlist] = useState(() => {
+    if (typeof localStorage !== 'undefined') {
+      const stored = localStorage.getItem('wishlist')
+      if (stored) {
+        try {
+          return JSON.parse(stored)
+        } catch {}
+      }
+    }
+    return []
+  })
+
+  useEffect(() => {
+    if (typeof localStorage !== 'undefined') {
+      localStorage.setItem('wishlist', JSON.stringify(wishlist))
+    }
+  }, [wishlist])
+
+  const addToWishlist = plant => {
+    setWishlist(prev => {
+      if (prev.find(p => p.id === plant.id)) return prev
+      return [...prev, plant]
+    })
+  }
+
+  const removeFromWishlist = id => {
+    setWishlist(prev => prev.filter(p => p.id !== id))
+  }
+
+  return (
+    <WishlistContext.Provider value={{ wishlist, addToWishlist, removeFromWishlist }}>
+      {children}
+    </WishlistContext.Provider>
+  )
+}
+
+export const useWishlist = () => useContext(WishlistContext)

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -9,6 +9,7 @@ import { WeatherProvider } from './WeatherContext.jsx'
 import { UserProvider } from './UserContext.jsx'
 import { OpenAIProvider } from './OpenAIContext.jsx'
 import SnackbarProvider, { Snackbar } from './hooks/SnackbarProvider.jsx'
+import { WishlistProvider } from './WishlistContext.jsx'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
@@ -20,12 +21,14 @@ ReactDOM.createRoot(document.getElementById('root')).render(
             <WeatherProvider>
               <PlantProvider>
                 <RoomProvider>
-                  <BrowserRouter
-                    basename={import.meta.env.VITE_BASE_PATH}
-                    future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
-                  >
-                    <App />
-                  </BrowserRouter>
+                  <WishlistProvider>
+                    <BrowserRouter
+                      basename={import.meta.env.VITE_BASE_PATH}
+                      future={{ v7_startTransition: true, v7_relativeSplatPath: true }}
+                    >
+                      <App />
+                    </BrowserRouter>
+                  </WishlistProvider>
                 </RoomProvider>
               </PlantProvider>
               <Snackbar />

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -26,6 +26,8 @@ import Card from '../components/Card.jsx'
 import SwipeTip from '../components/SwipeTip.jsx'
 import useHappyPlant from '../hooks/useHappyPlant.js'
 import useDiscoverablePlant from '../hooks/useDiscoverablePlant.js'
+import { useWishlist } from '../WishlistContext.jsx'
+import useSnackbar from '../hooks/useSnackbar.jsx'
 
 
 
@@ -41,6 +43,8 @@ export default function Home() {
   })
   const happyPlant = useHappyPlant()
   const { plant: discoverPlant } = useDiscoverablePlant()
+  const { addToWishlist } = useWishlist()
+  const { showSnackbar } = useSnackbar()
 
 
   const weatherCtx = useWeather()
@@ -209,6 +213,11 @@ export default function Home() {
     scrollToTasks()
   }
 
+  const handleAddToWishlist = plant => {
+    addToWishlist(plant)
+    showSnackbar(`${plant.name} added to Wishlist`)
+  }
+
 
 
   return (
@@ -252,7 +261,7 @@ export default function Home() {
     {discoverPlant && (
       <section className="mb-4 space-y-2" data-testid="discovery-section">
         <h2 className="sr-only">Discover a New Plant</h2>
-        <DiscoveryCard plant={discoverPlant} />
+        <DiscoveryCard plant={discoverPlant} onAdd={handleAddToWishlist} />
       </section>
     )}
     <CareStats

--- a/src/pages/Wishlist.jsx
+++ b/src/pages/Wishlist.jsx
@@ -1,0 +1,53 @@
+import { Link } from 'react-router-dom'
+import BalconyPlantCard from '../components/BalconyPlantCard.jsx'
+import PageContainer from '../components/PageContainer.jsx'
+import PageHeader from '../components/PageHeader.jsx'
+import { createRipple } from '../utils/interactions.js'
+import { useWishlist } from '../WishlistContext.jsx'
+import useSnackbar from '../hooks/useSnackbar.jsx'
+
+export default function Wishlist() {
+  const { wishlist, removeFromWishlist } = useWishlist()
+  const { showSnackbar } = useSnackbar()
+
+  const handleRemove = plant => {
+    removeFromWishlist(plant.id)
+    showSnackbar(`${plant.name} removed`, null)
+  }
+
+  if (wishlist.length === 0) {
+    return (
+      <PageContainer>
+        <PageHeader title="Wishlist" />
+        <p>No plants in wishlist.</p>
+      </PageContainer>
+    )
+  }
+
+  return (
+    <PageContainer>
+      <PageHeader title="Wishlist" />
+      <div className="space-y-8 pb-24">
+        {wishlist.map(plant => (
+          <div key={plant.id} className="relative">
+            <Link
+              to={plant.room ? `/room/${encodeURIComponent(plant.room)}/plant/${plant.id}` : `/plant/${plant.id}`}
+              className="block"
+              onMouseDown={createRipple}
+              onTouchStart={createRipple}
+            >
+              <BalconyPlantCard plant={plant} />
+            </Link>
+            <button
+              type="button"
+              onClick={() => handleRemove(plant)}
+              className="absolute top-2 right-2 bg-red-600 text-white text-xs px-2 py-1 rounded"
+            >
+              Remove
+            </button>
+          </div>
+        ))}
+      </div>
+    </PageContainer>
+  )
+}

--- a/src/pages/__tests__/Add.test.jsx
+++ b/src/pages/__tests__/Add.test.jsx
@@ -15,6 +15,10 @@ jest.mock('../../UserContext.jsx', () => ({
   useUser: () => ({ username: 'Jon', timeZone: 'UTC' }),
 }))
 
+jest.mock('../../WishlistContext.jsx', () => ({
+  useWishlist: () => ({ addToWishlist: jest.fn() })
+}))
+
 function renderWithSnackbar(ui) {
   return render(
     <OpenAIProvider>

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -26,6 +26,10 @@ jest.mock('../../hooks/useDiscoverablePlant.js', () => ({
   default: () => ({ plant: discoverPlant })
 }))
 
+jest.mock('../../WishlistContext.jsx', () => ({
+  useWishlist: () => ({ addToWishlist: jest.fn() })
+}))
+
 function renderWithSnackbar(ui) {
   return render(
     <OpenAIProvider>

--- a/src/pages/__tests__/Wishlist.test.jsx
+++ b/src/pages/__tests__/Wishlist.test.jsx
@@ -1,0 +1,31 @@
+import { render, screen } from '@testing-library/react'
+import { MemoryRouter } from 'react-router-dom'
+import { WishlistProvider } from '../../WishlistContext.jsx'
+import Wishlist from '../Wishlist.jsx'
+
+jest.mock('../../hooks/useSnackbar.jsx', () => ({
+  __esModule: true,
+  default: () => ({ showSnackbar: jest.fn() })
+}))
+
+function renderWithProvider(ui, wishlist = []) {
+  return render(
+    <WishlistProvider>
+      <MemoryRouter>{ui}</MemoryRouter>
+    </WishlistProvider>
+  )
+}
+
+test('shows message when wishlist empty', () => {
+  renderWithProvider(<Wishlist />)
+  expect(screen.getByText(/no plants in wishlist/i)).toBeInTheDocument()
+})
+
+const plant = { id: 1, name: 'Test', image: 't.jpg' }
+
+test('displays plants in wishlist', () => {
+  localStorage.setItem('wishlist', JSON.stringify([plant]))
+  renderWithProvider(<Wishlist />)
+  expect(screen.getByText('Test')).toBeInTheDocument()
+  localStorage.clear()
+})


### PR DESCRIPTION
## Summary
- create `WishlistContext` for saved plants
- add a `Wishlist` page with remove buttons
- show wishlist tab in bottom navigation
- hook up discovery card button to add wishlist entries
- wrap app with `WishlistProvider`
- test wishlist behavior and update other tests

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68856a9c5ca083249e8ef5583a36b861