### PR TITLE
Add browse tasks callback

### DIFF
--- a/src/components/TasksContainer.jsx
+++ b/src/components/TasksContainer.jsx
@@ -7,6 +7,7 @@ export default function TasksContainer({
   visibleTasks = [],
   happyPlant,
   nextTaskDate,
+  onBrowseTasks,
 }) {
   const days = nextTaskDate ? daysUntil(nextTaskDate) : null
   return (
@@ -61,12 +62,13 @@ export default function TasksContainer({
                 >
                   View Care Plan
                 </Link>
-                <Link
-                  to="/tasks"
+                <button
+                  type="button"
+                  onClick={onBrowseTasks}
                   className="px-4 py-2 border border-green-500 text-green-500 rounded-md active:scale-95"
                 >
                   Browse Tasks
-                </Link>
+                </button>
                 <Link
                   to="/add"
                   className="px-4 py-2 border border-green-500 text-green-500 rounded-md active:scale-95"

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -345,6 +345,7 @@ export default function Home() {
         visibleTasks={visibleTasks}
         happyPlant={happyPlant}
         nextTaskDate={nextTaskDate}
+        onBrowseTasks={() => setShowSummary(true)}
       />
       <SwipeTip />
       <div className="mt-4">

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -66,7 +66,7 @@ test('shows upbeat message when there are no tasks', () => {
   ).toBeInTheDocument()
   expect(screen.getByTestId('care-stats')).toBeInTheDocument()
   expect(screen.getByRole('link', { name: /view care plan/i })).toBeInTheDocument()
-  expect(screen.getByRole('link', { name: /browse tasks/i })).toBeInTheDocument()
+  expect(screen.getByRole('button', { name: /browse tasks/i })).toBeInTheDocument()
   expect(screen.getByRole('link', { name: /add plant/i })).toBeInTheDocument()
 })
 


### PR DESCRIPTION
## Summary
- modify TasksContainer to accept an `onBrowseTasks` callback
- trigger a modal instead of changing page
- adjust Home page to pass the handler
- update Home tests for new behaviour

## Testing
- `npx jest src/pages/__tests__/Home.test.jsx --runInBand`

------
https://chatgpt.com/codex/tasks/task_e_68864b18f4a48324916eb43921b62eb4