### PR TITLE
Improve MyPlants and RoomList UI

### DIFF
--- a/src/pages/MyPlants.jsx
+++ b/src/pages/MyPlants.jsx
@@ -1,6 +1,14 @@
 import { useState } from 'react'
 import { Link } from 'react-router-dom'
-import { Plus, Drop, Bug, Heart } from 'phosphor-react'
+import {
+  Plus,
+  Drop,
+  Bug,
+  Heart,
+  SquaresFour,
+  ListBullets,
+  MagnifyingGlass,
+} from 'phosphor-react'
 import { getNextWateringDate } from '../utils/watering.js'
 
 import Badge from '../components/Badge.jsx'
@@ -102,14 +110,17 @@ export default function MyPlants() {
       <PageHeader title="All Plants" subtitle={`${totalPlants} total`} />
       <div className="my-4">
         <label htmlFor="plant-search" className="sr-only">Search Plants</label>
-        <input
-          id="plant-search"
-          type="search"
-          value={query}
-          onChange={e => setQuery(e.target.value)}
-          placeholder="Search plants"
-          className="w-full border rounded p-2"
-        />
+        <div className="relative">
+          <MagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-500" aria-hidden="true" />
+          <input
+            id="plant-search"
+            type="search"
+            value={query}
+            onChange={e => setQuery(e.target.value)}
+            placeholder="Search plants"
+            className="w-full rounded-full border bg-gray-100 dark:bg-gray-800 py-2 pl-10 pr-3 focus:ring-2 focus:ring-green-600 focus:outline-none"
+          />
+        </div>
       </div>
       <div className="flex flex-wrap gap-2 mb-4">
         <label className="text-sm flex items-center gap-1">
@@ -142,14 +153,32 @@ export default function MyPlants() {
             ))}
           </select>
         </label>
-        <FilterPills
-          value={view}
-          onChange={setView}
-          options={[
-            { value: 'grid', label: 'Grid' },
-            { value: 'list', label: 'List' },
-          ]}
-        />
+        <div className="flex items-center gap-1">
+          <button
+            type="button"
+            onClick={() => setView('grid')}
+            className={`border rounded p-1 ${
+              view === 'grid'
+                ? 'bg-green-600 text-white border-green-600'
+                : 'text-gray-600 dark:text-gray-200'
+            }`}
+            aria-label="Grid view"
+          >
+            <SquaresFour className="w-4 h-4" aria-hidden="true" />
+          </button>
+          <button
+            type="button"
+            onClick={() => setView('list')}
+            className={`border rounded p-1 ${
+              view === 'list'
+                ? 'bg-green-600 text-white border-green-600'
+                : 'text-gray-600 dark:text-gray-200'
+            }`}
+            aria-label="List view"
+          >
+            <ListBullets className="w-4 h-4" aria-hidden="true" />
+          </button>
+        </div>
       </div>
       <FilterPills
         value={filter}

--- a/src/pages/RoomList.jsx
+++ b/src/pages/RoomList.jsx
@@ -1,5 +1,6 @@
 import { useParams, Link, useLocation } from 'react-router-dom'
 import { useState } from 'react'
+import { SquaresFour, ListBullets, MagnifyingGlass } from 'phosphor-react'
 import BalconyPlantCard from '../components/BalconyPlantCard.jsx'
 
 import { usePlants } from '../PlantContext.jsx'
