### PR TITLE
Improve wishlist UX

### DIFF
--- a/src/__tests__/FabVisibility.test.jsx
+++ b/src/__tests__/FabVisibility.test.jsx
@@ -25,6 +25,10 @@ jest.mock('../RoomContext.jsx', () => ({
   useRooms: () => ({ rooms: [] }),
 }))
 
+jest.mock('../WishlistContext.jsx', () => ({
+  useWishlist: () => ({ wishlist: [] })
+}))
+
 describe('floating action button visibility', () => {
   test('shows fab on All Plants page', () => {
     render(

--- a/src/components/DiscoveryCard.jsx
+++ b/src/components/DiscoveryCard.jsx
@@ -2,9 +2,13 @@ import Badge from './Badge.jsx'
 import { Sun, Leaf } from 'phosphor-react'
 import { createRipple } from '../utils/interactions.js'
 import usePlaceholderPhoto from '../hooks/usePlaceholderPhoto.js'
+import { useWishlist } from '../WishlistContext.jsx'
+import clsx from 'clsx'
 
 export default function DiscoveryCard({ plant, onAdd }) {
   if (!plant) return null
+  const { wishlist } = useWishlist()
+  const inWishlist = wishlist.some(p => p.id === plant.id)
   const placeholder = usePlaceholderPhoto(plant.name)
   const src =
     plant.image && !plant.image.includes('placeholder.svg')
@@ -53,12 +57,18 @@ export default function DiscoveryCard({ plant, onAdd }) {
           </div>
           <button
             type="button"
+            disabled={inWishlist}
             onMouseDown={createRipple}
             onTouchStart={createRipple}
             onClick={() => onAdd?.(plant)}
-            className="mt-2 bg-blue-600 text-white px-3 py-1 rounded relative overflow-hidden"
+            className={clsx(
+              'mt-2 px-3 py-1 rounded relative overflow-hidden',
+              inWishlist
+                ? 'bg-gray-300 text-gray-700 cursor-default'
+                : 'bg-blue-600 text-white hover:bg-blue-700'
+            )}
           >
-            Add to Wishlist
+            {inWishlist ? '✓ In Wishlist' : 'Add to Wishlist'}
           </button>
         </div>
       </div>

--- a/src/components/PersistentBottomNav.jsx
+++ b/src/components/PersistentBottomNav.jsx
@@ -2,10 +2,12 @@ import { useState, useEffect } from 'react'
 import { NavLink } from 'react-router-dom'
 import { useMenu } from '../MenuContext.jsx'
 import useOverdueCount from '../hooks/useOverdueCount.js'
+import { useWishlist } from '../WishlistContext.jsx'
 
 export default function PersistentBottomNav() {
   const [open, setOpen] = useState(false)
   const overdueCount = useOverdueCount()
+  const { wishlist } = useWishlist()
   const { menu } = useMenu()
 
   const { items, Icon } = menu
@@ -27,7 +29,8 @@ export default function PersistentBottomNav() {
     <nav className="fixed bottom-0 inset-x-0 bg-white dark:bg-gray-700 border-t border-gray-200 dark:border-gray-600 pb-safe z-20">
       <ul className="flex justify-around items-center py-2 text-xs">
         {mainLinks.map(({ to, label, Icon: LinkIcon }) => {
-          const showBadge = label === 'All Plants' && overdueCount > 0
+          const overdueBadge = label === 'All Plants' && overdueCount > 0
+          const wishlistBadge = label === 'Wishlist' && wishlist.length > 0
           return (
             <li key={to ?? label} className="relative">
               <NavLink
@@ -39,9 +42,9 @@ export default function PersistentBottomNav() {
                 }
               >
                 <LinkIcon className="w-6 h-6" aria-hidden="true" />
-                {showBadge && (
+                {(overdueBadge || wishlistBadge) && (
                   <span className="absolute -top-1 -right-2 bg-red-600 text-white text-badge rounded-full px-1">
-                    {overdueCount}
+                    {overdueBadge ? overdueCount : wishlist.length}
                   </span>
                 )}
               </NavLink>

--- a/src/components/__tests__/DiscoveryCard.test.jsx
+++ b/src/components/__tests__/DiscoveryCard.test.jsx
@@ -1,5 +1,6 @@
 import { render, screen, fireEvent } from '@testing-library/react'
 import DiscoveryCard from '../DiscoveryCard.jsx'
+import { WishlistProvider } from '../../WishlistContext.jsx'
 
 const plant = {
   id: 1,
@@ -12,14 +13,34 @@ const plant = {
 }
 
 test('renders plant info and button', () => {
-  render(<DiscoveryCard plant={plant} />)
+  render(
+    <WishlistProvider>
+      <DiscoveryCard plant={plant} />
+    </WishlistProvider>
+  )
   expect(screen.getByText('Test Plant')).toBeInTheDocument()
   expect(screen.getByText(/Add to Wishlist/i)).toBeInTheDocument()
 })
 
 test('calls callback when adding', () => {
   const onAdd = jest.fn()
-  render(<DiscoveryCard plant={plant} onAdd={onAdd} />)
+  render(
+    <WishlistProvider>
+      <DiscoveryCard plant={plant} onAdd={onAdd} />
+    </WishlistProvider>
+  )
   fireEvent.click(screen.getByText(/Add to Wishlist/i))
   expect(onAdd).toHaveBeenCalledWith(plant)
+})
+
+test('shows disabled state when already in wishlist', () => {
+  localStorage.setItem('wishlist', JSON.stringify([plant]))
+  render(
+    <WishlistProvider>
+      <DiscoveryCard plant={plant} />
+    </WishlistProvider>
+  )
+  const button = screen.getByText(/in wishlist/i)
+  expect(button).toBeDisabled()
+  localStorage.clear()
 })

--- a/src/components/__tests__/PersistentBottomNav.test.jsx
+++ b/src/components/__tests__/PersistentBottomNav.test.jsx
@@ -6,8 +6,10 @@ import { Gear } from 'phosphor-react'
 import PersistentBottomNav from '../PersistentBottomNav.jsx'
 import { MenuProvider, defaultMenu, useMenu } from '../../MenuContext.jsx'
 import useOverdueCount from '../../hooks/useOverdueCount.js'
+import { useWishlist } from '../../WishlistContext.jsx'
 
 jest.mock('../../hooks/useOverdueCount.js')
+jest.mock('../../WishlistContext.jsx')
 
 const customMenu = {
   ...defaultMenu,
@@ -36,6 +38,7 @@ function MenuSetter({ children }) {
 
 test('renders main navigation links', () => {
   useOverdueCount.mockReturnValue(0)
+  useWishlist.mockReturnValue({ wishlist: [] })
   const { container } = render(
     <MemoryRouter>
       <CustomMenuProvider>
@@ -52,6 +55,7 @@ test('renders main navigation links', () => {
 
 test('shows overdue badge when tasks pending', () => {
   useOverdueCount.mockReturnValue(3)
+  useWishlist.mockReturnValue({ wishlist: [] })
   render(
     <MemoryRouter>
       <CustomMenuProvider>
@@ -64,6 +68,7 @@ test('shows overdue badge when tasks pending', () => {
 
 test('profile link replaces more button when additional links exist', () => {
   useOverdueCount.mockReturnValue(0)
+  useWishlist.mockReturnValue({ wishlist: [] })
   const { container } = render(
     <MemoryRouter>
       <CustomMenuProvider>
@@ -83,4 +88,18 @@ test('profile link replaces more button when additional links exist', () => {
   fireEvent.click(screen.getByRole('button', { name: /close menu/i }))
 
   expect(screen.queryByRole('dialog', { name: /navigation menu/i })).toBeNull()
+})
+
+test('shows wishlist count badge', () => {
+  useOverdueCount.mockReturnValue(0)
+  useWishlist.mockReturnValue({ wishlist: [{ id: 1 }] })
+  const { container } = render(
+    <MemoryRouter>
+      <CustomMenuProvider>
+        <PersistentBottomNav />
+      </CustomMenuProvider>
+    </MemoryRouter>
+  )
+  const link = container.querySelector('a[href="/wishlist"]')
+  expect(link.querySelector('span').textContent).toBe('1')
 })

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -43,7 +43,7 @@ export default function Home() {
   })
   const happyPlant = useHappyPlant()
   const { plant: discoverPlant } = useDiscoverablePlant()
-  const { addToWishlist } = useWishlist()
+  const { addToWishlist, removeFromWishlist } = useWishlist()
   const { showSnackbar } = useSnackbar()
 
 
@@ -215,7 +215,10 @@ export default function Home() {
 
   const handleAddToWishlist = plant => {
     addToWishlist(plant)
-    showSnackbar(`${plant.name} added to Wishlist`)
+    showSnackbar(
+      `${plant.name} added to Wishlist`,
+      () => removeFromWishlist(plant.id)
+    )
   }
 
 

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -27,7 +27,11 @@ jest.mock('../../hooks/useDiscoverablePlant.js', () => ({
 }))
 
 jest.mock('../../WishlistContext.jsx', () => ({
-  useWishlist: () => ({ addToWishlist: jest.fn() })
+  useWishlist: () => ({
+    addToWishlist: jest.fn(),
+    removeFromWishlist: jest.fn(),
+    wishlist: []
+  })
 }))
 
 function renderWithSnackbar(ui) {

--- a/src/pages/__tests__/ProfileRoute.test.jsx
+++ b/src/pages/__tests__/ProfileRoute.test.jsx
@@ -20,6 +20,10 @@ jest.mock('../../ThemeContext.jsx', () => ({
   useTheme: () => ({ theme: 'light', toggleTheme: () => {} }),
 }))
 
+jest.mock('../../WishlistContext.jsx', () => ({
+  useWishlist: () => ({ wishlist: [] })
+}))
+
 test('navigating to /profile renders the Settings page', () => {
   render(
     <OpenAIProvider>

--- a/src/pages/__tests__/TimelineRoute.test.jsx
+++ b/src/pages/__tests__/TimelineRoute.test.jsx
@@ -8,6 +8,10 @@ jest.mock('../../PlantContext.jsx', () => ({
   addBase: (u) => u,
 }))
 
+jest.mock('../../WishlistContext.jsx', () => ({
+  useWishlist: () => ({ wishlist: [] })
+}))
+
 test('navigating to /timeline renders the Timeline page', () => {
   render(
     <OpenAIProvider>


### PR DESCRIPTION
## Summary
- disable the wishlist button once added and show "✓ In Wishlist"
- add undo action when adding plants to wishlist
- display wishlist badge in the bottom nav
- adjust unit tests for new wishlist behavior

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68857269abf483249bd87457edbcaa8c