### PR TITLE
Add retry mechanism for plant loading

### DIFF
--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -32,7 +32,7 @@ import useSnackbar from '../hooks/useSnackbar.jsx'
 
 
 export default function Home() {
-  const { plants, error: plantsError } = usePlants()
+  const { plants, error: plantsError, retryLoad } = usePlants()
   const [showSummary, setShowSummary] = useState(false)
   const [typeFilter, setTypeFilter] = useState('all')
   const [showHeader, setShowHeader] = useState(() => {
@@ -276,7 +276,19 @@ export default function Home() {
       </header>
       )}
     {plantsError && (
-      <p role="alert" className="text-center text-red-600">{plantsError}</p>
+      <div
+        role="alert"
+        className="my-4 flex items-center justify-between rounded-md bg-red-100 p-3 text-sm text-red-700"
+      >
+        <span>{plantsError}</span>
+        <button
+          type="button"
+          onClick={retryLoad}
+          className="font-medium underline"
+        >
+          Try again
+        </button>
+      </div>
     )}
     {!discoverySkipped && (
       <section role="region" aria-labelledby="discover-heading" className="mb-4 space-y-2">


### PR DESCRIPTION
## Summary
- add retry callback and friendly error message when plant data fails to load
- expose retry function from PlantContext and display banner on Home with retry option

## Testing
- `npm test api/__tests__/plantsRoutes.test.js` *(fails: Expected: 204 Received: 404)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68901e1083288324b743060597afb3a8