### PR TITLE
Expose vite dev server to LAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ npx prisma migrate deploy
 # optional: seed sample data
 SEED_EXAMPLE_DATA=true npx prisma db seed
 npm run server   # Express API on :3000
-npm run dev      # Vite on :5173
+npm run dev      # Vite on :5173 (LAN accessible)
 ```
 
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "version": "0.0.2",
   "type": "module",
   "scripts": {
-    "dev": "vite",
+    "dev": "vite --host",
     "build": "vite build",
     "preview": "vite preview",
     "server": "node api/server.js",

--- a/vite.config.js
+++ b/vite.config.js
@@ -28,6 +28,7 @@ export default defineConfig(({ mode }) => {
       },
     },
     server: {
+      host: true,
       proxy: {
         '/api': 'http://localhost:3000',
       },


### PR DESCRIPTION
## Summary
- allow network access by running Vite with `--host`
- document that the dev server is LAN-accessible
- update Vite config for default LAN hosting

## Testing
- `npm test --silent src/components/__tests__/PlantCard.test.jsx`

------
https://chatgpt.com/codex/tasks/task_e_688598a8699483248379c99d87b141b7