### PR TITLE
Fix watch subscription in AddPlantForm

### DIFF
--- a/src/components/AddPlantForm.tsx
+++ b/src/components/AddPlantForm.tsx
@@ -22,13 +22,13 @@ export default function AddPlantForm({ mode, defaultValues, onSubmit, onNameChan
     defaultValues,
   })
 
-  const values = watch()
-  const nameValue = values.name
-
   useEffect(() => {
-    if (onNameChange) onNameChange(nameValue || '')
-    if (onChange) onChange(values)
-  }, [nameValue, values, onNameChange, onChange])
+    const subscription = watch(data => {
+      onChange?.(data)
+      onNameChange?.(data.name ?? '')
+    })
+    return () => subscription.unsubscribe()
+  }, [watch, onNameChange, onChange])
 
   return (
     <form onSubmit={handleSubmit(onSubmit)} className="space-y-4">


### PR DESCRIPTION
## Summary
- prevent recursive re-renders in `AddPlantForm` by subscribing to `watch`
- use effect cleanup on subscription

## Testing
- `npm test` *(fails: delete plant, shows error message on failure, shows fallback list when discovery fetch fails)*

------
https://chatgpt.com/codex/tasks/task_e_6886d778cb548324aa842deb209fdd3e