### PR TITLE
Allow configuring JSON payload limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ Lisa is a **mobile-first** plant care app with weather-driven reminders, an AI C
 ```bash
 npm install
 cp .env.example .env   # add your API keys and DB URL
+# optional: change JSON_LIMIT to adjust Express JSON body size (default 1mb)
 # start MySQL here if using Docker
 npx prisma migrate deploy
 # optional: seed sample data

--- a/api/server.js
+++ b/api/server.js
@@ -18,8 +18,9 @@ try {
   taxonList = []
 }
 const app = express()
-// Temporarily increase JSON payload limit while the upload feature is in progress
-app.use(express.json({ limit: '100mb' }))
+// Allow customizing the JSON payload limit via env; default 1mb
+const jsonLimit = process.env.JSON_LIMIT || '1mb'
+app.use(express.json({ limit: jsonLimit }))
 
 // Cloudinary is configured in cloudinary.js
 


### PR DESCRIPTION
## Summary
- add `JSON_LIMIT` env support in `api/server.js`
- document `JSON_LIMIT` in the install instructions

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_6885a91d6f408324b9140dc60df5d834