### PR TITLE
refactor: update add plant button

### DIFF
--- a/src/components/AddPlantForm.tsx
+++ b/src/components/AddPlantForm.tsx
@@ -140,13 +140,11 @@ export default function AddPlantForm({
       </section>
 
       <button
-
-        type="button"
-        onClick={handleSubmit(onSubmit)}
+        type="submit"
+        disabled={submitDisabled}
         className="px-4 py-2 bg-green-600 text-white rounded"
       >
-        {mode === 'add' ? 'Add Plant' : 'Save Changes'}
-
+        {submitLabel ?? (mode === 'add' ? 'Add Plant' : 'Save Changes')}
       </button>
     </form>
   )


### PR DESCRIPTION
## Summary
- update AddPlantForm submit button to use form submission
- support optional label and disabled state for submit button

## Testing
- `npm test` *(fails: 4 failed, 60 passed)*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_6894955921a08324b3f1a50c60604940