### PR TITLE
Fix prisma seed import

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "lint": "eslint ."
   },
   "prisma": {
-    "seed": "ts-node prisma/seed.ts"
+    "seed": "node --loader ts-node/esm prisma/seed.ts"
   },
   "dependencies": {
     "@babel/preset-typescript": "^7.27.1",

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -1,5 +1,6 @@
 // prisma/seed.ts
-import { PrismaClient, CareEventType } from '@prisma/client'
+import pkg from '@prisma/client'
+const { PrismaClient, CareEventType } = pkg
 const prisma = new PrismaClient()
 
 async function main() {


### PR DESCRIPTION
## Summary
- switch to default import in `prisma/seed.ts`
- run seeding via `ts-node` ESM loader

## Testing
- `npx prisma migrate deploy`
- `npx prisma db seed`

------
https://chatgpt.com/codex/tasks/task_e_68859394fbac8324896bcfb88e6e23c1