### PR TITLE
Add plant total summary on My Plants page

### DIFF
--- a/src/components/PageHeader.jsx
+++ b/src/components/PageHeader.jsx
@@ -1,12 +1,20 @@
 import Breadcrumb from './Breadcrumb.jsx'
 
-export default function PageHeader({ title, breadcrumb, className = '' }) {
+export default function PageHeader({
+  title,
+  breadcrumb,
+  className = '',
+  subtitle,
+  children,
+}) {
   return (
     <header className={`mb-4 space-y-1 text-left ${className}`.trim()}>
       {breadcrumb && <Breadcrumb {...breadcrumb} />}
       {title && (
         <h1 className="text-2xl tracking-wide font-bold font-headline">{title}</h1>
       )}
+      {subtitle && <p className="text-sm text-gray-500">{subtitle}</p>}
+      {children}
     </header>
   )
 }

--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -19,6 +19,7 @@ import BalconyPlantCard from '../components/BalconyPlantCard.jsx'
 export default function MyPlants() {
   const { rooms } = useRooms()
   const { plants } = usePlants()
+  const totalPlants = plants.length
   const speciesOptions = Array.from(new Set(plants.map(p => p.name))).sort()
 
   const [filter, setFilter] = useState('love')
@@ -84,7 +85,7 @@ export default function MyPlants() {
   if (rooms.length === 0) {
     return (
       <div className="text-center space-y-4">
-        <PageHeader title="All Plants" />
+        <PageHeader title="All Plants" subtitle={`${totalPlants} total`} />
         <Link
           to="/room/add"
           className="inline-block px-4 py-2 bg-green-600 text-white rounded"
@@ -98,7 +99,7 @@ export default function MyPlants() {
 
   return (
     <PageContainer>
-      <PageHeader title="All Plants" />
+      <PageHeader title="All Plants" subtitle={`${totalPlants} total`} />
       <div className="my-4">
         <label htmlFor="plant-search" className="sr-only">Search Plants</label>
         <input

--- a/src/pages/__tests__/MyPlants.test.jsx
+++ b/src/pages/__tests__/MyPlants.test.jsx
@@ -150,3 +150,17 @@ test('searches plants by name', () => {
   expect(links).toHaveLength(1)
   expect(links[0]).toHaveTextContent('Living')
 })
+
+test('shows total plant count in header', () => {
+  mockRooms = []
+  mockPlants = [
+    { id: 1, name: 'Fern', room: 'Living', lastWatered: '2025-07-01' },
+    { id: 2, name: 'Basil', room: 'Kitchen', lastWatered: '2025-07-01' },
+  ]
+  render(
+    <MemoryRouter>
+      <MyPlants />
+    </MemoryRouter>
+  )
+  expect(screen.getByText('2 total')).toBeInTheDocument()
+})


### PR DESCRIPTION
## Summary
- extend `PageHeader` to accept `subtitle`
- show plant count in `MyPlants` header
- test plant count rendering

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68857790fe508324a09e60f2fee6aa8d