### PR TITLE
Add room field to EditPlant

### DIFF
--- a/src/pages/EditPlant.jsx
+++ b/src/pages/EditPlant.jsx
@@ -2,10 +2,12 @@ import { useState, useEffect, useRef } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
 import PageContainer from "../components/PageContainer.jsx"
 import { usePlants, addBase } from '../PlantContext.jsx'
+import { useRooms } from '../RoomContext.jsx'
 
 export default function EditPlant() {
   const { id } = useParams()
   const { plants, updatePlant } = usePlants()
+  const { rooms } = useRooms()
   const navigate = useNavigate()
 
   const plant = plants.find(p => p.id === Number(id))
@@ -15,6 +17,7 @@ export default function EditPlant() {
   const [nextWater, setNextWater] = useState('')
   const [lastFertilized, setLastFertilized] = useState('')
   const [nextFertilize, setNextFertilize] = useState('')
+  const [room, setRoom] = useState('')
   const nameInputRef = useRef(null)
 
   useEffect(() => {
@@ -47,6 +50,7 @@ export default function EditPlant() {
       setNextWater(plant.nextWater || '')
       setLastFertilized(plant.lastFertilized || '')
       setNextFertilize(plant.nextFertilize || '')
+      setRoom(plant.room || '')
     }
   }, [plant])
 
@@ -63,6 +67,7 @@ export default function EditPlant() {
       nextWater,
       lastFertilized,
       nextFertilize,
+      room,
     })
     navigate(`/plant/${plant.id}`)
   }
@@ -149,6 +154,19 @@ export default function EditPlant() {
           onChange={e => setNextFertilize(e.target.value)}
           className="border rounded p-2"
         />
+      </div>
+      <div className="grid gap-1">
+        <label htmlFor="room" className="font-medium">Room</label>
+        <input
+          id="room"
+          list="room-list"
+          value={room}
+          onChange={e => setRoom(e.target.value)}
+          className="border rounded p-2"
+        />
+        <datalist id="room-list">
+          {rooms.map(r => <option key={r} value={r} />)}
+        </datalist>
       </div>
       <button
         type="submit"

--- a/src/pages/__tests__/EditPlant.test.jsx
+++ b/src/pages/__tests__/EditPlant.test.jsx
@@ -1,0 +1,60 @@
+import { render, screen, fireEvent } from '@testing-library/react'
+import { MemoryRouter, Routes, Route } from 'react-router-dom'
+import EditPlant from '../EditPlant.jsx'
+import { __updatePlant as updatePlant } from '../../PlantContext.jsx'
+
+let mockPlants = []
+let mockRooms = []
+
+jest.mock('../../PlantContext.jsx', () => {
+  const updatePlant = jest.fn()
+  return {
+    __esModule: true,
+    usePlants: () => ({ plants: mockPlants, updatePlant }),
+    __updatePlant: updatePlant,
+    addBase: (u) => u,
+  }
+})
+
+jest.mock('../../RoomContext.jsx', () => ({
+  useRooms: () => ({ rooms: mockRooms }),
+}))
+
+afterEach(() => {
+  updatePlant.mockClear()
+})
+
+test('room field displays current value and submits updates', () => {
+  mockRooms = ['Living', 'Kitchen']
+  mockPlants = [
+    {
+      id: 1,
+      name: 'Fern',
+      room: 'Living',
+      lastWatered: '',
+      nextWater: '',
+      lastFertilized: '',
+      nextFertilize: '',
+      image: ''
+    },
+  ]
+
+  render(
+    <MemoryRouter initialEntries={['/plant/1/edit']}>
+      <Routes>
+        <Route path="/plant/:id/edit" element={<EditPlant />} />
+      </Routes>
+    </MemoryRouter>
+  )
+
+  const input = screen.getByLabelText(/room/i)
+  expect(input).toHaveValue('Living')
+
+  fireEvent.change(input, { target: { value: 'Kitchen' } })
+  fireEvent.click(screen.getByRole('button', { name: /save changes/i }))
+
+  expect(updatePlant).toHaveBeenCalledWith(
+    1,
+    expect.objectContaining({ room: 'Kitchen' })
+  )
+})


### PR DESCRIPTION
## Summary
- allow room selection in EditPlant
- test EditPlant room behavior

## Testing
- `npx jest src/pages/__tests__/EditPlant.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_68858815e1a08324b09d917055cc508d