### PR TITLE
docs: document npm start option

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ npx prisma migrate deploy
 # optional: seed sample data
 SEED_EXAMPLE_DATA=true npx prisma db seed
 # or: npm run seed:sample
+npm start        # Express API + Vite (on :3000 and :5173)
+# optional: run them separately
 npm run server   # Express API on :3000
 npm run dev      # Vite on :5173 (LAN accessible)
 ```


### PR DESCRIPTION
## Summary
- add `npm start` combined server/frontend run instructions
- list separate `npm run server` and `npm run dev` commands as alternatives

## Testing
- `npm test` *(fails: Test Suites: 4 failed, 60 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689511916fb883248b8efa4a27dcbae4