### PR TITLE
Fix timezone issue for discovery plants

### DIFF
--- a/src/hooks/useDiscoverablePlant.js
+++ b/src/hooks/useDiscoverablePlant.js
@@ -1,5 +1,6 @@
 import { useEffect, useState, useCallback } from 'react'
 import { usePlants } from '../PlantContext.jsx'
+import { localIsoDate } from '../utils/date.js'
 
 export default function useDiscoverablePlant(count = 3) {
   const { plants } = usePlants()
@@ -9,7 +10,7 @@ export default function useDiscoverablePlant(count = 3) {
   const [skipped, setSkipped] = useState(false)
 
   const fetchPlants = useCallback(async () => {
-    const today = new Date().toISOString().slice(0, 10)
+    const today = localIsoDate()
     const key = `discover_${today}`
     setLoading(true)
     setError('')
@@ -41,7 +42,7 @@ export default function useDiscoverablePlant(count = 3) {
   }, [plants, count])
 
   useEffect(() => {
-    const today = new Date().toISOString().slice(0, 10)
+    const today = localIsoDate()
     const key = `discover_${today}`
     const skipKey = `discover_skip_${today}`
     if (typeof localStorage !== 'undefined') {
@@ -64,7 +65,7 @@ export default function useDiscoverablePlant(count = 3) {
   }, [plants, fetchPlants])
 
   const refetch = () => {
-    const today = new Date().toISOString().slice(0, 10)
+    const today = localIsoDate()
     const key = `discover_${today}`
     if (typeof localStorage !== 'undefined') {
       localStorage.removeItem(key)
@@ -73,7 +74,7 @@ export default function useDiscoverablePlant(count = 3) {
   }
 
   const skipToday = () => {
-    const today = new Date().toISOString().slice(0, 10)
+    const today = localIsoDate()
     if (typeof localStorage !== 'undefined') {
       localStorage.setItem(`discover_skip_${today}`, 'true')
       localStorage.removeItem(`discover_${today}`)
@@ -83,7 +84,7 @@ export default function useDiscoverablePlant(count = 3) {
   }
 
   const remindLater = () => {
-    const today = new Date().toISOString().slice(0, 10)
+    const today = localIsoDate()
     if (typeof localStorage !== 'undefined') {
       localStorage.removeItem(`discover_${today}`)
     }

--- a/src/utils/date.js
+++ b/src/utils/date.js
@@ -70,3 +70,8 @@ export function formatCareSummary(lastWatered, nextWater, today = new Date()) {
   }
   return parts.join(' \u00B7 ')
 }
+
+export function localIsoDate(date = new Date()) {
+  const t = new Date(date.getTime() - date.getTimezoneOffset() * 60000)
+  return t.toISOString().slice(0, 10)
+}


### PR DESCRIPTION
## Summary
- add `localIsoDate` helper for client timezone
- use `localIsoDate` when generating daily cache keys for discoverable plants

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_688646740c1083248fd53eeb21595cdf