### PR TITLE
Add button to use outdoor humidity

### DIFF
--- a/src/pages/Onboard.jsx
+++ b/src/pages/Onboard.jsx
@@ -172,6 +172,14 @@ export default function Onboard() {
         submitLabel="Generate Plan"
         submitDisabled={loading}
       />
+      <button
+        type="button"
+        onClick={handleUseOutdoorHumidity}
+        disabled={forecast?.humidity === undefined}
+        className="mt-2 text-sm text-green-600 underline disabled:text-gray-400"
+      >
+        Use outdoor humidity
+      </button>
       {loading && <Spinner className="mt-4 text-green-600" />}
       {error && <p role="alert" className="text-red-600 mt-4">{error}</p>}
       {history.length > 1 && (


### PR DESCRIPTION
## Summary
- allow onboarding to prefill humidity from weather via 'Use outdoor humidity' button

## Testing
- `npm test src/pages/__tests__/Onboard.test.jsx` *(failed: Unable to find a label with the text of: /plant name/i)*

------
https://chatgpt.com/codex/tasks/task_e_68949b646f608324a7f4d7ecd77bfe02