### PR TITLE
Fallback to sample plants when API is unavailable

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,10 @@ npm run server   # Express API on :3000
 npm run dev      # Vite on :5173 (LAN accessible)
 ```
 
+If the `/api/plants` endpoint is unavailable, the app falls back to sample
+plants from `src/__fixtures__/plants.json` so you can explore the UI without
+running the server.
+
 
 ### Personal Use Tips
 - View the app on your laptop at `http://localhost:5173`.

--- a/src/PlantContext.jsx
+++ b/src/PlantContext.jsx
@@ -1,5 +1,5 @@
 import { createContext, useContext, useEffect, useState } from "react";
-import testPlants from "./__fixtures__/plants.json";
+import samplePlants from "./__fixtures__/plants.json";
 import { useWeather } from "./WeatherContext.jsx";
 import { getNextWateringDate } from "./utils/watering.js";
 import { getWaterPlan, getSmartWaterPlan } from "./utils/waterCalculator.js";
@@ -78,7 +78,7 @@ export function PlantProvider({ children }) {
       }
     }
     if (process.env.NODE_ENV === 'test') {
-      return testPlants.map(mapPlant);
+      return samplePlants.map(mapPlant);
     }
     return [];
   });
@@ -97,7 +97,10 @@ export function PlantProvider({ children }) {
           setLoadError('');
         }
       } catch {
-        if (!ignore) setLoadError('Failed to load plants');
+        if (!ignore) {
+          setPlants(samplePlants.map(mapPlant));
+          setLoadError('Failed to load plants');
+        }
       }
     }
     load();


### PR DESCRIPTION
## Summary
- use fixture plants as fallback when API fetch fails
- document sample-data fallback in README

## Testing
- `npm test` (fails: 4 failed)
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68901b0bc22083249599f1cf82f4c8e3