### PR TITLE
Add hero image selection

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Lisa is a **mobile-first** plant care app with weather-driven reminders, an AI C
 - Today, All Plants and Timeline views
 - Add/edit/delete plants
 - Photo gallery & tasks per plant
+- Set hero image from gallery thumbnails
 - Placeholder images come from Wikipedia with a local fallback
 
 <details>

--- a/src/pages/PlantDetail.jsx
+++ b/src/pages/PlantDetail.jsx
@@ -686,6 +686,14 @@ export default function PlantDetail() {
                   >
                     <Trash className="w-3 h-3" aria-hidden="true" />
                   </button>
+                  <button
+                    type="button"
+                    aria-label="Set as hero"
+                    className="absolute bottom-1 left-1 bg-white/70 rounded px-1 py-0.5 text-[10px] text-gray-600 hover:text-green-700 opacity-0 group-hover:opacity-100 focus:opacity-100 transition-all ease-in-out duration-200"
+                    onClick={() => updatePlant(plant.id, { image: photo.src })}
+                  >
+                    Set as hero
+                  </button>
                 </div>
               );
             })}

--- a/src/pages/__tests__/PlantDetail.test.jsx
+++ b/src/pages/__tests__/PlantDetail.test.jsx
@@ -264,6 +264,46 @@ test('view all button opens the viewer from first image', () => {
   expect(viewerImg).toHaveAttribute('src', plant.photos[0].src)
 })
 
+test('set hero image from gallery', () => {
+  localStorage.setItem(
+    'plants',
+    JSON.stringify([
+      {
+        id: 1,
+        name: 'Aloe',
+        image: 'hero.jpg',
+        waterPlan: { volume_ml: 164, volume_oz: 6, interval: 7 },
+        photos: [
+          { src: 'a.jpg', caption: '' },
+          { src: 'b.jpg', caption: '' },
+        ],
+        careLog: [],
+      },
+    ])
+  )
+
+  render(
+    <OpenAIProvider>
+      <MenuProvider>
+        <PlantProvider>
+          <MemoryRouter initialEntries={['/plant/1']}>
+            <Routes>
+              <Route path="/plant/:id" element={<PlantDetail />} />
+            </Routes>
+          </MemoryRouter>
+        </PlantProvider>
+      </MenuProvider>
+    </OpenAIProvider>
+  )
+
+  fireEvent.click(screen.getByRole('tab', { name: /gallery/i }))
+  const btns = screen.getAllByRole('button', { name: /set as hero/i })
+  fireEvent.click(btns[1])
+
+  expect(screen.getByAltText('Aloe')).toHaveAttribute('src', 'b.jpg')
+  localStorage.clear()
+})
+
 test('back button navigates to previous page', () => {
   const plant = plants[0]
   const { container } = render(


### PR DESCRIPTION
## Summary
- add button to choose hero image from gallery
- test hero image update in PlantDetail
- document new hero image option

## Testing
- `npx jest src/pages/__tests__/PlantDetail.test.jsx -t "set hero image"`

------
https://chatgpt.com/codex/tasks/task_e_6885bcf2cd688324a33d516653bf1c33