### PR TITLE
feat: auto fill scientific name

### DIFF
--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -69,6 +69,11 @@ export default function Onboard() {
     if (!plan && !water) setWater(s.waterPlan)
   }, [form.name, form.diameter, form.light, forecast, plan, enabled])
 
+  useEffect(() => {
+    const match = taxa.find(t => t.commonName.toLowerCase() === form.name.toLowerCase())
+    if (match) setForm(f => ({ ...f, scientificName: match.scientificName }))
+  }, [taxa, form.name])
+
   const handleUseOutdoorHumidity = () => {
     if (forecast?.humidity !== undefined) {
       setForm(f => ({ ...f, humidity: forecast.humidity }))
@@ -76,11 +81,9 @@ export default function Onboard() {
   }
 
   const handleNameChange = async name => {
-    const match = taxa.find(t => t.commonName.toLowerCase() === name.toLowerCase())
     setForm(f => ({
       ...f,
       name,
-      scientificName: match ? match.scientificName : f.scientificName,
     }))
 
     if (!name || !form.diameter) return


### PR DESCRIPTION
## Summary
- simplify plant name change handler so it only tracks the entered name
- automatically update scientific name when a matching taxon suggestion exists

## Testing
- `npm test src/pages/__tests__/Onboard.test.jsx` *(fails: Unable to find label "plant name")*


------
https://chatgpt.com/codex/tasks/task_e_689023e067048324b40c24b542d9e839