### PR TITLE
Fix prisma memory fallback

### DIFF
--- a/api/__tests__/plantsRoutes.test.js
+++ b/api/__tests__/plantsRoutes.test.js
@@ -88,6 +88,8 @@ jest.mock('cloudinary', () => ({
 }))
 
 import { PrismaClient } from '@prisma/client'
+process.env.DATABASE_URL = 'test'
+process.env.NODE_ENV = 'development'
 const prisma = new PrismaClient()
 store = prisma.__store
 

--- a/api/server.js
+++ b/api/server.js
@@ -88,9 +88,9 @@ function createMemoryPrisma() {
 }
 
 const prisma =
-  (process.env.DATABASE_URL || process.env.NODE_ENV === 'test')
-    ? new PrismaClient()
-    : createMemoryPrisma()
+  process.env.NODE_ENV === 'test' || !process.env.DATABASE_URL
+    ? createMemoryPrisma()
+    : new PrismaClient()
 const upload = multer({ storage: multer.memoryStorage() })
 
 const plantSchema = z.object({


### PR DESCRIPTION
## Summary
- choose in-memory prisma when NODE_ENV is 'test' or DATABASE_URL is missing
- set NODE_ENV and DATABASE_URL in plantsRoutes test so PrismaClient mock is used

## Testing
- `CI=true npx jest api/__tests__/plantsRoutes.test.js api/__tests__/coachRoute.test.js api/__tests__/uploadValidation.test.js`

------
https://chatgpt.com/codex/tasks/task_e_6885a53b512483249d9a1219e21ece08