### PR TITLE
feat: add submit label for add plant form

### DIFF
--- a/src/components/AddPlantForm.tsx
+++ b/src/components/AddPlantForm.tsx
@@ -9,9 +9,27 @@ export interface AddPlantFormProps {
   onSubmit: (data: PlantForm) => void
   onNameChange?: (name: string) => void
   onChange?: (data: Partial<PlantForm>) => void
+  /**
+   * Optional label for the submit button. Defaults to
+   * "Add Plant" or "Save Changes" based on the mode.
+   */
+  submitLabel?: string
+  /**
+   * When true, disables the internal submit button. Useful for
+   * preventing duplicate submissions while generating a plan.
+   */
+  submitDisabled?: boolean
 }
 
-export default function AddPlantForm({ mode, defaultValues, onSubmit, onNameChange, onChange }: AddPlantFormProps) {
+export default function AddPlantForm({
+  mode,
+  defaultValues,
+  onSubmit,
+  onNameChange,
+  onChange,
+  submitLabel,
+  submitDisabled,
+}: AddPlantFormProps) {
   const {
     register,
     handleSubmit,
@@ -121,8 +139,12 @@ export default function AddPlantForm({ mode, defaultValues, onSubmit, onNameChan
         </div>
       </section>
 
-      <button type="submit" className="px-4 py-2 bg-green-600 text-white rounded">
-        {mode === 'add' ? 'Add Plant' : 'Save Changes'}
+      <button
+        type="submit"
+        className="px-4 py-2 bg-green-600 text-white rounded disabled:opacity-50"
+        disabled={submitDisabled}
+      >
+        {submitLabel ?? (mode === 'add' ? 'Add Plant' : 'Save Changes')}
       </button>
     </form>
   )

--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -169,6 +169,8 @@ export default function Onboard() {
         onChange={setForm}
         onNameChange={handleNameChange}
         onSubmit={handleSubmit}
+        submitLabel="Generate Plan"
+        submitDisabled={loading}
       />
       {loading && <Spinner className="mt-4 text-green-600" />}
       {error && <p role="alert" className="text-red-600 mt-4">{error}</p>}


### PR DESCRIPTION
## Summary
- allow AddPlantForm to accept a custom submit label and disabled state
- use custom "Generate Plan" label for onboarding form and disable it while loading

## Testing
- `npm test` *(fails: Test Suites: 5 failed, 59 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68948bd1d69883248105d63295433699