### PR TITLE
Add global comment for VITE_BASE_PATH

### DIFF
--- a/src/hooks/useServiceWorker.js
+++ b/src/hooks/useServiceWorker.js
@@ -1,6 +1,6 @@
+/* global VITE_BASE_PATH */
 import { useEffect } from 'react';
 import useSnackbar from './useSnackbar.jsx';
-/* global VITE_BASE_PATH */
 
 export default function useServiceWorker() {
   const context = useSnackbar();


### PR DESCRIPTION
## Summary
- move the `/* global VITE_BASE_PATH */` directive to the top of `useServiceWorker.js`

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6885b175a2d883249d97a7750d9a0d2f