### PR TITLE
Fix moduleDir path in server

### DIFF
--- a/api/server.js
+++ b/api/server.js
@@ -12,7 +12,7 @@ import { generateCarePlan } from '../lib/carePlan.js'
 const moduleDir =
   typeof __dirname !== 'undefined'
     ? __dirname
-    : path.dirname(fileURLToPath(eval('import.meta.url')))
+    : path.dirname(fileURLToPath(import.meta.url))
 const discoverPath = path.join(moduleDir, '..', 'src', 'discoverablePlants.json')
 const discoverable = JSON.parse(fs.readFileSync(discoverPath))
 const taxonPath = path.join(moduleDir, '..', 'src', '__fixtures__', 'plants.json')


### PR DESCRIPTION
## Summary
- use `fileURLToPath(import.meta.url)` when resolving `moduleDir`
- verified that `npm run server` starts successfully

## Testing
- `npm run server`

------
https://chatgpt.com/codex/tasks/task_e_6885b7fb0a9883248ce6020e3ac7a67c