### PR TITLE
Unify Add Plant flow

### DIFF
--- a/src/components/AddMenu.jsx
+++ b/src/components/AddMenu.jsx
@@ -4,7 +4,7 @@ import { Plus, Note, MagicWand } from 'phosphor-react'
 export default function AddMenu({ open = false, onClose = () => {} }) {
   if (!open) return null
   const items = [
-    { to: '/add', label: 'Add Plant', Icon: Plus },
+    { to: '/onboard', label: 'Add Plant', Icon: Plus },
     { to: '/room/add', label: 'Add Room', Icon: Plus },
     // Future: { to: '/note/add', label: 'Add Note', Icon: Note }
   ]

--- a/src/components/CreateFab.jsx
+++ b/src/components/CreateFab.jsx
@@ -16,7 +16,7 @@ export default function CreateFab() {
   }, [open])
 
   const items = [
-    { to: '/add', label: 'Add Plant', Icon: Leaf, color: 'green' },
+    { to: '/onboard', label: 'Add Plant', Icon: Leaf, color: 'green' },
     { to: '/room/add', label: 'Add Room', Icon: Door, color: 'violet' },
   ]
 

--- a/src/pages/Add.jsx
+++ b/src/pages/Add.jsx
@@ -1,36 +1,5 @@
-import { useState } from 'react'
-import { useNavigate } from 'react-router-dom'
-import { usePlants, addBase } from '../PlantContext.jsx'
-import PageContainer from '../components/PageContainer.jsx'
-import AddPlantForm from '../components/AddPlantForm.tsx'
-import usePlaceholderPhoto from '../hooks/usePlaceholderPhoto.js'
-import useToast from '../hooks/useToast.jsx'
+import { Navigate } from 'react-router-dom'
 
 export default function Add() {
-  const { addPlant } = usePlants()
-  const navigate = useNavigate()
-  const [name, setName] = useState('')
-  const placeholder = usePlaceholderPhoto(name)
-  const { Toast, showToast } = useToast()
-
-  const handleSubmit = data => {
-    const imagePath = addBase(data.image || placeholder?.src || '')
-    addPlant({
-      ...data,
-      image: imagePath,
-      diameter: Number(data.diameter) || 0,
-      ...(data.humidity && { humidity: Number(data.humidity) })
-    })
-    showToast('Added')
-    setTimeout(() => navigate('/'), 800)
-  }
-
-  return (
-    <>
-      <Toast />
-      <PageContainer size="md">
-        <AddPlantForm mode="add" onSubmit={handleSubmit} onNameChange={setName} />
-      </PageContainer>
-    </>
-  )
+  return <Navigate to="/onboard" replace />
 }

--- a/src/pages/EditCarePlan.jsx
+++ b/src/pages/EditCarePlan.jsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react'
 import { useNavigate, useParams } from 'react-router-dom'
+import { useOpenAI } from '../OpenAIContext.jsx'
 import PageContainer from '../components/PageContainer.jsx'
 import Spinner from '../components/Spinner.jsx'
 import { usePlants } from '../PlantContext.jsx'
@@ -8,6 +9,7 @@ import useCarePlan from '../hooks/useCarePlan.js'
 export default function EditCarePlan() {
   const { id } = useParams()
   const { plants, updatePlant } = usePlants()
+  const { enabled } = useOpenAI()
   const navigate = useNavigate()
 
   const plant = plants.find(p => p.id === Number(id))
@@ -98,14 +100,16 @@ export default function EditCarePlan() {
           />
         </div>
         <div className="flex gap-2">
-          <button
-            type="button"
-            onClick={handleGenerate}
-            className="px-4 py-2 bg-green-600 text-white rounded"
-            disabled={loading}
-          >
-            Generate Care Plan
-          </button>
+          {enabled && (
+            <button
+              type="button"
+              onClick={handleGenerate}
+              className="px-4 py-2 bg-green-600 text-white rounded"
+              disabled={loading}
+            >
+              Regenerate AI Plan
+            </button>
+          )}
           <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">Save</button>
         </div>
         {history.length > 1 && (

--- a/src/pages/__tests__/Add.test.jsx
+++ b/src/pages/__tests__/Add.test.jsx
@@ -35,9 +35,9 @@ test('user can add a plant', () => {
   renderWithSnackbar(
     <PlantProvider>
       <RoomProvider>
-        <MemoryRouter initialEntries={['/add']}>
+        <MemoryRouter initialEntries={['/onboard']}>
           <Routes>
-            <Route path="/add" element={<Add />} />
+            <Route path="/onboard" element={<Add />} />
             <Route path="/" element={<Home />} />
           </Routes>
         </MemoryRouter>

--- a/src/pages/__tests__/EditCarePlan.test.jsx
+++ b/src/pages/__tests__/EditCarePlan.test.jsx
@@ -58,7 +58,7 @@ test('generates plan and saves updates', async () => {
     </MemoryRouter>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /generate care plan/i }))
+  fireEvent.click(screen.getByRole('button', { name: /regenerate ai plan/i }))
 
   await waitFor(() => expect(screen.getByLabelText(/water interval/i)).toHaveValue(7))
   expect(screen.getByLabelText(/fertilize interval/i)).toHaveValue(30)
@@ -103,7 +103,7 @@ test('shows spinner while loading', async () => {
     </MemoryRouter>
   )
 
-  fireEvent.click(screen.getByRole('button', { name: /generate care plan/i }))
+  fireEvent.click(screen.getByRole('button', { name: /regenerate ai plan/i }))
 
   expect(screen.getByTestId('spinner')).toBeInTheDocument()
 
@@ -120,7 +120,7 @@ test('uses fallback plan on failure', async () => {
       </Routes>
     </MemoryRouter>
   )
-  fireEvent.click(screen.getByRole('button', { name: /generate care plan/i }))
+  fireEvent.click(screen.getByRole('button', { name: /regenerate ai plan/i }))
   await waitFor(() =>
     expect(screen.getByLabelText(/water interval/i)).toHaveValue(0)
   )


### PR DESCRIPTION
## Summary
- redirect `/add` route to onboarding wizard
- adjust menu links for Add Plant
- respect the AI toggle in onboarding and care-plan edit flow
- update related tests for new button text

## Testing
- `npm test` *(fails: Jest cannot parse server-side ESM files)*

------
https://chatgpt.com/codex/tasks/task_e_6886483b51ac8324b945997dc5d83758