### PR TITLE
feat: add hierarchical clustering for correlation matrix

### DIFF
--- a/src/components/CorrelationRippleMatrix.tsx
+++ b/src/components/CorrelationRippleMatrix.tsx
@@ -1,0 +1,129 @@
+import useCorrelationMatrix, { Cluster, clusterOrder } from '../hooks/useCorrelationMatrix.ts'
+
+interface Props {
+  labels: string[]
+  matrix: number[][]
+  drilldown?: any[][]
+  showDendrogram?: boolean
+}
+
+type Orientation = 'top' | 'left'
+
+function Dendrogram({ tree, orientation = 'top', size = 20 }: { tree: Cluster; orientation?: Orientation; size?: number }) {
+  const order = clusterOrder(tree)
+  const positions: Record<number, number> = {}
+  order.forEach((idx, i) => {
+    positions[idx] = i * size + size / 2
+  })
+
+  const depth = getDepth(tree)
+  const layout = buildLayout(tree, 0)
+  const lines: JSX.Element[] = []
+  buildLines(layout)
+
+  const width = order.length * size
+  const height = depth * size
+  let svgWidth = width
+  let svgHeight = height
+  const style: React.CSSProperties | undefined =
+    orientation === 'left' ? { transform: 'rotate(-90deg)' } : undefined
+  if (orientation === 'left') {
+    svgWidth = height
+    svgHeight = width
+  }
+
+  return (
+    <svg
+      width={svgWidth}
+      height={svgHeight}
+      style={style}
+      className="dendrogram"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth={1}
+    >
+      {lines}
+    </svg>
+  )
+
+  function getDepth(node: Cluster): number {
+    if (!node.left || !node.right) return 0
+    return 1 + Math.max(getDepth(node.left), getDepth(node.right))
+  }
+
+  interface Layout {
+    x: number
+    y: number
+    left?: Layout
+    right?: Layout
+  }
+
+  function buildLayout(node: Cluster, level: number): Layout {
+    if (!node.left || !node.right) {
+      const idx = node.indices[0]
+      return { x: positions[idx], y: level }
+    }
+    const left = buildLayout(node.left, level + 1)
+    const right = buildLayout(node.right, level + 1)
+    return { x: (left.x + right.x) / 2, y: level, left, right }
+  }
+
+  function buildLines(node: Layout) {
+    if (!node.left || !node.right) return
+    const parentY = node.y * size
+    const childY = (node.y + 1) * size
+    lines.push(
+      <line key={lines.length} x1={node.left.x} y1={childY} x2={node.left.x} y2={parentY} />
+    )
+    lines.push(
+      <line key={lines.length} x1={node.right.x} y1={childY} x2={node.right.x} y2={parentY} />
+    )
+    lines.push(
+      <line key={lines.length} x1={node.left.x} y1={parentY} x2={node.right.x} y2={parentY} />
+    )
+    buildLines(node.left)
+    buildLines(node.right)
+  }
+}
+
+export default function CorrelationRippleMatrix({
+  labels,
+  matrix,
+  drilldown,
+  showDendrogram = true,
+}: Props) {
+  const { labels: orderedLabels, matrix: orderedMatrix, tree } =
+    useCorrelationMatrix(labels, matrix, drilldown)
+
+  const size = 20
+
+  return (
+    <div className="correlation-ripple-matrix" style={{ display: 'inline-block' }}>
+      {showDendrogram && tree && <Dendrogram tree={tree} orientation="top" size={size} />}
+      <div style={{ display: 'flex' }}>
+        {showDendrogram && tree && <Dendrogram tree={tree} orientation="left" size={size} />}
+        <table>
+          <thead>
+            <tr>
+              <th></th>
+              {orderedLabels.map(l => (
+                <th key={l}>{l}</th>
+              ))}
+            </tr>
+          </thead>
+          <tbody>
+            {orderedMatrix.map((row, i) => (
+              <tr key={i}>
+                <th>{orderedLabels[i]}</th>
+                {row.map((val, j) => (
+                  <td key={j}>{typeof val === 'number' ? val.toFixed(2) : val}</td>
+                ))}
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+

--- a/src/hooks/useCorrelationMatrix.ts
+++ b/src/hooks/useCorrelationMatrix.ts
@@ -1,0 +1,88 @@
+import { useMemo } from 'react'
+
+export interface Cluster {
+  indices: number[]
+  left?: Cluster
+  right?: Cluster
+  distance: number
+}
+
+function averageLinkage(matrix: number[][], a: Cluster, b: Cluster): number {
+  let sum = 0
+  let count = 0
+  for (const i of a.indices) {
+    for (const j of b.indices) {
+      if (i === j) continue
+      sum += 1 - matrix[i][j]
+      count++
+    }
+  }
+  return count ? sum / count : 0
+}
+
+export function hierarchicalCluster(matrix: number[][]): Cluster {
+  const n = matrix.length
+  let clusters: Cluster[] = []
+  for (let i = 0; i < n; i++) {
+    clusters.push({ indices: [i], distance: 0 })
+  }
+
+  while (clusters.length > 1) {
+    let min = Infinity
+    let pair: [number, number] = [0, 1]
+    for (let i = 0; i < clusters.length; i++) {
+      for (let j = i + 1; j < clusters.length; j++) {
+        const dist = averageLinkage(matrix, clusters[i], clusters[j])
+        if (dist < min) {
+          min = dist
+          pair = [i, j]
+        }
+      }
+    }
+    const [a, b] = pair
+    const left = clusters[a]
+    const right = clusters[b]
+    const merged: Cluster = {
+      indices: [...left.indices, ...right.indices],
+      left,
+      right,
+      distance: min,
+    }
+    clusters = clusters.filter((_, idx) => idx !== a && idx !== b)
+    clusters.push(merged)
+  }
+
+  return clusters[0]
+}
+
+export function clusterOrder(root: Cluster): number[] {
+  if (!root.left || !root.right) return root.indices
+  return [...clusterOrder(root.left), ...clusterOrder(root.right)]
+}
+
+export default function useCorrelationMatrix<T>(
+  labels: T[],
+  matrix: number[][],
+  drilldown?: any[][]
+) {
+  return useMemo(() => {
+    if (!matrix || !matrix.length) {
+      return { labels, matrix, drilldown, order: [], tree: null as Cluster | null }
+    }
+    const tree = hierarchicalCluster(matrix)
+    const order = clusterOrder(tree)
+    const reorderedLabels = order.map(i => labels[i])
+    const reorderedMatrix = order.map(i => order.map(j => matrix[i][j]))
+    const reorderedDrilldown = drilldown
+      ? order.map(i => order.map(j => drilldown[i][j]))
+      : undefined
+    return {
+      labels: reorderedLabels,
+      matrix: reorderedMatrix,
+      drilldown: reorderedDrilldown,
+      order,
+      tree,
+    }
+  }, [labels, matrix, drilldown])
+}
+


### PR DESCRIPTION
## Summary
- add `useCorrelationMatrix` hook with hierarchical clustering and seriation
- provide `CorrelationRippleMatrix` component with optional dendrogram display

## Testing
- `npm test` *(fails: 4 failed, 60 passed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68902f0d9fe08324bfce551900ca91d9