### PR TITLE
Fallback local suggestions for discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Lisa is a **mobile-first** plant care app with weather-driven reminders, an AI C
 - Weather-based scheduling
 - OpenAI Coach & care plan
 - Discoverable plant suggestions
-- If the API for suggestions fails, an error message is shown instead of a blank section
+- If the API for suggestions fails, fallback picks from a local list are displayed
 - Offline PWA support
 - Photo uploads via Cloudinary
 </details>

--- a/src/hooks/useDiscoverablePlant.js
+++ b/src/hooks/useDiscoverablePlant.js
@@ -1,6 +1,7 @@
 import { useEffect, useState, useCallback } from 'react'
 import { usePlants } from '../PlantContext.jsx'
 import { localIsoDate } from '../utils/date.js'
+import fallbackPlants from '../discoverablePlants.json'
 
 export default function useDiscoverablePlant(count = 3) {
   const { plants } = usePlants()
@@ -15,8 +16,9 @@ export default function useDiscoverablePlant(count = 3) {
     setLoading(true)
     setError('')
     if (typeof fetch !== 'function') {
+      const shuffled = [...fallbackPlants].sort(() => 0.5 - Math.random())
+      setList(shuffled.slice(0, count))
       setLoading(false)
-      setError('Failed to load plant')
       return
     }
     const exclude = plants.map(p => p.name).join(',')
@@ -35,7 +37,13 @@ export default function useDiscoverablePlant(count = 3) {
       }
     } catch (err) {
       console.error('discoverable error', err)
-      setError('Failed to load plant')
+      const shuffled = [...fallbackPlants].sort(() => 0.5 - Math.random())
+      const suggestions = shuffled.slice(0, count)
+      setList(suggestions)
+      if (typeof localStorage !== 'undefined') {
+        localStorage.setItem(key, JSON.stringify(suggestions))
+      }
+      setError('')
     } finally {
       setLoading(false)
     }

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -26,6 +26,7 @@ const usePlantsMock = require('../../PlantContext.jsx').usePlants
 usePlantsMock.mockImplementation(() => ({ plants: mockPlants, error: '' }))
 
 const discoverPlant = { id: 99, name: 'Calathea', image: 'd.jpg' }
+const actualDiscoverHook = jest.requireActual('../../hooks/useDiscoverablePlant.js')
 const mockDiscoverHook = jest.fn(() => ({
   plants: [discoverPlant],
   loading: false,
@@ -157,18 +158,13 @@ test('discovery section provides extra spacing', () => {
   expect(section).toHaveClass('mb-4')
 })
 
-test('shows error message when discovery fails', () => {
-  mockDiscoverHook.mockReturnValueOnce({
-    plants: [],
-    loading: false,
-    error: 'Failed to load plant',
-    refetch: jest.fn(),
-    skipToday: jest.fn(),
-    remindLater: jest.fn(),
-    skipped: false,
-  })
+test('shows fallback list when discovery fetch fails', async () => {
+  const origFetch = global.fetch
+  global.fetch = jest.fn(() => Promise.reject(new Error('fail')))
+  mockDiscoverHook.mockImplementationOnce(actualDiscoverHook.default)
   renderWithSnackbar(<Home />)
-  expect(screen.getByText('Failed to load plant')).toBeInTheDocument()
+  await screen.findByText(/Chinese Evergreen|Fiddle Leaf Fig|Spider Plant|English Ivy|Boston Fern/)
+  global.fetch = origFetch
 })
 
 test('shows error when plant fetch fails', () => {


### PR DESCRIPTION
## Summary
- shuffle a local list of discoverable plants when the API call fails
- test the fallback discovery list on Home
- document discovery fallback logic

## Testing
- `npm test -- -b` *(fails: delete plant test in api/__tests__/plantsRoutes.test.js)*

------
https://chatgpt.com/codex/tasks/task_e_6886d01771208324b6c0da3383e255e8