### PR TITLE
Improve discovery card images

### DIFF
--- a/src/components/DiscoveryCard.jsx
+++ b/src/components/DiscoveryCard.jsx
@@ -1,10 +1,15 @@
 import Badge from './Badge.jsx'
 import { Sun, Leaf } from 'phosphor-react'
 import { createRipple } from '../utils/interactions.js'
+import usePlaceholderPhoto from '../hooks/usePlaceholderPhoto.js'
 
 export default function DiscoveryCard({ plant, onAdd }) {
   if (!plant) return null
-  const src = plant.image || plant.placeholderSrc
+  const placeholder = usePlaceholderPhoto(plant.name)
+  const src =
+    plant.image && !plant.image.includes('placeholder.svg')
+      ? plant.image
+      : placeholder?.src || plant.placeholderSrc
   return (
     <div className="relative h-64 rounded-3xl overflow-hidden shadow">
       <img


### PR DESCRIPTION
## Summary
- use the `usePlaceholderPhoto` hook in `DiscoveryCard`
- load images from Unsplash if a plant lacks an image

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68856b59c0e08324b636d5ef076840d5