### PR TITLE
Add region role to discovery section

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -279,8 +279,8 @@ export default function Home() {
       <p role="alert" className="text-center text-red-600">{plantsError}</p>
     )}
     {!discoverySkipped && (
-      <section className="mb-4 space-y-2" data-testid="discovery-section">
-        <h2 className="sr-only">Discover a New Plant</h2>
+      <section role="region" aria-labelledby="discover-heading" className="mb-4 space-y-2">
+        <h2 id="discover-heading" className="sr-only">Discover a New Plant</h2>
         {discoverLoading && (
           <div
             className="h-64 rounded-3xl bg-gray-200 animate-pulse"

--- a/src/pages/__tests__/Home.test.jsx
+++ b/src/pages/__tests__/Home.test.jsx
@@ -101,7 +101,7 @@ test('care stats render when tasks exist', () => {
 test('discovery card appears before care stats', () => {
   renderWithSnackbar(<Home />)
 
-  const section = screen.getByTestId('discovery-section')
+  const section = screen.getByRole('region', { name: /discover a new plant/i })
   const stats = screen.getByTestId('care-stats')
   expect(section).toBeInTheDocument()
   const order = section.compareDocumentPosition(stats)
@@ -154,7 +154,7 @@ test('discovery section provides extra spacing', () => {
   expect(container).toBeInTheDocument()
   expect(container).not.toHaveClass('bg-sage')
 
-  const section = screen.getByTestId('discovery-section')
+  const section = screen.getByRole('region', { name: /discover a new plant/i })
   expect(section).toHaveClass('mb-4')
 })
 


### PR DESCRIPTION
## Summary
- make discovery section a region with an aria label
- search for the region by role instead of a test id

## Testing
- `npm test` *(fails: delete plant route and other tests)*

------
https://chatgpt.com/codex/tasks/task_e_6886da9379648324b8a268a6c28837f7