### PR TITLE
Enhance wishlist navigation

### DIFF
--- a/src/components/BalconyPlantCard.jsx
+++ b/src/components/BalconyPlantCard.jsx
@@ -1,17 +1,23 @@
 import Badge from './Badge.jsx'
 import { Sun, Leaf } from 'phosphor-react'
 import { formatDaysAgo } from '../utils/dateFormat.js'
+import { daysUntil as calcDaysUntil } from '../utils/date.js'
 
 export default function BalconyPlantCard({ plant }) {
   const today = new Date()
-  const daysUntil = plant.nextWater
-    ? Math.ceil((new Date(plant.nextWater) - today) / 86400000)
-    : null
+  const daysUntil = plant.nextWater ? calcDaysUntil(plant.nextWater, today) : null
   const overdue = daysUntil != null && daysUntil <= 0
   const src =
     typeof plant.image === 'string' && plant.image.trim() !== ''
       ? plant.image
       : plant.placeholderSrc
+
+  let waterText = null
+  if (daysUntil != null) {
+    if (daysUntil <= 0) waterText = 'Needs water today'
+    else if (daysUntil === 1) waterText = 'Needs water tomorrow'
+    else waterText = `Needs water in ${daysUntil} days`
+  }
 
   return (
     <div className="relative h-64 rounded-3xl overflow-hidden shadow">
@@ -41,6 +47,7 @@ export default function BalconyPlantCard({ plant }) {
           <p className="text-sm italic leading-none">{plant.scientificName}</p>
         )}
         <p className="text-sm text-left">Last watered {formatDaysAgo(plant.lastWatered)}</p>
+        {waterText && <p className="text-sm text-left">{waterText}</p>}
         {plant.lastFertilized && (
           <p className="text-sm text-left">
             Last fertilized {formatDaysAgo(plant.lastFertilized)}

--- a/src/components/__tests__/BalconyPlantCard.test.jsx
+++ b/src/components/__tests__/BalconyPlantCard.test.jsx
@@ -14,5 +14,6 @@ test('shows last fertilized info', () => {
   }
   render(<BalconyPlantCard plant={plant} />)
   expect(screen.getByText(/last fertilized 5 days ago/i)).toBeInTheDocument()
+  expect(screen.getByText(/needs water in 5 days/i)).toBeInTheDocument()
   jest.useRealTimers()
 })

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -775,6 +775,17 @@ export default function PlantDetail() {
                   {plant.scientificName}
                 </p>
               )}
+              {plant.scientificName && (
+                <a
+                  href={`https://en.wikipedia.org/wiki/${encodeURIComponent(plant.scientificName)}`}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-xs text-blue-300 hover:underline animate-fade-in-down"
+                  style={{ animationDelay: '80ms' }}
+                >
+                  More on Wikipedia
+                </a>
+              )}
               {plant.nickname && (
                 <p
                   className="text-sm italic text-gray-100 animate-fade-in-down"

--- a/src/pages/Wishlist.jsx
+++ b/src/pages/Wishlist.jsx
@@ -32,6 +32,7 @@ export default function Wishlist() {
           <div key={plant.id} className="relative">
             <Link
               to={plant.room ? `/room/${encodeURIComponent(plant.room)}/plant/${plant.id}` : `/plant/${plant.id}`}
+              state={{ from: '/wishlist' }}
               className="block"
               onMouseDown={createRipple}
               onTouchStart={createRipple}


### PR DESCRIPTION
## Summary
- link wishlist cards to the in-app plant detail view
- show next watering needs on plant cards
- offer Wikipedia link in the plant detail header
- test for watering text on BalconyPlantCard

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_688573291e5c8324930e2209ebb8a81d