### PR TITLE
Add Wikipedia fallback for placeholder photos

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Lisa is a **mobile-first** plant care app with weather-driven reminders, an AI C
 - Today, All Plants and Timeline views
 - Add/edit/delete plants
 - Photo gallery & tasks per plant
+- Placeholder images fall back to Wikipedia if Unsplash is unavailable
 
 <details>
 <summary>Advanced</summary>

--- a/setupTests.js
+++ b/setupTests.js
@@ -2,6 +2,7 @@ import '@testing-library/jest-dom';
 
 // Suppress React Router future flag warnings during tests
 const originalWarn = console.warn;
+const nativeFetch = global.fetch;
 beforeAll(() => {
   jest.spyOn(console, 'warn').mockImplementation((...args) => {
     if (
@@ -12,8 +13,26 @@ beforeAll(() => {
     }
     originalWarn.call(console, ...args);
   });
+  if (!global.fetch) {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+  }
+});
+
+beforeEach(() => {
+  if (!global.fetch) {
+    global.fetch = jest.fn(() =>
+      Promise.resolve({ ok: true, json: () => Promise.resolve({}) })
+    );
+  }
 });
 
 afterAll(() => {
   console.warn.mockRestore();
+  if (nativeFetch) {
+    global.fetch = nativeFetch;
+  } else {
+    delete global.fetch;
+  }
 });

--- a/src/components/DiscoveryCard.jsx
+++ b/src/components/DiscoveryCard.jsx
@@ -9,7 +9,7 @@ export default function DiscoveryCard({ plant, onAdd }) {
   const src =
     plant.image && !plant.image.includes('placeholder.svg')
       ? plant.image
-      : placeholder?.src || plant.placeholderSrc
+      : placeholder?.src
   return (
     <div className="relative h-64 rounded-3xl overflow-hidden shadow">
       <img

--- a/src/hooks/__tests__/usePlaceholderPhoto.test.js
+++ b/src/hooks/__tests__/usePlaceholderPhoto.test.js
@@ -1,6 +1,8 @@
 import { render, screen } from '@testing-library/react'
 import usePlaceholderPhoto from '../usePlaceholderPhoto.js'
 
+const originalFetch = global.fetch
+
 function Test({ name }) {
   const photo = usePlaceholderPhoto(name)
   return <div>{photo ? photo.src : 'loading'}</div>
@@ -8,6 +10,7 @@ function Test({ name }) {
 
 afterEach(() => {
   localStorage.clear()
+  global.fetch = originalFetch
 })
 
 test('reads cached photo from localStorage', () => {
@@ -17,10 +20,27 @@ test('reads cached photo from localStorage', () => {
   expect(screen.getByText('cached.jpg')).toBeInTheDocument()
 })
 
-test('uses Unsplash when not cached', () => {
+test('uses Unsplash when not cached', async () => {
   render(<Test name="aloe" />)
-  const text = screen.getByText(/source\.unsplash\.com\/featured\/\?aloe/)
+  const text = await screen.findByText(/source\.unsplash\.com\/featured\/\?aloe/)
   expect(text).toBeInTheDocument()
   const stored = JSON.parse(localStorage.getItem('placeholder_aloe'))
   expect(stored.src).toMatch(/source\.unsplash\.com/)
+})
+
+test('falls back to Wikipedia on Unsplash failure', async () => {
+  global.fetch = jest.fn(url => {
+    if (url.includes('unsplash')) {
+      return Promise.reject(new Error('fail'))
+    }
+    return Promise.resolve({
+      ok: true,
+      json: () => Promise.resolve({ thumbnail: { source: 'wiki.jpg' } }),
+    })
+  })
+  render(<Test name="rose" />)
+  expect(await screen.findByText('wiki.jpg')).toBeInTheDocument()
+  const stored = JSON.parse(localStorage.getItem('placeholder_rose'))
+  expect(stored.src).toBe('wiki.jpg')
+  expect(stored.attribution).toBe('Photo from Wikipedia')
 })


### PR DESCRIPTION
## Summary
- improve `usePlaceholderPhoto` with Wikipedia fallback and attribution caching
- update DiscoveryCard to rely solely on hook
- ensure fetch is available during tests
- expand hook tests for Wikipedia fallback
- document new behaviour in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885723112e08324943f894fa58bd089