### PR TITLE
Fix fab icon color

### DIFF
--- a/src/components/AddPlantForm.tsx
+++ b/src/components/AddPlantForm.tsx
@@ -11,7 +11,7 @@ export interface AddPlantFormProps {
   onChange?: (data: Partial<PlantForm>) => void
 }
 
-export default function AddPlantForm({ mode, defaultValues, onSubmit, onNameChange }: AddPlantFormProps) {
+export default function AddPlantForm({ mode, defaultValues, onSubmit, onNameChange, onChange }: AddPlantFormProps) {
   const {
     register,
     handleSubmit,

--- a/src/components/CreateFab.jsx
+++ b/src/components/CreateFab.jsx
@@ -77,7 +77,7 @@ export default function CreateFab() {
         aria-haspopup="menu"
         className={`fixed bottom-24 right-20 z-30 bg-accent text-black w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
       >
-        <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
+        <Plus className={`w-6 h-6 text-white transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
       </button>
     </>
   )

--- a/src/components/NoteFab.jsx
+++ b/src/components/NoteFab.jsx
@@ -66,7 +66,7 @@ export default function NoteFab({ onAddNote }) {
         aria-haspopup="menu"
         className={`absolute bottom-4 right-4 z-30 bg-accent text-black w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
       >
-        <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
+        <Plus className={`w-6 h-6 text-white transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
       </button>
     </>
   )

--- a/src/components/PlantDetailFab.jsx
+++ b/src/components/PlantDetailFab.jsx
@@ -133,7 +133,7 @@ export default function PlantDetailFab({
         aria-haspopup="menu"
         className={`absolute bottom-4 right-4 sm:bottom-6 z-30 drop-shadow-md bg-accent text-black w-14 h-14 rounded-full shadow-lg flex items-center justify-center hover:bg-green-700 transition-transform ${open ? 'ring-pulse' : ''}`}
       >
-        <Plus className={`w-6 h-6 transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
+        <Plus className={`w-6 h-6 text-white transition-transform ${open ? 'rotate-45' : ''}`} aria-hidden="true" />
       </button>
     </>
   )


### PR DESCRIPTION
## Summary
- add missing prop in AddPlantForm
- use white icons for fab buttons so they stand out

## Testing
- `npm test --silent` *(fails: Add.test.jsx and EditPlant.test.jsx)*

------
https://chatgpt.com/codex/tasks/task_e_688597af02b48324b281d40339745502