### PR TITLE
Improve color contrast for accessibility

### DIFF
--- a/src/components/CreateFab.jsx
+++ b/src/components/CreateFab.jsx
@@ -75,7 +75,7 @@ export default function CreateFab() {
         title="Open create menu"
         aria-expanded={open}
         aria-haspopup="menu"
-        className={`fixed bottom-24 right-20 z-30 bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
+        className={`fixed bottom-24 right-20 z-30 bg-accent text-black w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
       >
         <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
       </button>

--- a/src/components/NoteFab.jsx
+++ b/src/components/NoteFab.jsx
@@ -64,7 +64,7 @@ export default function NoteFab({ onAddNote }) {
         title="Open create menu"
         aria-expanded={open}
         aria-haspopup="menu"
-        className={`absolute bottom-4 right-4 z-30 bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
+        className={`absolute bottom-4 right-4 z-30 bg-accent text-black w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
       >
         <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
       </button>

--- a/src/components/PlantDetailFab.jsx
+++ b/src/components/PlantDetailFab.jsx
@@ -131,7 +131,7 @@ export default function PlantDetailFab({
         title="Add to Journal"
         aria-expanded={open}
         aria-haspopup="menu"
-        className={`absolute bottom-4 right-4 sm:bottom-6 z-30 drop-shadow-md bg-accent text-white w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
+        className={`absolute bottom-4 right-4 sm:bottom-6 z-30 drop-shadow-md bg-accent text-black w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
       >
         <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
       </button>

--- a/src/index.css
+++ b/src/index.css
@@ -2,6 +2,14 @@
 @tailwind components;
 @tailwind utilities;
 
+:root {
+  --color-accent: #1e7832; /* accessible on light background */
+}
+
+.dark {
+  --color-accent: #7fb77e;
+}
+
 body {
   @apply bg-offwhite text-gray-900 font-body;
   font-size: 17px;

--- a/src/utils/__tests__/contrast.test.js
+++ b/src/utils/__tests__/contrast.test.js
@@ -1,0 +1,24 @@
+import { contrastRatio } from '../contrast.js'
+
+const lightAccent = '#1e7832'
+const darkAccent = '#7fb77e'
+const lightBg = '#f9faf8'
+const darkBg = '#1f2937'
+
+// WCAG AA requires 4.5:1 for text contrast
+
+test('light accent contrasts with light background', () => {
+  expect(contrastRatio(lightAccent, lightBg)).toBeGreaterThanOrEqual(4.5)
+})
+
+test('light accent contrasts with white text', () => {
+  expect(contrastRatio(lightAccent, '#ffffff')).toBeGreaterThanOrEqual(4.5)
+})
+
+test('dark accent contrasts with dark background', () => {
+  expect(contrastRatio(darkAccent, darkBg)).toBeGreaterThanOrEqual(4.5)
+})
+
+test('dark accent contrasts with black icons', () => {
+  expect(contrastRatio(darkAccent, '#000000')).toBeGreaterThanOrEqual(3)
+})

--- a/src/utils/contrast.js
+++ b/src/utils/contrast.js
@@ -1,0 +1,13 @@
+export function luminance(hex) {
+  const [r, g, b] = hex.replace('#', '').match(/.{2}/g).map(v => parseInt(v, 16) / 255).map(c =>
+    c <= 0.03928 ? c / 12.92 : Math.pow((c + 0.055) / 1.055, 2.4)
+  );
+  return 0.2126 * r + 0.7152 * g + 0.0722 * b;
+}
+
+export function contrastRatio(hex1, hex2) {
+  const l1 = luminance(hex1);
+  const l2 = luminance(hex2);
+  const [lighter, darker] = l1 > l2 ? [l1, l2] : [l2, l1];
+  return (lighter + 0.05) / (darker + 0.05);
+}

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -10,7 +10,7 @@ export default {
         offwhite: '#f9faf8',
         sage: '#eaf4ec',
         stone: '#f2f2f2',
-        accent: '#7fb77e',
+        accent: 'var(--color-accent)',
         water: colors.blue,
         fertilize: colors.orange,
         healthy: colors.green,


### PR DESCRIPTION
## Summary
- define CSS variables for accent colors and use them via Tailwind
- darken floating action button icons for better contrast
- add utility to compute WCAG contrast ratios
- ensure accent colors meet AA standards with tests

## Testing
- `npx jest src/utils/__tests__/contrast.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6885894be2708324b57437326aeeaf8e