### PR TITLE
Improve empty tasks state

### DIFF
--- a/src/components/TasksContainer.jsx
+++ b/src/components/TasksContainer.jsx
@@ -1,9 +1,14 @@
 import { Link } from 'react-router-dom'
-import { Note, Camera } from 'phosphor-react'
+import { daysUntil } from '../utils/date.js'
 import BaseCard from './BaseCard.jsx'
 import SimpleTaskCard from './SimpleTaskCard.jsx'
 
-export default function TasksContainer({ visibleTasks = [], happyPlant }) {
+export default function TasksContainer({
+  visibleTasks = [],
+  happyPlant,
+  nextTaskDate,
+}) {
+  const days = nextTaskDate ? daysUntil(nextTaskDate) : null
   return (
     <div
       data-testid="tasks-container"
@@ -44,23 +49,29 @@ export default function TasksContainer({ visibleTasks = [], happyPlant }) {
                   <img src={happyPlant} alt="Happy plant" className="w-20 h-20" />
                 </div>
               </div>
-              <h3 className="text-lg font-semibold mb-1">All plants are happy</h3>
-              <p className="text-sm text-gray-600 mb-4">Want to add a note or photo today?</p>
+              <h3 className="text-lg font-semibold mb-1">No tasks due now – your care plan is on track!</h3>
+              {days != null && (
+                <p className="text-sm text-gray-600">Next task in {days} day{days === 1 ? '' : 's'}</p>
+              )}
               <hr className="mx-auto w-1/2 border-t border-gray-200" />
               <div className="flex flex-wrap justify-center gap-3">
                 <Link
-                  to="/timeline"
-                  className="px-4 py-2 bg-green-500 text-white rounded-md shadow active:scale-95 flex items-center gap-2"
+                  to="/myplants"
+                  className="px-4 py-2 bg-green-500 text-white rounded-md shadow active:scale-95"
                 >
-                  <Note className="w-4 h-4" aria-hidden="true" />
-                  Add Note
+                  View Care Plan
                 </Link>
                 <Link
-                  to="/gallery"
-                  className="px-4 py-2 border border-green-500 text-green-500 rounded-md active:scale-95 flex items-center gap-2"
+                  to="/tasks"
+                  className="px-4 py-2 border border-green-500 text-green-500 rounded-md active:scale-95"
                 >
-                  <Camera className="w-4 h-4" aria-hidden="true" />
-                  Take Photo
+                  Browse Tasks
+                </Link>
+                <Link
+                  to="/add"
+                  className="px-4 py-2 border border-green-500 text-green-500 rounded-md active:scale-95"
+                >
+                  Add Plant
                 </Link>
               </div>
             </div>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -78,6 +78,7 @@ export default function Home() {
     fertilizeTasks,
     wateredTodayCount,
     fertilizedTodayCount,
+    soonestDate,
   } = useMemo(() => {
     const todayIso = new Date().toISOString().slice(0, 10)
     const season = getSeason()
@@ -171,6 +172,7 @@ export default function Home() {
         fertilizeTasks: [],
         wateredTodayCount: 0,
         fertilizedTodayCount: 0,
+        soonestDate: null,
       }
     )
     return result
@@ -192,6 +194,10 @@ export default function Home() {
 
   const totalWaterToday = waterTasks.length + wateredTodayCount
   const totalFertilizeToday = fertilizeTasks.length + fertilizedTodayCount
+
+  const nextTaskDate = soonestDate
+    ? soonestDate.toISOString().slice(0, 10)
+    : null
 
   const weekday = new Date().toLocaleDateString(undefined, {
     weekday: 'long',
@@ -335,7 +341,11 @@ export default function Home() {
       {showSummary && (
         <CareSummaryModal tasks={tasks} onClose={() => setShowSummary(false)} />
       )}
-      <TasksContainer visibleTasks={visibleTasks} happyPlant={happyPlant} />
+      <TasksContainer
+        visibleTasks={visibleTasks}
+        happyPlant={happyPlant}
+        nextTaskDate={nextTaskDate}
+      />
       <SwipeTip />
       <div className="mt-4">
         <Card className="p-0 text-center font-semibold">

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -60,13 +60,14 @@ afterEach(async () => {
 })
 
 test('shows upbeat message when there are no tasks', () => {
-  renderWithSnackbar(
-      <Home />
-  )
-  expect(screen.getByText(/all plants are happy/i)).toBeInTheDocument()
+  renderWithSnackbar(<Home />)
+  expect(
+    screen.getByText(/no tasks due now – your care plan is on track/i)
+  ).toBeInTheDocument()
   expect(screen.getByTestId('care-stats')).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /add note/i })).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /take photo/i })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /view care plan/i })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /browse tasks/i })).toBeInTheDocument()
+  expect(screen.getByRole('link', { name: /add plant/i })).toBeInTheDocument()
 })
 
 test('care stats render when tasks exist', () => {


### PR DESCRIPTION
## Summary
- display next task info in TasksContainer
- surface upcoming date in Home and pass to TasksContainer
- update Home tests for new empty state message

## Testing
- `npm test` *(fails: SyntaxError: Cannot use 'import.meta' outside a module)*

------
https://chatgpt.com/codex/tasks/task_e_6886480af8048324adb9e4c70b21fd6f