### PR TITLE
Fix API routing and service worker base path

### DIFF
--- a/public/sw.js
+++ b/public/sw.js
@@ -11,14 +11,15 @@ let basePath = typeof VITE_BASE_PATH !== 'undefined'
 
 if (!basePath.endsWith('/')) basePath += '/'
 
-const BASE = basePath.replace(/\/$/, '')
+// Avoid generating malformed URLs like "//index.html" when the base path is root
+const BASE = basePath === '/' ? '' : basePath.replace(/\/$/, '')
 
 const URLS_TO_CACHE = [
   '/',
   '/index.html',
   '/manifest.webmanifest',
   '/favicon.svg'
-].map((p) => `${BASE}${p}`)
+].map(p => `${BASE}${p}`)
 
 self.addEventListener('install', (event) => {
   self.skipWaiting()

--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    { "source": "/api/(.*)", "destination": "/api/server.js" }
+  ]
+}


### PR DESCRIPTION
## Summary
- route /api/* to the Express server on Vercel
- prevent malformed URLs in the service worker cache list

## Testing
- `npm test` *(fails: 5 failed, 59 passed)*

------
https://chatgpt.com/codex/tasks/task_e_68952a8cf3b083248c65c034c0d2975e