### PR TITLE
Add sample seeding script and document usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ cp .env.example .env   # add your API keys and DB URL
 npx prisma migrate deploy
 # optional: seed sample data
 SEED_EXAMPLE_DATA=true npx prisma db seed
+# or: npm run seed:sample
 npm run server   # Express API on :3000
 npm run dev      # Vite on :5173 (LAN accessible)
 ```

--- a/package.json
+++ b/package.json
@@ -12,7 +12,8 @@
     "server": "node api/server.js",
     "start": "concurrently \"npm:server\" \"npm:dev\"",
     "test": "jest",
-    "lint": "eslint ."
+    "lint": "eslint .",
+    "seed:sample": "SEED_EXAMPLE_DATA=true npx prisma db seed"
   },
   "prisma": {
     "seed": "node --loader ts-node/esm prisma/seed.ts"


### PR DESCRIPTION
## Summary
- add `seed:sample` npm script for seeding example data
- mention `npm run seed:sample` in README as alternative to manual command

## Testing
- `npm test` *(fails: 4 failed, 60 passed, 64 total)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_689163c1b12c83248f4a6329cac06f22