### PR TITLE
Fix React act warnings

### DIFF
--- a/setupTests.js
+++ b/setupTests.js
@@ -1,4 +1,5 @@
-import '@testing-library/jest-dom';
+import '@testing-library/jest-dom'
+import { act } from '@testing-library/react'
 
 // Suppress React Router future flag warnings during tests
 const originalWarn = console.warn;
@@ -36,3 +37,7 @@ afterAll(() => {
     delete global.fetch;
   }
 });
+
+afterEach(async () => {
+  await act(async () => {})
+})

--- a/src/components/__tests__/DiscoveryCard.test.jsx
+++ b/src/components/__tests__/DiscoveryCard.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import DiscoveryCard from '../DiscoveryCard.jsx'
 import { WishlistProvider } from '../../WishlistContext.jsx'
 
@@ -43,4 +43,8 @@ test('shows disabled state when already in wishlist', () => {
   const button = screen.getByText(/in wishlist/i)
   expect(button).toBeDisabled()
   localStorage.clear()
+})
+
+afterEach(async () => {
+  await waitFor(() => {})
 })

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import Home from '../Home.jsx'
 import SnackbarProvider, { Snackbar } from '../../hooks/SnackbarProvider.jsx'
@@ -45,8 +45,9 @@ function renderWithSnackbar(ui) {
   )
 }
 
-afterEach(() => {
+afterEach(async () => {
   jest.useRealTimers()
+  await waitFor(() => {})
 })
 
 test('shows upbeat message when there are no tasks', () => {

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -621,3 +621,7 @@ test('handles unknown plant id gracefully', () => {
   expect(screen.getByText(/plant not found/i)).toBeInTheDocument()
 })
 
+afterEach(async () => {
+  await waitFor(() => {})
+})
+

--- a/src/pages/__tests__/PlantDetailCareLog.test.jsx
+++ b/src/pages/__tests__/PlantDetailCareLog.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 import { MemoryRouter, Routes, Route } from 'react-router-dom'
 import PlantDetail from '../PlantDetail.jsx'
 import { MenuProvider } from '../../MenuContext.jsx'
@@ -103,4 +103,8 @@ test('toggle reverses month ordering', () => {
 
   headings = screen.getAllByRole('heading', { level: 3 })
   expect(headings[0]).toHaveTextContent('June 2025')
+})
+
+afterEach(async () => {
+  await waitFor(() => {})
 })

--- a/src/pages/__tests__/TimelineRoute.test.jsx
+++ b/src/pages/__tests__/TimelineRoute.test.jsx
@@ -1,4 +1,4 @@
-import { render, screen } from '@testing-library/react'
+import { render, screen, waitFor } from '@testing-library/react'
 import { MemoryRouter } from 'react-router-dom'
 import { OpenAIProvider } from '../../OpenAIContext.jsx'
 import App from '../../App.jsx'
@@ -22,4 +22,8 @@ test('navigating to /timeline renders the Timeline page', () => {
   )
 
   expect(screen.getByRole('link', { name: 'Plant A' })).toBeInTheDocument()
+})
+
+afterEach(async () => {
+  await waitFor(() => {})
 })


### PR DESCRIPTION
## Summary
- silence React Router warnings
- add global afterEach hook to flush React updates
- wait for async updates in React tests

## Testing
- `CI=true npm test -- -w=1` *(fails: act warnings still present)*

------
https://chatgpt.com/codex/tasks/task_e_68858ad62fdc8324911cfb8aede0ab2a