### PR TITLE
Handle discovery API errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ Lisa is a **mobile-first** plant care app with weather-driven reminders, an AI C
 - Weather-based scheduling
 - OpenAI Coach & care plan
 - Discoverable plant suggestions
+- If the API for suggestions fails, an error message is shown instead of a blank section
 - Offline PWA support
 - Photo uploads via Cloudinary
 </details>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -278,6 +278,9 @@ export default function Home() {
             data-testid="discovery-loading"
           />
         )}
+        {!discoverLoading && discoverError && (
+          <div className="text-center text-red-600">{discoverError}</div>
+        )}
         {!discoverLoading && discoverPlants.length > 0 && (
           <>
             <div className="flex flex-nowrap gap-4 overflow-x-auto pb-2">

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -20,18 +20,19 @@ jest.mock('../../PlantContext.jsx', () => ({
 }))
 
 const discoverPlant = { id: 99, name: 'Calathea', image: 'd.jpg' }
+const mockDiscoverHook = jest.fn(() => ({
+  plants: [discoverPlant],
+  loading: false,
+  error: '',
+  refetch: jest.fn(),
+  skipToday: jest.fn(),
+  remindLater: jest.fn(),
+  skipped: false,
+}))
 
 jest.mock('../../hooks/useDiscoverablePlant.js', () => ({
   __esModule: true,
-  default: () => ({
-    plants: [discoverPlant],
-    loading: false,
-    error: '',
-    refetch: jest.fn(),
-    skipToday: jest.fn(),
-    remindLater: jest.fn(),
-    skipped: false,
-  })
+  default: (...args) => mockDiscoverHook(...args),
 }))
 
 jest.mock('../../WishlistContext.jsx', () => ({
@@ -147,5 +148,19 @@ test('discovery section provides extra spacing', () => {
 
   const section = screen.getByTestId('discovery-section')
   expect(section).toHaveClass('mb-4')
+})
+
+test('shows error message when discovery fails', () => {
+  mockDiscoverHook.mockReturnValueOnce({
+    plants: [],
+    loading: false,
+    error: 'Failed to load plant',
+    refetch: jest.fn(),
+    skipToday: jest.fn(),
+    remindLater: jest.fn(),
+    skipped: false,
+  })
+  renderWithSnackbar(<Home />)
+  expect(screen.getByText('Failed to load plant')).toBeInTheDocument()
 })
 


### PR DESCRIPTION
## Summary
- show a red error alert if plant discovery fails
- test Home page error handling
- mention discovery error messages in README

## Testing
- `npm test -- src/pages/__tests__/Home.test.jsx`
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6885bbd2b9088324b98170a0185665e3