### PR TITLE
Fix task summary hook and clarify plant form labels

### DIFF
--- a/src/components/AddPlantForm.tsx
+++ b/src/components/AddPlantForm.tsx
@@ -140,7 +140,7 @@ export default function AddPlantForm({
             htmlFor="name"
             className="font-medium after:content-['*'] after:text-red-600"
           >
-            Name
+            Plant Name
           </label>
           <input id="name" {...register('name')} required className="border rounded p-2" />
           {errors.name && (
@@ -200,7 +200,7 @@ export default function AddPlantForm({
           <input id="fertilizingFrequency" type="number" {...register('fertilizingFrequency', { valueAsNumber: true })} className="border rounded p-2" />
         </div>
         <div className="grid gap-1">
-          <label htmlFor="waterAmount" className="font-medium">Water Amount (mL)</label>
+          <label htmlFor="waterAmount" className="font-medium">Water Amount</label>
           <input id="waterAmount" type="number" {...register('waterAmount', { valueAsNumber: true })} className="border rounded p-2" />
         </div>
       </section>

--- a/src/pages/Home.jsx
+++ b/src/pages/Home.jsx
@@ -94,11 +94,13 @@ export default function Home() {
     wateredTodayCount,
     fertilizedTodayCount,
     soonestDate,
-  } = useMemo(() => {
+  } = (() => {
     const todayIso = new Date().toISOString().slice(0, 10)
     const season = getSeason()
 
-    const result = plants.reduce(
+    const list = Array.isArray(plants) ? plants : []
+
+    const result = list.reduce(
       (acc, p) => {
         const { date: waterDate, reason } = getNextWateringDate(
           p.lastWatered,
@@ -191,7 +193,7 @@ export default function Home() {
       }
     )
     return result
-  }, [plants, weatherData])
+  })()
 
   const tasks = [...waterTasks, ...fertilizeTasks].sort(
     (a, b) => new Date(a.date) - new Date(b.date)


### PR DESCRIPTION
## Summary
- Handle missing plant arrays in Home task calculations
- Rename form fields for clearer plant name and water amount labels

## Testing
- `npm test` *(fails: 5 failed, 59 passed)*

------
https://chatgpt.com/codex/tasks/task_e_689526e3fc1c832483f4e6b58cf28cc6