@@ -13,6 +14,8 @@ export default function RoomList() {
   const location = useLocation()
   const { plants } = usePlants()
   const [sortBy, setSortBy] = useState('name')
+  const [view, setView] = useState('list')
+  const [query, setQuery] = useState('')
   const list = plants.filter(p => p.room === roomName)
   const today = new Date()
   const sorted = [...list].sort((a, b) => {
@@ -30,25 +33,74 @@ export default function RoomList() {
     return a.id - b.id
   })
 
+  const search = query.trim().toLowerCase()
+  const filtered = search
+    ? sorted.filter(p => (p.name || '').toLowerCase().includes(search))
+    : sorted
+
   return (
     <PageContainer>
       <PageHeader title={roomName} breadcrumb={{ room: roomName }} />
       {list.length > 0 && (
-        <FilterPills
-          value={sortBy}
-          onChange={setSortBy}
-          options={[
-            { value: 'name', label: 'Name' },
-            { value: 'status', label: 'Watering Status' },
-            { value: 'recent', label: 'Recently Added' },
-          ]}
-        />
+        <div className="my-4">
+          <label htmlFor="room-search" className="sr-only">Search Plants</label>
+          <div className="relative">
+            <MagnifyingGlass className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-gray-500" aria-hidden="true" />
+            <input
+              id="room-search"
+              type="search"
+              value={query}
+              onChange={e => setQuery(e.target.value)}
+              placeholder="Search plants"
+              className="w-full rounded-full border bg-gray-100 dark:bg-gray-800 py-2 pl-10 pr-3 focus:ring-2 focus:ring-green-600 focus:outline-none"
+            />
+          </div>
+        </div>
+      )}
+      {list.length > 0 && (
+        <div className="flex flex-wrap items-center gap-2 mb-4">
+          <FilterPills
+            value={sortBy}
+            onChange={setSortBy}
+            options={[
+              { value: 'name', label: 'Name' },
+              { value: 'status', label: 'Watering Status' },
+              { value: 'recent', label: 'Recently Added' },
+            ]}
+          />
+          <div className="flex items-center gap-1 ml-auto">
+            <button
+              type="button"
+              onClick={() => setView('grid')}
+              className={`border rounded p-1 ${
+                view === 'grid'
+                  ? 'bg-green-600 text-white border-green-600'
+                  : 'text-gray-600 dark:text-gray-200'
+              }`}
+              aria-label="Grid view"
+            >
+              <SquaresFour className="w-4 h-4" aria-hidden="true" />
+            </button>
+            <button
+              type="button"
+              onClick={() => setView('list')}
+              className={`border rounded p-1 ${
+                view === 'list'
+                  ? 'bg-green-600 text-white border-green-600'
+                  : 'text-gray-600 dark:text-gray-200'
+              }`}
+              aria-label="List view"
+            >
+              <ListBullets className="w-4 h-4" aria-hidden="true" />
+            </button>
+          </div>
+        </div>
       )}
       {list.length === 0 ? (
         <p>No plants in this room.</p>
       ) : (
-        <div className="space-y-8">
-          {sorted.map(plant => (
+        <div className={view === 'grid' ? 'grid gap-4 pb-24' : 'space-y-8'} style={view === 'grid' ? { gridTemplateColumns: 'repeat(auto-fill, minmax(160px,1fr))', gridAutoRows: '1fr' } : {}}>
+          {filtered.map(plant => (
             <Link
               key={plant.id}
               to={`/room/${encodeURIComponent(roomName)}/plant/${plant.id}`}
@@ -57,7 +109,16 @@ export default function RoomList() {
               onMouseDown={createRipple}
               onTouchStart={createRipple}
             >
-              <BalconyPlantCard plant={plant} />
+              {view === 'grid' ? (
+                <img
+                  src={plant.image || plant.placeholderSrc}
+                  alt={plant.name}
+                  className="aspect-[3/4] object-cover w-full h-full rounded-xl"
+                  loading="lazy"
+                />
+              ) : (
+                <BalconyPlantCard plant={plant} />
+              )}
             </Link>
           ))}
         </div>


### PR DESCRIPTION
## Summary
- use icons for grid and list toggles
- restyle search inputs with an icon
- allow filtering plants in room view and add grid option

## Testing
- `npm test` *(fails: Jest process hang)*

------
https://chatgpt.com/codex/tasks/task_e_6885bce4afd483248b7fbe9ef62c83eb