### PR TITLE
Add retryable plant loading with error banner

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -32,7 +32,7 @@ import useSnackbar from '../hooks/useSnackbar.jsx'
 
 
 export default function Home() {
-  const { plants, error: plantsError } = usePlants()
+  const { plants, error: plantsError, retryLoad } = usePlants()
   const [showSummary, setShowSummary] = useState(false)
   const [typeFilter, setTypeFilter] = useState('all')
   const [showHeader, setShowHeader] = useState(() => {
@@ -276,7 +276,15 @@ export default function Home() {
       </header>
       )}
     {plantsError && (
-      <p role="alert" className="text-center text-red-600">{plantsError}</p>
+      <div
+        role="alert"
+        className="fixed top-0 left-0 right-0 z-50 flex items-center justify-center gap-4 bg-red-500 text-white p-2 text-center"
+      >
+        <span>{plantsError}</span>
+        <button type="button" onClick={retryLoad} className="underline">
+          Try again
+        </button>
+      </div>
     )}
     {!discoverySkipped && (
       <section role="region" aria-labelledby="discover-heading" className="mb-4 space-y-2">


### PR DESCRIPTION
## Summary
- handle plant load failures with retry callback and friendly message
- show retryable error banner on home page
- adjust Home tests for new error handling

## Testing
- `npm test src/pages/__tests__/Home.test.jsx`
- `npm test` *(fails: 3 failed, 8 failed tests)*

------
https://chatgpt.com/codex/tasks/task_e_68901b0abdc8832495ef1ae7de1f719e